### PR TITLE
Ai tweeking

### DIFF
--- a/app/Console/Commands/TestSetlistImageExtraction.php
+++ b/app/Console/Commands/TestSetlistImageExtraction.php
@@ -1,0 +1,175 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Services\SetlistAiService;
+use GuzzleHttp\Client;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Storage;
+
+class TestSetlistImageExtraction extends Command
+{
+    protected $signature = 'setlist:test-image-extraction
+                            {attachment-id : ID from event_attachments table}
+                            {--songs= : Comma-separated list of song titles to use as the library (optional)}
+                            {--driver=gemini : Which AI to use for OCR: gemini or claude}';
+
+    protected $description = 'Test the image extraction step of setlist AI in isolation';
+
+    public function handle(SetlistAiService $service): void
+    {
+        $attachmentId = $this->argument('attachment-id');
+
+        $attachment = \DB::table('event_attachments')->find($attachmentId);
+        if (!$attachment) {
+            $this->error("Attachment ID {$attachmentId} not found.");
+            return;
+        }
+
+        $supported = ['image/jpeg', 'image/png', 'image/gif', 'image/webp'];
+        if (!in_array($attachment->mime_type, $supported)) {
+            $this->error("Attachment is not a supported image type: {$attachment->mime_type}");
+            return;
+        }
+
+        $this->info("Loading image: {$attachment->stored_filename} ({$attachment->mime_type})");
+
+        try {
+            $data = Storage::disk($attachment->disk)->get($attachment->stored_filename);
+        } catch (\Throwable $e) {
+            $this->error("Could not load image: {$e->getMessage()}");
+            return;
+        }
+
+        // Build song list — use --songs option, or pull all songs from DB
+        if ($this->option('songs')) {
+            $songs = collect(explode(',', $this->option('songs')))
+                ->map(fn ($t) => ['id' => 0, 'title' => trim($t)])
+                ->toArray();
+        } else {
+            $songs = \DB::table('songs')
+                ->select('id', 'title')
+                ->orderBy('title')
+                ->get()
+                ->map(fn ($s) => (array) $s)
+                ->toArray();
+        }
+
+        $driver = $this->option('driver');
+        $this->info("Driver: {$driver} | Songs in library: " . count($songs) . "\n");
+
+        $result = match ($driver) {
+            'claude' => $this->runClaude($service, $data, $attachment->mime_type, $songs),
+            default  => $this->runGemini($data, $attachment->mime_type, $songs),
+        };
+
+        $this->line('─────────────────────────────────────────');
+        $this->line($result);
+        $this->line('─────────────────────────────────────────');
+    }
+
+    private function runClaude(SetlistAiService $service, string $data, string $mimeType, array $songs): string
+    {
+        $images = [[
+            'data'       => base64_encode($data),
+            'media_type' => $mimeType,
+        ]];
+
+        return $service->testExtractMarkings($images, $songs);
+    }
+
+    private function runGemini(string $data, string $mimeType, array $songs): string
+    {
+        $apiKey = config('services.gemini.key');
+        if (!$apiKey) {
+            return 'ERROR: GEMINI_API_KEY is not set in .env';
+        }
+
+        $chunkSize = 25;
+        $chunks    = collect($songs)->values()->chunk($chunkSize);
+        $highlighted = [];
+        $excluded    = [];
+
+        foreach ($chunks as $chunkIndex => $chunk) {
+            $numberedList = $chunk->values()
+                ->map(fn ($s, $i) => ($chunkIndex * $chunkSize + $i + 1) . '. ' . $s['title'])
+                ->implode("\n");
+
+            $prompt = <<<PROMPT
+You are analyzing a band's printed master setlist that a client has physically marked up.
+
+The image shows a printed list of song titles. The client has made physical marks next to some songs.
+
+There are TWO types of client marks:
+1. HIGHLIGHTED / REQUESTED — a star (*), asterisk, circle, checkmark, or different-colored text (orange, gold, red) next to the title.
+2. CROSSED OUT / EXCLUDED — a line struck through the title.
+
+IMPORTANT — FUZZY TITLE MATCHING: The song titles in the list below may differ slightly from what is printed in the image. The image may use abbreviations, alternate punctuation, shortened titles, or omit subtitles. Match each song to the closest title you can find in the image. For example, "If You Don't Want Me To (The Freeze)" in the list may appear as "If You Don't Want Me To" or "The Freeze" in the image — treat these as the same song.
+
+TASK: For each song in the list below, find the closest matching title in the image and check whether it has a mark next to it.
+
+SONGS TO CHECK:
+{$numberedList}
+
+Output exactly one line per song, in the same order:
+[number]. [song title] | HIGHLIGHTED or EXCLUDED or UNMARKED
+
+Do not skip any song. If you cannot find a close match in the image or cannot read it clearly, output UNMARKED.
+PROMPT;
+
+            $http = new Client(['timeout' => 60]);
+
+            $response = $http->post(
+                "https://generativelanguage.googleapis.com/v1beta/models/gemini-3.1-pro-preview:generateContent?key={$apiKey}",
+                [
+                    'json' => [
+                        'contents' => [[
+                            'parts' => [
+                                [
+                                    'inline_data' => [
+                                        'mime_type' => $mimeType,
+                                        'data'      => base64_encode($data),
+                                    ],
+                                ],
+                                ['text' => $prompt],
+                            ],
+                        ]],
+                        'generationConfig' => [
+                            'temperature'     => 1,
+                            'maxOutputTokens' => 8192,
+                        ],
+                    ],
+                ]
+            );
+
+            $body = json_decode($response->getBody()->getContents(), true);
+            $raw  = $body['candidates'][0]['content']['parts'][0]['text'] ?? '';
+
+            $this->line("  chunk {$chunkIndex} raw:\n{$raw}\n");
+
+            foreach (explode("\n", $raw) as $line) {
+                $line = trim($line);
+                if (empty($line)) continue;
+                if (preg_match('/^\d+\.\s+(.+?)\s*\|\s*(HIGHLIGHTED|EXCLUDED|UNMARKED)/i', $line, $m)) {
+                    $title  = trim($m[1]);
+                    $status = strtoupper(trim($m[2]));
+                    if ($status === 'HIGHLIGHTED') {
+                        $highlighted[] = $title;
+                    } elseif ($status === 'EXCLUDED') {
+                        $excluded[] = $title;
+                    }
+                }
+            }
+        }
+
+        $highlightedText = !empty($highlighted)
+            ? implode("\n", array_map(fn ($t) => "- {$t}", $highlighted))
+            : 'None';
+
+        $excludedText = !empty($excluded)
+            ? implode("\n", array_map(fn ($t) => "- {$t}", $excluded))
+            : 'None';
+
+        return "REQUESTED SONGS (highlighted/starred by client):\n{$highlightedText}\n\nEXCLUDED SONGS (crossed out by client):\n{$excludedText}";
+    }
+}

--- a/app/Console/Commands/TestSetlistImageExtraction.php
+++ b/app/Console/Commands/TestSetlistImageExtraction.php
@@ -2,8 +2,9 @@
 
 namespace App\Console\Commands;
 
+use App\Services\Ai\Adapters\ClaudeAdapter;
+use App\Services\Ai\Adapters\GeminiAdapter;
 use App\Services\SetlistAiService;
-use GuzzleHttp\Client;
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\Storage;
 
@@ -12,11 +13,11 @@ class TestSetlistImageExtraction extends Command
     protected $signature = 'setlist:test-image-extraction
                             {attachment-id : ID from event_attachments table}
                             {--songs= : Comma-separated list of song titles to use as the library (optional)}
-                            {--driver=gemini : Which AI to use for OCR: gemini or claude}';
+                            {--driver=gemini : Which AI to use for vision: gemini or claude}';
 
     protected $description = 'Test the image extraction step of setlist AI in isolation';
 
-    public function handle(SetlistAiService $service): void
+    public function handle(): void
     {
         $attachmentId = $this->argument('attachment-id');
 
@@ -58,118 +59,22 @@ class TestSetlistImageExtraction extends Command
         $driver = $this->option('driver');
         $this->info("Driver: {$driver} | Songs in library: " . count($songs) . "\n");
 
-        $result = match ($driver) {
-            'claude' => $this->runClaude($service, $data, $attachment->mime_type, $songs),
-            default  => $this->runGemini($data, $attachment->mime_type, $songs),
+        $adapter = match ($driver) {
+            'claude' => new ClaudeAdapter(),
+            default  => new GeminiAdapter('gemini-3.1-pro-preview'),
         };
+
+        $service = new SetlistAiService($adapter);
+
+        $image = [
+            'data'       => base64_encode($data),
+            'media_type' => $attachment->mime_type,
+        ];
+
+        $result = $service->testExtractMarkings([$image], $songs);
 
         $this->line('─────────────────────────────────────────');
         $this->line($result);
         $this->line('─────────────────────────────────────────');
-    }
-
-    private function runClaude(SetlistAiService $service, string $data, string $mimeType, array $songs): string
-    {
-        $images = [[
-            'data'       => base64_encode($data),
-            'media_type' => $mimeType,
-        ]];
-
-        return $service->testExtractMarkings($images, $songs);
-    }
-
-    private function runGemini(string $data, string $mimeType, array $songs): string
-    {
-        $apiKey = config('services.gemini.key');
-        if (!$apiKey) {
-            return 'ERROR: GEMINI_API_KEY is not set in .env';
-        }
-
-        $chunkSize = 25;
-        $chunks    = collect($songs)->values()->chunk($chunkSize);
-        $highlighted = [];
-        $excluded    = [];
-
-        foreach ($chunks as $chunkIndex => $chunk) {
-            $numberedList = $chunk->values()
-                ->map(fn ($s, $i) => ($chunkIndex * $chunkSize + $i + 1) . '. ' . $s['title'])
-                ->implode("\n");
-
-            $prompt = <<<PROMPT
-You are analyzing a band's printed master setlist that a client has physically marked up.
-
-The image shows a printed list of song titles. The client has made physical marks next to some songs.
-
-There are TWO types of client marks:
-1. HIGHLIGHTED / REQUESTED — a star (*), asterisk, circle, checkmark, or different-colored text (orange, gold, red) next to the title.
-2. CROSSED OUT / EXCLUDED — a line struck through the title.
-
-IMPORTANT — FUZZY TITLE MATCHING: The song titles in the list below may differ slightly from what is printed in the image. The image may use abbreviations, alternate punctuation, shortened titles, or omit subtitles. Match each song to the closest title you can find in the image. For example, "If You Don't Want Me To (The Freeze)" in the list may appear as "If You Don't Want Me To" or "The Freeze" in the image — treat these as the same song.
-
-TASK: For each song in the list below, find the closest matching title in the image and check whether it has a mark next to it.
-
-SONGS TO CHECK:
-{$numberedList}
-
-Output exactly one line per song, in the same order:
-[number]. [song title] | HIGHLIGHTED or EXCLUDED or UNMARKED
-
-Do not skip any song. If you cannot find a close match in the image or cannot read it clearly, output UNMARKED.
-PROMPT;
-
-            $http = new Client(['timeout' => 60]);
-
-            $response = $http->post(
-                "https://generativelanguage.googleapis.com/v1beta/models/gemini-3.1-pro-preview:generateContent?key={$apiKey}",
-                [
-                    'json' => [
-                        'contents' => [[
-                            'parts' => [
-                                [
-                                    'inline_data' => [
-                                        'mime_type' => $mimeType,
-                                        'data'      => base64_encode($data),
-                                    ],
-                                ],
-                                ['text' => $prompt],
-                            ],
-                        ]],
-                        'generationConfig' => [
-                            'temperature'     => 1,
-                            'maxOutputTokens' => 8192,
-                        ],
-                    ],
-                ]
-            );
-
-            $body = json_decode($response->getBody()->getContents(), true);
-            $raw  = $body['candidates'][0]['content']['parts'][0]['text'] ?? '';
-
-            $this->line("  chunk {$chunkIndex} raw:\n{$raw}\n");
-
-            foreach (explode("\n", $raw) as $line) {
-                $line = trim($line);
-                if (empty($line)) continue;
-                if (preg_match('/^\d+\.\s+(.+?)\s*\|\s*(HIGHLIGHTED|EXCLUDED|UNMARKED)/i', $line, $m)) {
-                    $title  = trim($m[1]);
-                    $status = strtoupper(trim($m[2]));
-                    if ($status === 'HIGHLIGHTED') {
-                        $highlighted[] = $title;
-                    } elseif ($status === 'EXCLUDED') {
-                        $excluded[] = $title;
-                    }
-                }
-            }
-        }
-
-        $highlightedText = !empty($highlighted)
-            ? implode("\n", array_map(fn ($t) => "- {$t}", $highlighted))
-            : 'None';
-
-        $excludedText = !empty($excluded)
-            ? implode("\n", array_map(fn ($t) => "- {$t}", $excluded))
-            : 'None';
-
-        return "REQUESTED SONGS (highlighted/starred by client):\n{$highlightedText}\n\nEXCLUDED SONGS (crossed out by client):\n{$excludedText}";
     }
 }

--- a/app/Http/Controllers/Api/BookedDatesController.php
+++ b/app/Http/Controllers/Api/BookedDatesController.php
@@ -3,24 +3,42 @@
 namespace App\Http\Controllers\Api;
 
 use App\Http\Controllers\Controller;
-use App\Models\Events;
 use App\Models\Bookings;
 use Illuminate\Http\Request;
+use OpenApi\Attributes as OA;
 
 class BookedDatesController extends Controller
 {
-    /**
-     * Get all bookings for the authenticated band
-     *
-     * Returns bookings (not events) with optional date filtering.
-     *
-     * Query Parameters:
-     * - date: Specific date (YYYY-MM-DD)
-     * - from: Start date for range query (YYYY-MM-DD)
-     * - to: End date for range query (YYYY-MM-DD)
-     * - before: Get bookings before this date (YYYY-MM-DD)
-     * - after: Get bookings after this date (YYYY-MM-DD)
-     */
+    #[OA\Get(
+        path: '/booked-dates',
+        operationId: 'listBookedDates',
+        summary: 'List booked dates',
+        description: "Returns bookings for the authenticated band with optional date filtering. Results are ordered by date ascending, then start time ascending.\n\n**Required permission:** `api:read-bookings`",
+        security: [['BearerToken' => []]],
+        tags: ['Booked Dates'],
+        parameters: [
+            new OA\Parameter(name: 'date', in: 'query', required: false, description: 'Exact date match (YYYY-MM-DD)', schema: new OA\Schema(type: 'string', format: 'date', example: '2025-06-14')),
+            new OA\Parameter(name: 'from', in: 'query', required: false, description: 'Start of date range, inclusive (YYYY-MM-DD)', schema: new OA\Schema(type: 'string', format: 'date', example: '2025-06-01')),
+            new OA\Parameter(name: 'to', in: 'query', required: false, description: 'End of date range, inclusive (YYYY-MM-DD)', schema: new OA\Schema(type: 'string', format: 'date', example: '2025-06-30')),
+            new OA\Parameter(name: 'before', in: 'query', required: false, description: 'Exclusive upper-bound date (YYYY-MM-DD)', schema: new OA\Schema(type: 'string', format: 'date', example: '2025-07-01')),
+            new OA\Parameter(name: 'after', in: 'query', required: false, description: 'Exclusive lower-bound date (YYYY-MM-DD)', schema: new OA\Schema(type: 'string', format: 'date', example: '2025-05-31')),
+        ],
+        responses: [
+            new OA\Response(
+                response: 200,
+                description: 'Success',
+                content: new OA\JsonContent(properties: [
+                    new OA\Property(property: 'success', type: 'boolean', example: true),
+                    new OA\Property(property: 'band', ref: '#/components/schemas/BandSummary'),
+                    new OA\Property(property: 'bookings', type: 'array', items: new OA\Items(ref: '#/components/schemas/BookedDate')),
+                    new OA\Property(property: 'total', type: 'integer', example: 12),
+                    new OA\Property(property: 'filters', ref: '#/components/schemas/AppliedFilters'),
+                ]),
+            ),
+            new OA\Response(response: 401, description: 'Unauthorized', content: new OA\JsonContent(ref: '#/components/schemas/ErrorUnauthorized')),
+            new OA\Response(response: 403, description: 'Forbidden', content: new OA\JsonContent(ref: '#/components/schemas/ErrorForbidden')),
+        ],
+    )]
     public function index(Request $request)
     {
         $band = $request->input('authenticated_band');

--- a/app/Http/Controllers/Api/BookingsController.php
+++ b/app/Http/Controllers/Api/BookingsController.php
@@ -4,16 +4,34 @@ namespace App\Http\Controllers\Api;
 
 use App\Http\Controllers\Controller;
 use App\Models\Bookings;
-use App\Models\EventTypes;
 use Illuminate\Http\Request;
 use Illuminate\Validation\Rule;
 use Carbon\Carbon;
+use OpenApi\Attributes as OA;
 
 class BookingsController extends Controller
 {
-    /**
-     * Display a listing of bookings for the authenticated band
-     */
+    #[OA\Get(
+        path: '/bookings',
+        operationId: 'listBookings',
+        summary: 'List bookings',
+        description: "Returns all bookings for the authenticated band, ordered by date descending. Includes associated events, contacts, and payments.\n\n**Required permission:** `api:read-bookings`",
+        security: [['BearerToken' => []]],
+        tags: ['Bookings'],
+        responses: [
+            new OA\Response(
+                response: 200,
+                description: 'Success',
+                content: new OA\JsonContent(properties: [
+                    new OA\Property(property: 'success', type: 'boolean', example: true),
+                    new OA\Property(property: 'bookings', type: 'array', items: new OA\Items(ref: '#/components/schemas/Booking')),
+                    new OA\Property(property: 'total', type: 'integer', example: 25),
+                ]),
+            ),
+            new OA\Response(response: 401, description: 'Unauthorized', content: new OA\JsonContent(ref: '#/components/schemas/ErrorUnauthorized')),
+            new OA\Response(response: 403, description: 'Forbidden', content: new OA\JsonContent(ref: '#/components/schemas/ErrorForbidden')),
+        ],
+    )]
     public function index(Request $request)
     {
         $band = $request->input('authenticated_band');
@@ -40,9 +58,40 @@ class BookingsController extends Controller
         ]);
     }
 
-    /**
-     * Store a newly created booking
-     */
+    #[OA\Post(
+        path: '/bookings',
+        operationId: 'createBooking',
+        summary: 'Create a booking',
+        description: "Creates a new booking for the authenticated band. The end time is calculated automatically from `start_time` + `duration` (hours).\n\n**Required permission:** `api:write-bookings`",
+        security: [['BearerToken' => []]],
+        requestBody: new OA\RequestBody(
+            required: true,
+            content: new OA\JsonContent(
+                required: ['name', 'event_type_id', 'date', 'start_time', 'duration', 'price', 'contract_option'],
+                allOf: [
+                    new OA\Schema(ref: '#/components/schemas/BookingWriteBody'),
+                    new OA\Schema(properties: [
+                        new OA\Property(property: 'duration', type: 'integer', description: 'Duration in whole hours (1–24). Used to calculate end_time.', minimum: 1, maximum: 24, example: 5),
+                    ]),
+                ],
+            ),
+        ),
+        tags: ['Bookings'],
+        responses: [
+            new OA\Response(
+                response: 201,
+                description: 'Booking created',
+                content: new OA\JsonContent(properties: [
+                    new OA\Property(property: 'success', type: 'boolean', example: true),
+                    new OA\Property(property: 'message', type: 'string', example: 'Booking created successfully'),
+                    new OA\Property(property: 'booking', ref: '#/components/schemas/Booking'),
+                ]),
+            ),
+            new OA\Response(response: 401, description: 'Unauthorized', content: new OA\JsonContent(ref: '#/components/schemas/ErrorUnauthorized')),
+            new OA\Response(response: 403, description: 'Forbidden', content: new OA\JsonContent(ref: '#/components/schemas/ErrorForbidden')),
+            new OA\Response(response: 422, description: 'Validation failed', content: new OA\JsonContent(ref: '#/components/schemas/ErrorValidation')),
+        ],
+    )]
     public function store(Request $request)
     {
         $band = $request->input('authenticated_band');
@@ -89,9 +138,30 @@ class BookingsController extends Controller
         ], 201);
     }
 
-    /**
-     * Display the specified booking
-     */
+    #[OA\Get(
+        path: '/bookings/{id}',
+        operationId: 'getBooking',
+        summary: 'Get a booking',
+        description: "Returns a single booking. Returns 404 if the booking does not exist or does not belong to the authenticated band.\n\n**Required permission:** `api:read-bookings`",
+        security: [['BearerToken' => []]],
+        tags: ['Bookings'],
+        parameters: [
+            new OA\Parameter(name: 'id', in: 'path', required: true, description: 'Booking ID', schema: new OA\Schema(type: 'integer', example: 42)),
+        ],
+        responses: [
+            new OA\Response(
+                response: 200,
+                description: 'Success',
+                content: new OA\JsonContent(properties: [
+                    new OA\Property(property: 'success', type: 'boolean', example: true),
+                    new OA\Property(property: 'booking', ref: '#/components/schemas/Booking'),
+                ]),
+            ),
+            new OA\Response(response: 401, description: 'Unauthorized', content: new OA\JsonContent(ref: '#/components/schemas/ErrorUnauthorized')),
+            new OA\Response(response: 403, description: 'Forbidden', content: new OA\JsonContent(ref: '#/components/schemas/ErrorForbidden')),
+            new OA\Response(response: 404, description: 'Not Found', content: new OA\JsonContent(ref: '#/components/schemas/ErrorNotFound')),
+        ],
+    )]
     public function show(Request $request, $id)
     {
         $band = $request->input('authenticated_band');
@@ -114,9 +184,60 @@ class BookingsController extends Controller
         ]);
     }
 
-    /**
-     * Update the specified booking
-     */
+    #[OA\Put(
+        path: '/bookings/{id}',
+        operationId: 'replaceBooking',
+        summary: 'Replace a booking',
+        description: "Full update of an existing booking. Only fields provided are validated and updated.\n\n**Required permission:** `api:write-bookings`",
+        security: [['BearerToken' => []]],
+        requestBody: new OA\RequestBody(required: true, content: new OA\JsonContent(ref: '#/components/schemas/BookingWriteBody')),
+        tags: ['Bookings'],
+        parameters: [
+            new OA\Parameter(name: 'id', in: 'path', required: true, description: 'Booking ID', schema: new OA\Schema(type: 'integer', example: 42)),
+        ],
+        responses: [
+            new OA\Response(
+                response: 200,
+                description: 'Booking updated',
+                content: new OA\JsonContent(properties: [
+                    new OA\Property(property: 'success', type: 'boolean', example: true),
+                    new OA\Property(property: 'message', type: 'string', example: 'Booking updated successfully'),
+                    new OA\Property(property: 'booking', ref: '#/components/schemas/Booking'),
+                ]),
+            ),
+            new OA\Response(response: 401, description: 'Unauthorized', content: new OA\JsonContent(ref: '#/components/schemas/ErrorUnauthorized')),
+            new OA\Response(response: 403, description: 'Forbidden', content: new OA\JsonContent(ref: '#/components/schemas/ErrorForbidden')),
+            new OA\Response(response: 404, description: 'Not Found', content: new OA\JsonContent(ref: '#/components/schemas/ErrorNotFound')),
+            new OA\Response(response: 422, description: 'Validation failed', content: new OA\JsonContent(ref: '#/components/schemas/ErrorValidation')),
+        ],
+    )]
+    #[OA\Patch(
+        path: '/bookings/{id}',
+        operationId: 'updateBooking',
+        summary: 'Partially update a booking',
+        description: "Partial update — send only the fields you want to change.\n\n**Required permission:** `api:write-bookings`",
+        security: [['BearerToken' => []]],
+        requestBody: new OA\RequestBody(required: true, content: new OA\JsonContent(ref: '#/components/schemas/BookingWriteBody')),
+        tags: ['Bookings'],
+        parameters: [
+            new OA\Parameter(name: 'id', in: 'path', required: true, description: 'Booking ID', schema: new OA\Schema(type: 'integer', example: 42)),
+        ],
+        responses: [
+            new OA\Response(
+                response: 200,
+                description: 'Booking updated',
+                content: new OA\JsonContent(properties: [
+                    new OA\Property(property: 'success', type: 'boolean', example: true),
+                    new OA\Property(property: 'message', type: 'string', example: 'Booking updated successfully'),
+                    new OA\Property(property: 'booking', ref: '#/components/schemas/Booking'),
+                ]),
+            ),
+            new OA\Response(response: 401, description: 'Unauthorized', content: new OA\JsonContent(ref: '#/components/schemas/ErrorUnauthorized')),
+            new OA\Response(response: 403, description: 'Forbidden', content: new OA\JsonContent(ref: '#/components/schemas/ErrorForbidden')),
+            new OA\Response(response: 404, description: 'Not Found', content: new OA\JsonContent(ref: '#/components/schemas/ErrorNotFound')),
+            new OA\Response(response: 422, description: 'Validation failed', content: new OA\JsonContent(ref: '#/components/schemas/ErrorValidation')),
+        ],
+    )]
     public function update(Request $request, $id)
     {
         $band = $request->input('authenticated_band');
@@ -155,9 +276,30 @@ class BookingsController extends Controller
         ]);
     }
 
-    /**
-     * Remove the specified booking
-     */
+    #[OA\Delete(
+        path: '/bookings/{id}',
+        operationId: 'deleteBooking',
+        summary: 'Delete a booking',
+        description: "Permanently deletes a booking. This action cannot be undone.\n\n**Required permission:** `api:write-bookings`",
+        security: [['BearerToken' => []]],
+        tags: ['Bookings'],
+        parameters: [
+            new OA\Parameter(name: 'id', in: 'path', required: true, description: 'Booking ID', schema: new OA\Schema(type: 'integer', example: 42)),
+        ],
+        responses: [
+            new OA\Response(
+                response: 200,
+                description: 'Booking deleted',
+                content: new OA\JsonContent(properties: [
+                    new OA\Property(property: 'success', type: 'boolean', example: true),
+                    new OA\Property(property: 'message', type: 'string', example: 'Booking deleted successfully'),
+                ]),
+            ),
+            new OA\Response(response: 401, description: 'Unauthorized', content: new OA\JsonContent(ref: '#/components/schemas/ErrorUnauthorized')),
+            new OA\Response(response: 403, description: 'Forbidden', content: new OA\JsonContent(ref: '#/components/schemas/ErrorForbidden')),
+            new OA\Response(response: 404, description: 'Not Found', content: new OA\JsonContent(ref: '#/components/schemas/ErrorNotFound')),
+        ],
+    )]
     public function destroy(Request $request, $id)
     {
         $band = $request->input('authenticated_band');

--- a/app/Http/Controllers/Api/EventsController.php
+++ b/app/Http/Controllers/Api/EventsController.php
@@ -7,21 +7,40 @@ use App\Models\Events;
 use App\Models\Bookings;
 use App\Models\BandEvents;
 use Illuminate\Http\Request;
+use OpenApi\Attributes as OA;
 
 class EventsController extends Controller
 {
-    /**
-     * Get all events for the authenticated band
-     *
-     * Returns events from both bookings and band_events with optional date filtering.
-     *
-     * Query Parameters:
-     * - date: Specific date (YYYY-MM-DD)
-     * - from: Start date for range query (YYYY-MM-DD)
-     * - to: End date for range query (YYYY-MM-DD)
-     * - before: Get events before this date (YYYY-MM-DD)
-     * - after: Get events after this date (YYYY-MM-DD)
-     */
+    #[OA\Get(
+        path: '/events',
+        operationId: 'listEvents',
+        summary: 'List events',
+        description: "Returns events for the authenticated band from **both** bookings and legacy band events (polymorphic). Results are ordered by date ascending, then time ascending.\n\n**Required permission:** `api:read-events`",
+        security: [['BearerToken' => []]],
+        tags: ['Events'],
+        parameters: [
+            new OA\Parameter(name: 'date', in: 'query', required: false, description: 'Exact date match (YYYY-MM-DD)', schema: new OA\Schema(type: 'string', format: 'date', example: '2025-06-14')),
+            new OA\Parameter(name: 'from', in: 'query', required: false, description: 'Start of date range, inclusive (YYYY-MM-DD)', schema: new OA\Schema(type: 'string', format: 'date', example: '2025-06-01')),
+            new OA\Parameter(name: 'to', in: 'query', required: false, description: 'End of date range, inclusive (YYYY-MM-DD)', schema: new OA\Schema(type: 'string', format: 'date', example: '2025-06-30')),
+            new OA\Parameter(name: 'before', in: 'query', required: false, description: 'Exclusive upper-bound date (YYYY-MM-DD)', schema: new OA\Schema(type: 'string', format: 'date', example: '2025-07-01')),
+            new OA\Parameter(name: 'after', in: 'query', required: false, description: 'Exclusive lower-bound date (YYYY-MM-DD)', schema: new OA\Schema(type: 'string', format: 'date', example: '2025-05-31')),
+        ],
+        responses: [
+            new OA\Response(
+                response: 200,
+                description: 'Success',
+                content: new OA\JsonContent(properties: [
+                    new OA\Property(property: 'success', type: 'boolean', example: true),
+                    new OA\Property(property: 'band', ref: '#/components/schemas/BandSummary'),
+                    new OA\Property(property: 'events', type: 'array', items: new OA\Items(ref: '#/components/schemas/Event')),
+                    new OA\Property(property: 'total', type: 'integer', example: 8),
+                    new OA\Property(property: 'filters', ref: '#/components/schemas/AppliedFilters'),
+                ]),
+            ),
+            new OA\Response(response: 401, description: 'Unauthorized', content: new OA\JsonContent(ref: '#/components/schemas/ErrorUnauthorized')),
+            new OA\Response(response: 403, description: 'Forbidden', content: new OA\JsonContent(ref: '#/components/schemas/ErrorForbidden')),
+        ],
+    )]
     public function index(Request $request)
     {
         $band = $request->input('authenticated_band');

--- a/app/Http/Controllers/SetlistController.php
+++ b/app/Http/Controllers/SetlistController.php
@@ -29,7 +29,7 @@ class SetlistController extends Controller
 
         $songs = $band->songs()
             ->where('active', true)
-            ->with('leadSinger')
+            ->with('leadSinger.user')
             ->get()
             ->map(fn($s) => [
                 'id' => $s->id,
@@ -38,6 +38,7 @@ class SetlistController extends Controller
                 'song_key' => $s->song_key,
                 'genre' => $s->genre,
                 'bpm' => $s->bpm,
+                'energy' => $s->energy,
                 'lead_singer' => $s->leadSinger?->display_name,
             ]);
 
@@ -55,6 +56,7 @@ class SetlistController extends Controller
                     'role' => $m->role_name,
                 ]),
             ],
+            'bandId' => $band->id,
             'setlist' => $setlist ? $this->formatSetlist($setlist) : null,
             'songs' => $songs,
             'canWrite' => Auth::user()->canWrite('events', $band->id),
@@ -74,7 +76,7 @@ class SetlistController extends Controller
 
         $songs = $band->songs()
             ->where('active', true)
-            ->with(['leadSinger', 'transitionSong'])
+            ->with(['leadSinger.user', 'transitionSong'])
             ->get();
 
         $songsArray = $songs->map(fn($s) => [
@@ -84,6 +86,7 @@ class SetlistController extends Controller
             'song_key' => $s->song_key,
             'genre' => $s->genre,
             'bpm' => $s->bpm,
+            'energy' => $s->energy,
             'lead_singer' => $s->leadSinger?->display_name,
             'transition_song' => $s->transitionSong
                 ? $s->transitionSong->title . ($s->transitionSong->artist ? ' – ' . $s->transitionSong->artist : '')
@@ -107,29 +110,33 @@ class SetlistController extends Controller
 
         $attachmentImages = [];
         $attachments = $event->attachments()->get();
+        \Illuminate\Support\Facades\Log::info('SetlistController: attachments found', ['count' => $attachments->count(), 'event_id' => $event->id]);
         if ($attachments->isNotEmpty()) {
             $attachmentImages = $aiService->buildImageBlocks($attachments);
+            \Illuminate\Support\Facades\Log::info('SetlistController: image blocks built', ['count' => count($attachmentImages)]);
         }
 
-        $orderedItems = $aiService->generateSetlist($event, $songsArray, $request->input('context'), $attachmentImages);
+        $result = $aiService->generateSetlist($event, $songsArray, $request->input('context'), $attachmentImages);
 
-        if (empty($orderedItems)) {
+        if (empty($result['items'])) {
             return response()->json(['error' => 'AI could not generate a setlist. Please try again.'], 500);
         }
 
         $songMap    = $songs->keyBy('id');
-        $finalItems = $this->filterValidItems($orderedItems, $songMap);
+        $finalItems = $this->filterValidItems($result['items'], $songMap);
 
-        DB::transaction(function () use ($event, $band, $finalItems, $songsArray) {
+        DB::transaction(function () use ($event, $band, $finalItems, $songsArray, $result) {
             $setlist = EventSetlist::updateOrCreate(
                 ['event_id' => $event->id],
                 [
-                    'band_id' => $band->id,
+                    'band_id'      => $band->id,
                     'generated_at' => now(),
-                    'status' => 'draft',
-                    'ai_context' => [
-                        'song_count' => count($songsArray),
-                        'generated_at' => now()->toISOString(),
+                    'status'       => 'draft',
+                    'ai_context'   => [
+                        'song_count'    => count($songsArray),
+                        'generated_at'  => now()->toISOString(),
+                        'event_context' => $result['event_context'],
+                        'image_context' => $result['image_context'],
                     ],
                 ]
             );
@@ -139,8 +146,12 @@ class SetlistController extends Controller
         });
 
         $setlist = $event->setlist()->with('songs.song.leadSinger')->first();
+        $formatted = $this->formatSetlist($setlist);
+        \Illuminate\Support\Facades\Log::info('SetlistController: final order returned to frontend', [
+            'songs' => collect($formatted['songs'])->map(fn($s) => $s['position'] . '. ' . $s['title'] . ' (' . ($s['lead_singer'] ?? 'none') . ')')->values()->all()
+        ]);
 
-        return response()->json($this->formatSetlist($setlist));
+        return response()->json($formatted);
     }
 
     public function refine(Request $request, string $key): JsonResponse
@@ -168,7 +179,7 @@ class SetlistController extends Controller
 
         $songs = $band->songs()
             ->where('active', true)
-            ->with(['leadSinger', 'transitionSong'])
+            ->with(['leadSinger.user', 'transitionSong'])
             ->get();
 
         $songsArray = $songs->map(fn($s) => [
@@ -178,6 +189,7 @@ class SetlistController extends Controller
             'song_key'       => $s->song_key,
             'genre'          => $s->genre,
             'bpm'            => $s->bpm,
+            'energy'         => $s->energy,
             'lead_singer'    => $s->leadSinger?->display_name,
             'transition_song' => $s->transitionSong
                 ? $s->transitionSong->title . ($s->transitionSong->artist ? ' – ' . $s->transitionSong->artist : '')
@@ -272,15 +284,107 @@ class SetlistController extends Controller
         return response()->json($this->formatSetlist($setlist));
     }
 
+    /**
+     * Reorder items so no lead singer appears more than once in any 3-song window.
+     * Breaks are kept in place. Songs without a lead singer (instrumental/custom) are neutral.
+     */
+    private function interleaveSingers(\Illuminate\Support\Collection $items, \Illuminate\Support\Collection $songMap): \Illuminate\Support\Collection
+    {
+        $getSinger = function ($item) use ($songMap): ?string {
+            if ($item === 'break') return null;
+            $id = is_array($item) ? ($item['id'] ?? null) : $item;
+            if (!$id) return null;
+            $song = $songMap->get((int) $id);
+            return $song?->leadSinger?->display_name;
+        };
+
+        // Split into sets (separated by breaks) and process each independently
+        $sets = [];
+        $current = [];
+        foreach ($items->values()->all() as $item) {
+            if ($item === 'break') {
+                $sets[] = ['songs' => $current, 'break' => true];
+                $current = [];
+            } else {
+                $current[] = $item;
+            }
+        }
+        $sets[] = ['songs' => $current, 'break' => false];
+
+        $processedSets = [];
+        foreach ($sets as $set) {
+            $result = $set['songs'];
+            $maxPasses = count($result) * 2;
+            $pass = 0;
+
+            do {
+                $swapped = false;
+                for ($i = 0; $i < count($result) - 1; $i++) {
+                    $recentSingers = [];
+                    for ($j = $i; $j >= 0 && count($recentSingers) < 2; $j--) {
+                        $s = $getSinger($result[$j]);
+                        if ($s !== null) $recentSingers[] = $s;
+                    }
+
+                    $nextSinger = $getSinger($result[$i + 1]);
+                    if ($nextSinger === null) continue;
+
+                    if (count(array_filter($recentSingers, fn($s) => $s === $nextSinger)) >= 2) {
+                        for ($k = $i + 2; $k < count($result); $k++) {
+                            $candidateSinger = $getSinger($result[$k]);
+                            if ($candidateSinger !== $nextSinger) {
+                                [$result[$i + 1], $result[$k]] = [$result[$k], $result[$i + 1]];
+                                $swapped = true;
+                                break;
+                            }
+                        }
+                    }
+                }
+                $pass++;
+            } while ($swapped && $pass < $maxPasses);
+
+            $processedSets[] = ['songs' => $result, 'break' => $set['break']];
+        }
+
+        // Reassemble with breaks
+        $final = [];
+        foreach ($processedSets as $set) {
+            foreach ($set['songs'] as $song) {
+                $final[] = $song;
+            }
+            if ($set['break']) {
+                $final[] = 'break';
+            }
+        }
+
+        return collect($final);
+    }
+
     private function filterValidItems(array $orderedItems, \Illuminate\Support\Collection $songMap): \Illuminate\Support\Collection
     {
+        $seenIds = [];
+
         return collect($orderedItems)
-            ->filter(fn($item) =>
-                $item === 'break' ||
-                (is_int($item) && $songMap->has($item)) ||
-                (is_array($item) && isset($item['id']) && $songMap->has((int) $item['id'])) ||
-                (is_array($item) && !empty($item['title']))
-            )
+            ->filter(function ($item) use ($songMap, &$seenIds) {
+                if ($item === 'break') return true;
+
+                if (is_int($item) && $songMap->has($item)) {
+                    if (in_array($item, $seenIds)) return false;
+                    $seenIds[] = $item;
+                    return true;
+                }
+
+                if (is_array($item) && isset($item['id']) && $songMap->has((int) $item['id'])) {
+                    $id = (int) $item['id'];
+                    if (in_array($id, $seenIds)) return false;
+                    $seenIds[] = $id;
+                    return true;
+                }
+
+                if (is_array($item) && !empty($item['title'])) return true;
+
+                return false;
+            })
             ->values();
     }
 
@@ -326,10 +430,14 @@ class SetlistController extends Controller
 
     private function formatSetlist(EventSetlist $setlist): array
     {
+        $aiContext = $setlist->ai_context ?? [];
+
         return [
-            'id' => $setlist->id,
-            'status' => $setlist->status,
-            'generated_at' => $setlist->generated_at,
+            'id'            => $setlist->id,
+            'status'        => $setlist->status,
+            'generated_at'  => $setlist->generated_at,
+            'event_context' => $aiContext['event_context'] ?? null,
+            'image_context' => $aiContext['image_context'] ?? [],
             'songs' => $setlist->songs->map(fn($entry) => [
                 'id' => $entry->id,
                 'type' => $entry->type ?? 'song',
@@ -340,6 +448,7 @@ class SetlistController extends Controller
                 'song_key' => $entry->song?->song_key,
                 'genre' => $entry->song?->genre,
                 'bpm' => $entry->song?->bpm,
+                'energy' => $entry->song?->energy,
                 'lead_singer' => $entry->song?->leadSinger?->display_name,
                 'notes' => $entry->notes,
             ])->values()->all(),

--- a/app/Http/Controllers/SetlistPromptTemplateController.php
+++ b/app/Http/Controllers/SetlistPromptTemplateController.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Bands;
+use App\Models\SetlistPromptTemplate;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+
+class SetlistPromptTemplateController extends Controller
+{
+    public function index(Bands $band): JsonResponse
+    {
+        if (!Auth::user()->canRead('events', $band->id)) {
+            abort(403);
+        }
+
+        $templates = $band->setlistPromptTemplates()
+            ->orderBy('name')
+            ->get(['id', 'name', 'prompt']);
+
+        return response()->json($templates);
+    }
+
+    public function store(Request $request, Bands $band): JsonResponse
+    {
+        if (!Auth::user()->canWrite('events', $band->id)) {
+            abort(403);
+        }
+
+        $validated = $request->validate([
+            'name'   => 'required|string|max:100',
+            'prompt' => 'required|string|max:2000',
+        ]);
+
+        $template = $band->setlistPromptTemplates()->create($validated);
+
+        return response()->json($template->only(['id', 'name', 'prompt']), 201);
+    }
+
+    public function update(Request $request, Bands $band, SetlistPromptTemplate $template): JsonResponse
+    {
+        if (!Auth::user()->canWrite('events', $band->id)) {
+            abort(403);
+        }
+
+        if ($template->band_id !== $band->id) {
+            abort(404);
+        }
+
+        $validated = $request->validate([
+            'name'   => 'sometimes|string|max:100',
+            'prompt' => 'sometimes|string|max:2000',
+        ]);
+
+        $template->update($validated);
+
+        return response()->json($template->only(['id', 'name', 'prompt']));
+    }
+
+    public function destroy(Bands $band, SetlistPromptTemplate $template): JsonResponse
+    {
+        if (!Auth::user()->canWrite('events', $band->id)) {
+            abort(403);
+        }
+
+        if ($template->band_id !== $band->id) {
+            abort(404);
+        }
+
+        $template->delete();
+
+        return response()->json(null, 204);
+    }
+}

--- a/app/Http/Controllers/SongsController.php
+++ b/app/Http/Controllers/SongsController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers;
 
 use App\Models\Bands;
 use App\Models\Song;
+use App\Services\GetSongBpmService;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
@@ -74,6 +75,8 @@ class SongsController extends Controller
             'song_key' => 'nullable|string|max:20',
             'genre' => 'nullable|string|max:100',
             'bpm' => 'nullable|integer|min:1|max:999',
+            'rating' => 'nullable|integer|min:1|max:10',
+            'energy' => 'nullable|integer|min:1|max:10',
             'notes' => 'nullable|string',
             'lead_singer_id' => 'nullable|integer|exists:roster_members,id',
             'transition_song_id' => 'nullable|integer|exists:songs,id',
@@ -104,6 +107,8 @@ class SongsController extends Controller
             'song_key' => 'nullable|string|max:20',
             'genre' => 'nullable|string|max:100',
             'bpm' => 'nullable|integer|min:1|max:999',
+            'rating' => 'nullable|integer|min:1|max:10',
+            'energy' => 'nullable|integer|min:1|max:10',
             'notes' => 'nullable|string',
             'lead_singer_id' => 'nullable|integer|exists:roster_members,id',
             'transition_song_id' => 'nullable|integer|exists:songs,id',
@@ -114,6 +119,21 @@ class SongsController extends Controller
         $song->load(['leadSinger', 'transitionSong:id,title,artist']);
 
         return response()->json($song);
+    }
+
+    public function lookup(Request $request): JsonResponse
+    {
+        $request->validate([
+            'title'  => 'required|string|max:255',
+            'artist' => 'nullable|string|max:255',
+        ]);
+
+        $result = (new GetSongBpmService())->lookup(
+            $request->input('title'),
+            $request->input('artist')
+        );
+
+        return response()->json($result);
     }
 
     public function destroy(Song $song): JsonResponse

--- a/app/Http/Controllers/SongsController.php
+++ b/app/Http/Controllers/SongsController.php
@@ -41,7 +41,7 @@ class SongsController extends Controller
         }
 
         $songs = $band->songs()
-            ->with(['leadSinger', 'transitionSong:id,title,artist'])
+            ->with(['leadSinger.user', 'transitionSong:id,title,artist'])
             ->get();
 
         $rosterMembers = $band->rosters()
@@ -90,7 +90,7 @@ class SongsController extends Controller
         }
 
         $song = $band->songs()->create($validated);
-        $song->load(['leadSinger', 'transitionSong:id,title,artist']);
+        $song->load(['leadSinger.user', 'transitionSong:id,title,artist']);
 
         return response()->json($song, 201);
     }
@@ -116,7 +116,7 @@ class SongsController extends Controller
         ]);
 
         $song->update($validated);
-        $song->load(['leadSinger', 'transitionSong:id,title,artist']);
+        $song->load(['leadSinger.user', 'transitionSong:id,title,artist']);
 
         return response()->json($song);
     }

--- a/app/Models/Bands.php
+++ b/app/Models/Bands.php
@@ -235,6 +235,11 @@ class Bands extends Model
         return $this->hasMany(Song::class, 'band_id')->orderBy('title');
     }
 
+    public function setlistPromptTemplates()
+    {
+        return $this->hasMany(SetlistPromptTemplate::class, 'band_id');
+    }
+
     public function apiTokens()
     {
         return $this->hasMany(BandApiToken::class, 'band_id')->orderBy('created_at', 'desc');

--- a/app/Models/RosterMember.php
+++ b/app/Models/RosterMember.php
@@ -24,6 +24,8 @@ class RosterMember extends Model
         'deleted_at',
     ];
 
+    protected $appends = ['display_name'];
+
     protected $casts = [
         'is_active' => 'boolean',
     ];

--- a/app/Models/SetlistPromptTemplate.php
+++ b/app/Models/SetlistPromptTemplate.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class SetlistPromptTemplate extends Model
+{
+    protected $fillable = ['band_id', 'name', 'prompt'];
+}

--- a/app/Models/Song.php
+++ b/app/Models/Song.php
@@ -21,11 +21,15 @@ class Song extends Model
         'lead_singer_id',
         'transition_song_id',
         'active',
+        'rating',
+        'energy',
     ];
 
     protected $casts = [
         'active' => 'boolean',
         'bpm' => 'integer',
+        'rating' => 'integer',
+        'energy' => 'integer',
     ];
 
     public function band()

--- a/app/Services/Ai/Adapters/ClaudeAdapter.php
+++ b/app/Services/Ai/Adapters/ClaudeAdapter.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace App\Services\Ai\Adapters;
+
+use App\Services\Ai\Contracts\AiAdapterInterface;
+use GuzzleHttp\Client;
+
+class ClaudeAdapter implements AiAdapterInterface
+{
+    private Client $http;
+    private string $apiKey;
+    private string $model;
+
+    public function __construct(string $model = 'claude-opus-4-6', ?string $apiKey = null)
+    {
+        $this->apiKey = $apiKey ?? config('services.anthropic.key', '');
+        $this->model  = $model;
+        $this->http   = new Client([
+            'base_uri' => 'https://api.anthropic.com',
+            'timeout'  => 60,
+        ]);
+    }
+
+    public function query(string $prompt, int $maxTokens = 256): string
+    {
+        return $this->send([['role' => 'user', 'content' => $prompt]], $maxTokens);
+    }
+
+    public function queryWithImage(string $prompt, array $image, int $maxTokens = 256): string
+    {
+        return $this->send([
+            [
+                'role' => 'user',
+                'content' => [
+                    [
+                        'type'   => 'image',
+                        'source' => [
+                            'type'       => 'base64',
+                            'media_type' => $image['media_type'],
+                            'data'       => $image['data'],
+                        ],
+                    ],
+                    ['type' => 'text', 'text' => $prompt],
+                ],
+            ],
+        ], $maxTokens);
+    }
+
+    private function send(array $messages, int $maxTokens): string
+    {
+        $response = $this->http->post('/v1/messages', [
+            'headers' => [
+                'x-api-key'         => $this->apiKey,
+                'anthropic-version' => '2023-06-01',
+                'content-type'      => 'application/json',
+            ],
+            'json' => [
+                'model'      => $this->model,
+                'max_tokens' => $maxTokens,
+                'messages'   => $messages,
+            ],
+        ]);
+
+        $body = json_decode($response->getBody()->getContents(), true);
+
+        return $body['content'][0]['text'] ?? '';
+    }
+}

--- a/app/Services/Ai/Adapters/GeminiAdapter.php
+++ b/app/Services/Ai/Adapters/GeminiAdapter.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace App\Services\Ai\Adapters;
+
+use App\Services\Ai\Contracts\AiAdapterInterface;
+use GuzzleHttp\Client;
+
+class GeminiAdapter implements AiAdapterInterface
+{
+    private Client $http;
+    private string $apiKey;
+    private string $model;
+
+    public function __construct(string $model = 'gemini-3.1-pro-preview', ?string $apiKey = null)
+    {
+        $this->apiKey = $apiKey ?? config('services.gemini.key', '');
+        $this->model  = $model;
+        $this->http   = new Client([
+            'base_uri' => 'https://generativelanguage.googleapis.com',
+            'timeout'  => 60,
+        ]);
+    }
+
+    public function query(string $prompt, int $maxTokens = 256): string
+    {
+        return $this->send([['text' => $prompt]], $maxTokens);
+    }
+
+    public function queryWithImage(string $prompt, array $image, int $maxTokens = 256): string
+    {
+        return $this->send([
+            [
+                'inline_data' => [
+                    'mime_type' => $image['media_type'],
+                    'data'      => $image['data'],
+                ],
+            ],
+            ['text' => $prompt],
+        ], $maxTokens);
+    }
+
+    private function send(array $parts, int $maxTokens): string
+    {
+        $response = $this->http->post(
+            "/v1beta/models/{$this->model}:generateContent?key={$this->apiKey}",
+            [
+                'json' => [
+                    'contents'         => [['parts' => $parts]],
+                    'generationConfig' => [
+                        'temperature'     => 0,
+                        'maxOutputTokens' => $maxTokens,
+                    ],
+                ],
+            ]
+        );
+
+        $body = json_decode($response->getBody()->getContents(), true);
+
+        return $body['candidates'][0]['content']['parts'][0]['text'] ?? '';
+    }
+}

--- a/app/Services/Ai/Contracts/AiAdapterInterface.php
+++ b/app/Services/Ai/Contracts/AiAdapterInterface.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Services\Ai\Contracts;
+
+interface AiAdapterInterface
+{
+    /**
+     * Send a text-only prompt and return the raw response.
+     */
+    public function query(string $prompt, int $maxTokens = 256): string;
+
+    /**
+     * Send an image + prompt and return the raw response.
+     *
+     * @param  array  $image  ['data' => base64string, 'media_type' => 'image/jpeg']
+     */
+    public function queryWithImage(string $prompt, array $image, int $maxTokens = 256): string;
+}

--- a/app/Services/GetSongBpmService.php
+++ b/app/Services/GetSongBpmService.php
@@ -1,0 +1,114 @@
+<?php
+
+namespace App\Services;
+
+use GuzzleHttp\Client;
+use GuzzleHttp\Exception\RequestException;
+use Illuminate\Support\Facades\Log;
+
+class GetSongBpmService
+{
+    private Client $http;
+    private string $apiKey;
+    private const BASE_URL = 'https://api.getsong.co';
+
+    public function __construct()
+    {
+        $this->apiKey = config('services.getsongbpm.key');
+        $this->http = new Client([
+            'base_uri' => self::BASE_URL,
+            'timeout' => 10,
+        ]);
+    }
+
+    /**
+     * Look up a song by title and optional artist, returning key, BPM, and genre.
+     * Falls back to Claude if GetSongBPM has no result.
+     *
+     * @return array{bpm: int|null, song_key: string|null, genre: string|null, artist: string|null}
+     */
+    public function lookup(string $title, ?string $artist = null): array
+    {
+        $songId = $this->searchSongId($title, $artist);
+
+        if ($songId) {
+            $result = $this->getSongDetails($songId);
+            Log::info('GetSongBPM result', ['songId' => $songId, 'result' => $result]);
+            // If we got useful data, return it
+            if ($result['bpm'] || $result['song_key']) {
+                return $result;
+            }
+        }
+
+        Log::info('GetSongBPM: no result, falling back to Claude', ['title' => $title, 'artist' => $artist]);
+        // Fall back to Claude
+        return (new SetlistAiService())->lookupSongDetails($title, $artist);
+    }
+
+    private function searchSongId(string $title, ?string $artist): ?string
+    {
+        try {
+            $type = $artist ? 'both' : 'song';
+            $lookup = $artist
+                ? 'song:' . $title . ' artist:' . $artist
+                : $title;
+
+            $response = $this->http->get('/search/', [
+                'query' => [
+                    'api_key' => $this->apiKey,
+                    'type'    => $type,
+                    'lookup'  => $lookup,
+                    'limit'   => 1,
+                ],
+            ]);
+
+            $data = json_decode($response->getBody(), true);
+            return $data['search'][0]['id'] ?? null;
+
+        } catch (RequestException $e) {
+            Log::warning('GetSongBPM search failed', ['error' => $e->getMessage(), 'title' => $title]);
+            return null;
+        }
+    }
+
+    private function getSongDetails(string $songId): array
+    {
+        try {
+            $response = $this->http->get('/song/', [
+                'query' => [
+                    'api_key' => $this->apiKey,
+                    'id'      => $songId,
+                ],
+            ]);
+
+            $data = json_decode($response->getBody(), true);
+            $song = $data['song'] ?? null;
+
+            if (!$song) {
+                return ['bpm' => null, 'song_key' => null, 'genre' => null, 'artist' => null];
+            }
+
+            $genres = $song['artist']['genres'] ?? [];
+
+            // key_of format: "Em", "Bb", "F#m", "C" — trailing 'm' = minor, absent = major
+            $keyOf = $song['key_of'] ?? null;
+            $songKey = null;
+            if ($keyOf) {
+                $isMinor = str_ends_with($keyOf, 'm');
+                $note = $isMinor ? substr($keyOf, 0, -1) : $keyOf;
+                $songKey = $note . ($isMinor ? ' min' : ' maj');
+            }
+
+            return [
+                'bpm'      => isset($song['tempo']) ? (int) $song['tempo'] : null,
+                'song_key' => $songKey,
+                'genre'    => !empty($genres) ? ucfirst($genres[0]) : null,
+                'artist'   => $song['artist']['name'] ?? null,
+            ];
+
+        } catch (RequestException $e) {
+            Log::warning('GetSongBPM song details failed', ['error' => $e->getMessage(), 'id' => $songId]);
+            return ['bpm' => null, 'song_key' => null, 'genre' => null, 'artist' => null];
+        }
+    }
+}

--- a/app/Services/SetlistAiService.php
+++ b/app/Services/SetlistAiService.php
@@ -11,7 +11,7 @@ class SetlistAiService
 {
     private Client $http;
     private string $apiKey;
-    private string $model = 'claude-sonnet-4-6';
+    private string $model = 'claude-opus-4-6';
 
     public function __construct()
     {
@@ -32,14 +32,21 @@ class SetlistAiService
     {
         $context = $this->buildEventContext($event);
         $songList = $this->buildSongList($songs);
-
+        
         $extraSection = $extraContext
             ? "\nBAND LEADER INSTRUCTIONS:\n{$extraContext}\n"
             : '';
 
-        $attachmentSection = !empty($attachmentImages)
-            ? "\nATTACHMENT IMAGES: One or more images are attached showing a handwritten or printed song request list from the client. Study each image carefully before building the setlist:\n- Any song that is CROSSED OUT, STRUCK THROUGH, or has a line drawn through it is FORBIDDEN. Treat it exactly like an exclusion in rule 1 — do not include it under any circumstances, even if it appears in the event notes.\n- Any song that is HIGHLIGHTED or circled is a must-play request.\n- When in doubt about whether a marking indicates exclusion, assume it does and leave the song out.\n"
-            : '';
+        Log::info(empty($attachmentImages) ? 'No attachment images provided' : count($attachmentImages) . ' attachment image(s) provided');
+
+        // Two-step image analysis: first extract client markings, then generate setlist.
+        // This isolates the noisy vision task so the setlist prompt only sees clean text.
+        $attachmentSection = '';
+        if (!empty($attachmentImages)) {
+            $imageAnalysis = $this->extractClientMarkingsFromImages($attachmentImages, $songs);
+            Log::info('SetlistAiService: image analysis result', ['analysis' => $imageAnalysis]);
+            $attachmentSection = "\nCLIENT MARKINGS FROM ATTACHED IMAGE (pre-extracted):\n{$imageAnalysis}\n";
+        }
 
         $prompt = <<<PROMPT
 You are a professional band manager building a setlist for a live performance.
@@ -47,26 +54,29 @@ You are a professional band manager building a setlist for a live performance.
 EVENT DETAILS:
 {$context}
 {$extraSection}{$attachmentSection}
-AVAILABLE SONGS (format: ID | Title – Artist | Key | Genre | BPM | Lead singer | Transitions into):
+AVAILABLE SONGS (format: ID | Title – Artist | Key | Genre | BPM | Energy | Lead singer | Transitions into):
 {$songList}
 
 RULES — follow every rule without exception:
 
 1. EXCLUSIONS ARE ABSOLUTE: Songs are excluded if: (a) the band leader's instructions say to exclude them, (b) they appear crossed out or struck through in any attached image. Do NOT include excluded songs under any circumstances — not to fill time, not to round out a set, not for any reason. A shorter setlist is always preferable to violating an exclusion. If a song is crossed out in an image AND mentioned in the notes as a request, the crossed-out marking wins — do not play it.
 2. PLAY/DO-NOT-PLAY: Respect any play or do-not-play lists in the event notes with the same strictness as rule 1.
-3. REQUESTED SONGS: If the event notes, band leader instructions, or attached images reference a specific song (that is NOT crossed out):
-   - If it IS in the library, include it as {"id": <song_id>, "note": "Client request"} instead of a bare integer.
-   - If it is NOT in the library, include it as {"title": "...", "artist": "...", "note": "Client request — not in library"}.
-   Do not silently omit client requests in either case.
-4. HIGHLIGHTED SONGS: Songs highlighted or circled in any attached images are must-play requests — include them unless they conflict with rule 1.
+3. REQUESTED SONGS: Only include a song as a client request if it is EXPLICITLY named in the event notes, band leader instructions, or listed under "REQUESTED SONGS" in the CLIENT MARKINGS section above. Do NOT infer, guess, or add songs you think the client might want — only what is literally listed.
+   - If the song IS in the library, include it as {"id": <song_id>, "note": "Client request"} instead of a bare integer.
+   - If the song is NOT in the library, include it as {"title": "...", "artist": "...", "note": "Client request — not in library"}.
+   Do not silently omit client requests, but also do not fabricate them.
+4. HIGHLIGHTED SONGS: Songs listed under "REQUESTED SONGS" in the CLIENT MARKINGS section are client preferences. Include them where possible without violating other rules. Add {"note": "Highlighted"} for any such song. Take note of the genre pattern of requested songs and try to reflect that in the overall setlist.
 5. TRANSITIONS: When a song has a "Transitions into" field, place that target song immediately after it in the setlist.
-6. ENERGY FLOW: Vary genres and BPM to manage crowd energy. Do not cluster all slow songs together.
-7. LEAD SINGERS: Vary lead singers throughout the set when possible.
+6. ENERGY FLOW: Use the Energy field (Energy: 1/10) to shape the crowd arc. Take into account the BPM and what you already know about a song. Build energy gradually and always end the night on high energy songs (≥7). Avoid placing multiple low-energy songs (≤4) consecutively. After a set break, start with a high-energy song (≥7 if available). Songs with no energy rating should be treated as moderate (5).
+7. LEAD SINGERS: Distribute lead singers proportionally. Never have more than 3 consecutive songs with the same lead singer.
 8. BREAKS: If the event details specify multiple sets or a total performance duration, insert the string "break" between sets to represent set breaks. Do NOT place a break at the very beginning or very end of the setlist. Use the performance duration and typical ~3.5-minute song length to determine approximately how many songs fit per set.
+9. PERFORMANCE TYPE: Consider the type of performance specified in the event details (e.g., full concert, festival set, private event) and structure the setlist accordingly. For example, a festival set may require a shorter, high-energy selection of songs, whereas a full concert may allow for a more gradual build and inclusion of lower-energy songs or a wedding needs to include a mix of crowd-pleasing, familiar songs that appeal to a broad audience and keep the energy appropriate for a family-friendly or celebratory atmosphere.
+10. LOCATION: If the the event is taking place in South Louisiana, for example, consider including songs that reflect the local musical culture, such as zydeco, Cajun, or swamp pop influences, where appropriate, to connect with the audience and enhance the event experience.
 
 Return ONLY a valid JSON array in performance order. Each element is one of:
 - A song ID integer (plain library song with no special notes)
 - {"id": <song_id>, "note": "Client request"} for a library song that was specifically requested by the client
+- {"id": <song_id>, "note": "Highlighted"} for a library song that was highlighted or circled in an attached image
 - {"title": "...", "artist": "...", "note": "Client request — not in library"} for a requested song not in the library
 - The string "break" for set breaks
 
@@ -75,9 +85,34 @@ Example: [42, {"id": 17, "note": "Client request"}, {"title": "Sugar", "artist":
 Do not include any explanation, commentary, reasoning, or markdown. Output the raw JSON array and nothing else.
 PROMPT;
 
-        $responseText = $this->callClaude($prompt, $attachmentImages);
+        Log::info('SetlistAiService: prompt sent to Claude', ['prompt' => $prompt]);
 
-        return $this->parseSetlistItems($responseText);
+        $responseText = $this->callClaude($prompt);
+        Log::info('SetlistAiService: response received from Claude', ['response' => $responseText]);
+
+        $parsed = $this->parseSetlistItems($responseText);
+
+        $songMap = collect($songs)->keyBy('id');
+        $readable = collect($parsed)->map(function ($item) use ($songMap) {
+            if ($item === 'break') return '[BREAK]';
+            if (is_int($item)) {
+                $s = $songMap->get($item);
+                return $s ? "#{$item} {$s['title']}" : "#{$item} (unknown)";
+            }
+            if (is_array($item) && isset($item['id'])) {
+                $s = $songMap->get($item['id']);
+                $title = $s ? $s['title'] : "#{$item['id']} (unknown)";
+                return "{$title} [{$item['note']}]";
+            }
+            if (is_array($item) && isset($item['title'])) {
+                return "{$item['title']} (not in library)";
+            }
+            return '(unknown)';
+        })->values()->toArray();
+
+        Log::info('SetlistAiService: parsed setlist from Claude', ['order' => $readable]);
+
+        return $parsed;
     }
 
     /**
@@ -174,7 +209,7 @@ SONGS ALREADY PLAYED THIS SHOW: {$playedText}
 CROWD REACTIONS SO FAR:
 {$reactionsText}
 {$afterBreakSection}{$excludeSection}
-AVAILABLE SONGS (format: ID | Title – Artist | Key | Genre | BPM | Lead singer | Transitions into):
+AVAILABLE SONGS (format: ID | Title – Artist | Key | Genre | BPM | Energy | Lead singer | Transitions into):
 {$songList}
 
 Choose the single best next song to play right now. Consider:
@@ -193,6 +228,82 @@ PROMPT;
         $ids = $this->parseSongIds($responseText);
 
         return $ids[0] ?? null;
+    }
+
+    /** Public wrapper for testing in isolation via artisan command. */
+    public function testExtractMarkings(array $images, array $songs): string
+    {
+        return $this->extractClientMarkingsFromImages($images, $songs);
+    }
+
+    /**
+     * Step 1 of two-step image analysis.
+     * Send the image(s) to Claude with a focused extraction prompt and return
+     * a plain-English summary of client markings (requested, highlighted, crossed-out).
+     * This keeps the noisy vision task separate from setlist generation.
+     */
+    private function extractClientMarkingsFromImages(array $images, array $songs): string
+    {
+        $highlighted = [];
+        $excluded    = [];
+
+        // Split into chunks of 25 and ask Claude to check each chunk separately.
+        // This forces full coverage — Claude won't skip songs when the list is short.
+        $chunkSize = 15;
+        $chunks = collect($songs)->values()->chunk($chunkSize);
+
+        foreach ($chunks as $chunkIndex => $chunk) {
+            $numberedList = $chunk->values()
+                ->map(fn ($s, $i) => ($chunkIndex * $chunkSize + $i + 1) . '. ' . $s['title'])
+                ->implode("\n");
+
+            $extractionPrompt = <<<PROMPT
+You are analyzing a band's printed master setlist that a client has physically marked up.
+
+The image shows a printed list of song titles. The client has made physical marks next to some songs.
+
+There are TWO types of client marks:
+1. HIGHLIGHTED / REQUESTED — a star (*), asterisk, circle, checkmark, or different-colored text (orange, gold, red) next to the title.
+2. CROSSED OUT / EXCLUDED — a line struck through the title.
+
+TASK: For each song in the list below, find that title in the image and check whether it has a mark next to it.
+
+SONGS TO CHECK:
+{$numberedList}
+
+Output exactly one line per song, in the same order:
+[number]. [song title] | HIGHLIGHTED or EXCLUDED or UNMARKED
+
+Do not skip any song. If you cannot find the title in the image or cannot read it clearly, output UNMARKED.
+PROMPT;
+
+            $raw = $this->callClaude($extractionPrompt, $images);
+            Log::info("SetlistAiService: image checklist chunk {$chunkIndex}", ['raw' => $raw]);
+
+            foreach (explode("\n", $raw) as $line) {
+                $line = trim($line);
+                if (empty($line)) continue;
+                if (preg_match('/^\d+\.\s+(.+?)\s*\|\s*(HIGHLIGHTED|EXCLUDED|UNMARKED)/i', $line, $m)) {
+                    $title  = trim($m[1]);
+                    $status = strtoupper(trim($m[2]));
+                    if ($status === 'HIGHLIGHTED') {
+                        $highlighted[] = $title;
+                    } elseif ($status === 'EXCLUDED') {
+                        $excluded[] = $title;
+                    }
+                }
+            }
+        }
+
+        $highlightedText = !empty($highlighted)
+            ? implode("\n", array_map(fn ($t) => "- {$t}", $highlighted))
+            : 'None';
+
+        $excludedText = !empty($excluded)
+            ? implode("\n", array_map(fn ($t) => "- {$t}", $excluded))
+            : 'None';
+
+        return "REQUESTED SONGS (highlighted/starred by client):\n{$highlightedText}\n\nEXCLUDED SONGS (crossed out by client):\n{$excludedText}";
     }
 
     private function buildEventContext(Events $event): string
@@ -241,13 +352,14 @@ PROMPT;
     private function buildSongList(array $songs): string
     {
         return collect($songs)->map(fn($s) => sprintf(
-            'ID:%d | %s%s | Key: %s | Genre: %s | BPM: %s | Lead: %s%s',
+            'ID:%d | %s%s | Key: %s | Genre: %s | BPM: %s | Energy: %s | Lead Singer: %s%s',
             $s['id'],
             $s['title'],
             !empty($s['artist']) ? ' – ' . $s['artist'] : '',
             $s['song_key'] ?? '—',
             $s['genre'] ?? '—',
             $s['bpm'] ?? '—',
+            isset($s['energy']) ? $s['energy'] . '/10' : '—',
             $s['lead_singer'] ?? 'Instrumental',
             !empty($s['transition_song']) ? ' | Transitions into: ' . $s['transition_song'] : ''
         ))->implode("\n");
@@ -333,7 +445,7 @@ PROMPT;
             ],
             'json' => [
                 'model' => $this->model,
-                'max_tokens' => 2048,
+                'max_tokens' => 4096,
                 'messages' => $payload,
             ],
         ]);
@@ -382,7 +494,7 @@ You are a professional band manager refining a live performance setlist based on
 EVENT DETAILS:
 {$context}
 
-AVAILABLE SONGS (format: ID | Title – Artist | Key | Genre | BPM | Lead singer | Transitions into):
+AVAILABLE SONGS (format: ID | Title – Artist | Key | Genre | BPM | Energy | Lead singer | Transitions into):
 {$songList}
 
 CURRENT SETLIST:

--- a/app/Services/SetlistAiService.php
+++ b/app/Services/SetlistAiService.php
@@ -3,6 +3,9 @@
 namespace App\Services;
 
 use App\Models\Events;
+use App\Services\Ai\Contracts\AiAdapterInterface;
+use App\Services\Ai\Adapters\ClaudeAdapter;
+use App\Services\Ai\Adapters\GeminiAdapter;
 use GuzzleHttp\Client;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Storage;
@@ -12,19 +15,21 @@ class SetlistAiService
     private Client $http;
     private string $apiKey;
     private string $model = 'claude-opus-4-6';
+    private AiAdapterInterface $visionAdapter;
 
-    public function __construct()
+    public function __construct(?AiAdapterInterface $visionAdapter = null, ?string $apiKey = null)
     {
-        $this->apiKey = config('services.anthropic.key');
+        $this->apiKey = $apiKey ?? config('services.anthropic.key', '');
         $this->http = new Client([
             'base_uri' => 'https://api.anthropic.com',
             'timeout' => 60,
         ]);
+        $this->visionAdapter = $visionAdapter ?? new GeminiAdapter();
     }
 
     /**
      * Generate a setlist for an event.
-     * Returns an array of items: integers (song IDs) or the string "break".
+     * Returns ['items' => [...], 'event_context' => string, 'image_context' => string[]].
      *
      * @param array $attachmentImages  Each element: ['data' => base64string, 'media_type' => 'image/jpeg']
      */
@@ -32,20 +37,38 @@ class SetlistAiService
     {
         $context = $this->buildEventContext($event);
         $songList = $this->buildSongList($songs);
-        
+
         $extraSection = $extraContext
             ? "\nBAND LEADER INSTRUCTIONS:\n{$extraContext}\n"
             : '';
 
         Log::info(empty($attachmentImages) ? 'No attachment images provided' : count($attachmentImages) . ' attachment image(s) provided');
 
-        // Two-step image analysis: first extract client markings, then generate setlist.
-        // This isolates the noisy vision task so the setlist prompt only sees clean text.
+        // Classify each image then extract structured information based on its type.
+        // This keeps the noisy vision tasks separate from setlist generation.
+        $imageSections   = []; // keyed entries: ['type' => ..., 'content' => ...]
+        $attachmentParts = []; // plain text for the prompt
+        foreach ($attachmentImages as $image) {
+            $type = $this->classifyImage($image);
+            Log::info('SetlistAiService: image classified', ['type' => $type]);
+
+            $extracted = match ($type) {
+                'MARKED_SETLIST' => $this->extractClientMarkingsFromImages([$image], $songs),
+                'PLAIN_SETLIST'  => $this->extractPlainSetlist([$image]),
+                'TIMELINE'       => $this->extractTimeline([$image]),
+                default          => null,
+            };
+
+            $imageSections[] = ['type' => $type, 'content' => $extracted];
+
+            if ($extracted !== null) {
+                $attachmentParts[] = $extracted;
+            }
+        }
+
         $attachmentSection = '';
-        if (!empty($attachmentImages)) {
-            $imageAnalysis = $this->extractClientMarkingsFromImages($attachmentImages, $songs);
-            Log::info('SetlistAiService: image analysis result', ['analysis' => $imageAnalysis]);
-            $attachmentSection = "\nCLIENT MARKINGS FROM ATTACHED IMAGE (pre-extracted):\n{$imageAnalysis}\n";
+        if (!empty($attachmentParts)) {
+            $attachmentSection = "\nATTACHMENT CONTEXT:\n" . implode("\n\n", $attachmentParts) . "\n";
         }
 
         $prompt = <<<PROMPT
@@ -112,7 +135,11 @@ PROMPT;
 
         Log::info('SetlistAiService: parsed setlist from Claude', ['order' => $readable]);
 
-        return $parsed;
+        return [
+            'items'         => $parsed,
+            'event_context' => trim($context . ($extraContext ? "\n\nBand leader instructions: {$extraContext}" : '')),
+            'image_context' => $imageSections,
+        ];
     }
 
     /**
@@ -230,27 +257,139 @@ PROMPT;
         return $ids[0] ?? null;
     }
 
-    /** Public wrapper for testing in isolation via artisan command. */
+    /**
+     * Public wrapper for testing in isolation via artisan command.
+     * Classifies each image then routes to the appropriate extractor.
+     */
     public function testExtractMarkings(array $images, array $songs): string
     {
-        return $this->extractClientMarkingsFromImages($images, $songs);
+        $sections = [];
+        foreach ($images as $image) {
+            $type = $this->classifyImage($image);
+            Log::info('SetlistAiService: test image classified', ['type' => $type]);
+
+            $extracted = match ($type) {
+                'MARKED_SETLIST' => $this->extractClientMarkingsFromImages([$image], $songs),
+                'PLAIN_SETLIST'  => $this->extractPlainSetlist([$image]),
+                'TIMELINE'       => $this->extractTimeline([$image]),
+                default          => null,
+            };
+
+            $sections[] = "[Classified as: {$type}]";
+            if ($extracted !== null) {
+                $sections[] = $extracted;
+            } else {
+                $sections[] = "(No structured extraction for this image type — passed as general context only.)";
+            }
+        }
+
+        return implode("\n\n", $sections);
     }
 
     /**
-     * Step 1 of two-step image analysis.
-     * Send the image(s) to Claude with a focused extraction prompt and return
-     * a plain-English summary of client markings (requested, highlighted, crossed-out).
-     * This keeps the noisy vision task separate from setlist generation.
+     * Pre-flight: classify an image so the correct extraction strategy can be applied.
+     * Returns one of: MARKED_SETLIST, PLAIN_SETLIST, TIMELINE, OTHER.
+     */
+    private function classifyImage(array $image): string
+    {
+        $prompt = <<<PROMPT
+Look at this image and classify it into exactly one of these four categories:
+
+MARKED_SETLIST — a printed or typed list of song titles where the client has added handwritten marks (highlights, circles, stars, asterisks, checkmarks, crossed-out lines, or colored annotations).
+PLAIN_SETLIST — a printed, typed, or handwritten list of song titles with no client marks or annotations.
+TIMELINE — a schedule, run-of-show, or timeline for an event (e.g. wedding reception order, ceremony schedule, show itinerary with times).
+OTHER — anything else (stage plot, photo, logo, contract, diagram, etc.).
+
+Reply with exactly one word: MARKED_SETLIST, PLAIN_SETLIST, TIMELINE, or OTHER.
+PROMPT;
+
+        $raw = trim($this->visionAdapter->queryWithImage($prompt, $image));
+        $type = strtoupper(preg_replace('/[^A-Z_]/', '', $raw));
+
+        if (!in_array($type, ['MARKED_SETLIST', 'PLAIN_SETLIST', 'TIMELINE', 'OTHER'])) {
+            Log::warning('SetlistAiService: unexpected image classification', ['raw' => $raw]);
+            return 'OTHER';
+        }
+
+        return $type;
+    }
+
+    /**
+     * Extract song titles from a plain (unmarked) setlist image.
+     * Returns a formatted string listing the songs as client requests.
+     */
+    private function extractPlainSetlist(array $images): string
+    {
+        $prompt = <<<PROMPT
+This image contains a list of song titles provided by a client.
+
+Read every song title visible in the image and return them as a JSON array of strings, in the order they appear.
+
+Example: ["September", "Can't Stop the Feeling", "Uptown Funk"]
+
+Return ONLY the JSON array. No explanation, no markdown.
+PROMPT;
+
+        $raw  = $this->visionAdapter->queryWithImage($prompt, $images[0], 1024);
+        $json = preg_replace('/^```(?:json)?\s*|\s*```$/m', '', trim($raw));
+        $titles = json_decode($json, true);
+
+        if (!is_array($titles)) {
+            Log::warning('SetlistAiService: could not parse plain setlist', ['raw' => $raw]);
+            return "CLIENT SONG LIST (from image):\nNone";
+        }
+
+        $list = implode("\n", array_map(fn ($t) => "- {$t}", $titles));
+        return "CLIENT SONG LIST (from attached image — treat as requested songs):\n{$list}";
+    }
+
+    /**
+     * Extract event timeline / run-of-show from a schedule image.
+     * Returns a formatted string with time-ordered event notes.
+     */
+    private function extractTimeline(array $images): string
+    {
+        $prompt = <<<PROMPT
+This image contains an event timeline, run-of-show, or schedule.
+
+Extract every item you can read and return them as a JSON array of objects with "time" and "description" keys.
+
+Example: [{"time": "6:00 PM", "description": "Cocktail hour — background music"}, {"time": "7:00 PM", "description": "Grand entrance"}]
+
+If no time is listed for an item, use null for "time". Return ONLY the JSON array. No explanation, no markdown.
+PROMPT;
+
+        $raw  = $this->visionAdapter->queryWithImage($prompt, $images[0], 1024);
+        $json = preg_replace('/^```(?:json)?\s*|\s*```$/m', '', trim($raw));
+        $items = json_decode($json, true);
+
+        if (!is_array($items)) {
+            Log::warning('SetlistAiService: could not parse timeline', ['raw' => $raw]);
+            return "EVENT TIMELINE (from image):\nNone";
+        }
+
+        $lines = array_map(function ($item) {
+            $time = $item['time'] ?? null;
+            $desc = $item['description'] ?? '';
+            return $time ? "{$time}: {$desc}" : $desc;
+        }, $items);
+
+        $list = implode("\n", $lines);
+        return "EVENT TIMELINE (from attached image — use for set breaks and performance timing):\n{$list}";
+    }
+
+    /**
+     * Extract client markings from a marked-up setlist image using Gemini.
+     * Chunks the song library and checks each title against the image.
      */
     private function extractClientMarkingsFromImages(array $images, array $songs): string
     {
         $highlighted = [];
         $excluded    = [];
+        $image       = $images[0]; // one image per classification call
 
-        // Split into chunks of 25 and ask Claude to check each chunk separately.
-        // This forces full coverage — Claude won't skip songs when the list is short.
-        $chunkSize = 15;
-        $chunks = collect($songs)->values()->chunk($chunkSize);
+        $chunkSize = 25;
+        $chunks    = collect($songs)->values()->chunk($chunkSize);
 
         foreach ($chunks as $chunkIndex => $chunk) {
             $numberedList = $chunk->values()
@@ -266,7 +405,9 @@ There are TWO types of client marks:
 1. HIGHLIGHTED / REQUESTED — a star (*), asterisk, circle, checkmark, or different-colored text (orange, gold, red) next to the title.
 2. CROSSED OUT / EXCLUDED — a line struck through the title.
 
-TASK: For each song in the list below, find that title in the image and check whether it has a mark next to it.
+IMPORTANT — FUZZY TITLE MATCHING: The song titles in the list below may differ slightly from what is printed in the image. The image may use abbreviations, alternate punctuation, shortened titles, or omit subtitles. Match each song to the closest title you can find in the image. For example, "If You Don't Want Me To (The Freeze)" in the list may appear as "If You Don't Want Me To" or "The Freeze" in the image — treat these as the same song.
+
+TASK: For each song in the list below, find the closest matching title in the image and check whether it has a mark next to it.
 
 SONGS TO CHECK:
 {$numberedList}
@@ -274,11 +415,11 @@ SONGS TO CHECK:
 Output exactly one line per song, in the same order:
 [number]. [song title] | HIGHLIGHTED or EXCLUDED or UNMARKED
 
-Do not skip any song. If you cannot find the title in the image or cannot read it clearly, output UNMARKED.
+Do not skip any song. If you cannot find a close match in the image or cannot read it clearly, output UNMARKED.
 PROMPT;
 
-            $raw = $this->callClaude($extractionPrompt, $images);
-            Log::info("SetlistAiService: image checklist chunk {$chunkIndex}", ['raw' => $raw]);
+            $raw = $this->visionAdapter->queryWithImage($extractionPrompt, $image, 8192);
+            Log::info("SetlistAiService: marked setlist chunk {$chunkIndex}", ['raw' => $raw]);
 
             foreach (explode("\n", $raw) as $line) {
                 $line = trim($line);
@@ -310,40 +451,41 @@ PROMPT;
     {
         $lines = [];
 
-        $lines[] = 'Title: ' . ($event->title ?? 'Unknown');
+        $lines[] = 'Event Title: ' . ($event->title ?? 'Unknown');
         $lines[] = 'Date: ' . ($event->date?->toFormattedDateString() ?? 'Unknown');
-
-        if ($event->type) {
-            $lines[] = 'Event Type: ' . $event->type->name;
-        }
+        $lines[] = 'Event Type: ' . ($event->type?->name ?? 'Unknown');
 
         if ($event->eventable) {
             $booking = $event->eventable;
 
             if (!empty($booking->venue_name)) {
-                $lines[] = 'Venue: ' . $booking->venue_name;
+                $venueLine = 'Venue: ' . $booking->venue_name;
+                if (!empty($booking->venue_address)) {
+                    $venueLine .= ' — ' . $booking->venue_address;
+                }
+                $lines[] = $venueLine;
             }
 
             if (!empty($booking->start_time) && !empty($booking->end_time)) {
-                $start = $booking->start_time->format('g:i A');
-                $end   = $booking->end_time->format('g:i A');
-                $lines[] = "Performance Time: {$start} – {$end}";
-
-                $duration = $booking->duration; // hours (float)
-                $minutes  = (int) round($duration * 60);
-                $lines[] = "Total Performance Duration: {$minutes} minutes";
+                $start   = $booking->start_time->format('g:i A');
+                $end     = $booking->end_time->format('g:i A');
+                $minutes = (int) round($booking->duration * 60);
+                $lines[] = "Performance Time: {$start} – {$end} ({$minutes} minutes total)";
             }
         } elseif ($event->time) {
             $lines[] = 'Start Time: ' . $event->time;
         }
 
         if ($event->notes) {
-            $lines[] = 'Notes / Special Requests: ' . strip_tags($event->notes);
+            $lines[] = 'Client Notes / Special Requests: ' . strip_tags($event->notes);
         }
 
         if ($event->roster_members && count($event->roster_members) > 0) {
-            $roster = collect($event->roster_members)->pluck('name')->implode(', ');
-            $lines[] = 'Performing Musicians: ' . $roster;
+            $lines[] = 'Performing Musicians:';
+            foreach ($event->roster_members as $member) {
+                $role    = !empty($member['role']) ? " ({$member['role']})" : '';
+                $lines[] = "  - {$member['name']}{$role}";
+            }
         }
 
         return implode("\n", $lines);

--- a/app/Services/SetlistAiService.php
+++ b/app/Services/SetlistAiService.php
@@ -254,6 +254,52 @@ PROMPT;
     }
 
     /**
+     * Look up song details (key, BPM, genre, artist) using Claude as a fallback.
+     *
+     * @return array{bpm: int|null, song_key: string|null, genre: string|null, artist: string|null}
+     */
+    public function lookupSongDetails(string $title, ?string $artist = null): array
+    {
+        $artistLine = $artist ? " by {$artist}" : '';
+        $prompt = <<<PROMPT
+You are a music reference tool. Return the details for the song "{$title}"{$artistLine}.
+
+Respond with ONLY a JSON object, no explanation:
+{
+  "bpm": <integer or null>,
+  "song_key": "<note> <accidental if any> <maj or min>, e.g. 'Bb min' or 'E maj', or null if unknown>",
+  "genre": "<primary genre, e.g. Rock, Country, R&B, or null if unknown>",
+  "artist": "<canonical artist name, or null if unknown>"
+}
+
+If you are not confident about a value, use null rather than guessing.
+PROMPT;
+
+        try {
+            $raw = $this->callClaude($prompt);
+            Log::info('Claude song lookup raw', ['raw' => $raw]);
+            // Strip markdown code fences if present
+            $json = preg_replace('/^```(?:json)?\s*|\s*```$/m', '', trim($raw));
+            $data = json_decode($json, true);
+            Log::info('Claude song lookup parsed', ['data' => $data]);
+
+            if (!is_array($data)) {
+                return ['bpm' => null, 'song_key' => null, 'genre' => null, 'artist' => null];
+            }
+
+            return [
+                'bpm'      => isset($data['bpm']) ? (int) $data['bpm'] : null,
+                'song_key' => $data['song_key'] ?? null,
+                'genre'    => $data['genre'] ?? null,
+                'artist'   => $data['artist'] ?? null,
+            ];
+        } catch (\Throwable $e) {
+            Log::warning('Claude song lookup failed', ['error' => $e->getMessage(), 'title' => $title]);
+            return ['bpm' => null, 'song_key' => null, 'genre' => null, 'artist' => null];
+        }
+    }
+
+    /**
      * @param array|null $messages  Pre-built multi-turn messages array. When provided,
      *                              $prompt and $images are ignored.
      */

--- a/config/services.php
+++ b/config/services.php
@@ -34,6 +34,10 @@ return [
         'key' => env('ANTHROPIC_API_KEY'),
     ],
 
+    'gemini' => [
+        'key' => env('GEMINI_API_KEY'),
+    ],
+
     'pandadoc' => [
         'api_key' => env('PANDADOC_KEY'),
         'client_id' => env('PANDADOC_CLIENT_ID'),

--- a/config/services.php
+++ b/config/services.php
@@ -55,6 +55,10 @@ return [
         'redirect_uri' => env('APP_URL') . '/media/drive/callback',
     ],
 
+    'getsongbpm' => [
+        'key' => env('GETSONGBPM_API_KEY'),
+    ],
+
     'media' => [
         'upload_notification_delay' => env('MEDIA_UPLOAD_NOTIFICATION_DELAY', 5), // minutes
     ],

--- a/database/migrations/2026_04_08_173457_add_rating_and_energy_to_songs_table.php
+++ b/database/migrations/2026_04_08_173457_add_rating_and_energy_to_songs_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('songs', function (Blueprint $table) {
+            $table->unsignedTinyInteger('rating')->nullable()->after('bpm');
+            $table->unsignedTinyInteger('energy')->nullable()->after('rating');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('songs', function (Blueprint $table) {
+            $table->dropColumn(['rating', 'energy']);
+        });
+    }
+};

--- a/database/migrations/2026_04_09_105555_create_setlist_prompt_templates_table.php
+++ b/database/migrations/2026_04_09_105555_create_setlist_prompt_templates_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('setlist_prompt_templates', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('band_id')->constrained('bands')->cascadeOnDelete();
+            $table->string('name');
+            $table->text('prompt');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('setlist_prompt_templates');
+    }
+};

--- a/resources/js/Pages/Setlists/Editor.vue
+++ b/resources/js/Pages/Setlists/Editor.vue
@@ -141,6 +141,54 @@
         />
       </div>
 
+      <!-- AI Sources panel (shown after generation) -->
+      <div
+        v-if="localSetlist && (localSetlist.event_context || localSetlist.image_context?.length)"
+        class="bg-white dark:bg-slate-800 rounded-lg shadow mb-4 print:hidden overflow-hidden"
+      >
+        <button
+          class="w-full flex items-center justify-between px-4 py-3 text-sm text-gray-500 dark:text-gray-400 hover:bg-gray-50 dark:hover:bg-slate-700 transition-colors"
+          @click="sourcesOpen = !sourcesOpen"
+        >
+          <span class="flex items-center gap-2">
+            <i class="pi pi-eye text-xs" />
+            AI sources — what the generator saw
+          </span>
+          <i :class="['pi text-xs transition-transform', sourcesOpen ? 'pi-chevron-up' : 'pi-chevron-down']" />
+        </button>
+
+        <div v-if="sourcesOpen" class="border-t border-gray-100 dark:border-gray-700 px-4 py-3 flex flex-col gap-4">
+          <!-- Event context -->
+          <div v-if="localSetlist.event_context">
+            <p class="text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wide mb-1.5">Event details</p>
+            <pre class="text-xs text-gray-700 dark:text-gray-300 whitespace-pre-wrap font-sans leading-relaxed">{{ localSetlist.event_context }}</pre>
+          </div>
+
+          <!-- Image context -->
+          <div v-if="localSetlist.image_context?.length">
+            <p class="text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wide mb-1.5">
+              Attachments ({{ localSetlist.image_context.length }})
+            </p>
+            <div class="flex flex-col gap-3">
+              <div
+                v-for="(img, i) in localSetlist.image_context"
+                :key="i"
+                class="rounded-md bg-gray-50 dark:bg-slate-700 p-3"
+              >
+                <div class="flex items-center gap-2 mb-1">
+                  <span :class="['text-xs font-medium px-1.5 py-0.5 rounded', imageTypeClass(img.type)]">
+                    {{ imageTypeLabel(img.type) }}
+                  </span>
+                  <span class="text-xs text-gray-400 dark:text-gray-500">Image {{ i + 1 }}</span>
+                </div>
+                <pre v-if="img.content" class="text-xs text-gray-700 dark:text-gray-300 whitespace-pre-wrap font-sans leading-relaxed mt-1">{{ img.content }}</pre>
+                <p v-else class="text-xs text-gray-400 dark:text-gray-500 italic mt-1">No structured extraction — used as general context only.</p>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+
       <!-- No setlist yet -->
       <div
         v-if="!localSetlist && !generating"
@@ -315,6 +363,7 @@
                   </span>
                   <span v-if="element.genre" class="text-xs text-gray-400">{{ element.genre }}</span>
                   <span v-if="element.bpm" class="text-xs text-gray-400">{{ element.bpm }} BPM</span>
+                  <span v-if="element.energy" class="text-xs text-gray-400">E{{ element.energy }}</span>
                   <span v-if="element.lead_singer" class="text-xs text-gray-400">
                     <i class="pi pi-microphone text-xs" /> {{ element.lead_singer }}
                   </span>
@@ -369,17 +418,111 @@
           AI will build a setlist using the event type, roster, notes, and your song library.
           Add any extra context below.
         </p>
+
+        <!-- Saved prompts -->
+        <div v-if="promptTemplates.length > 0">
+          <p class="text-xs text-gray-500 dark:text-gray-400 mb-1.5">Saved prompts — click to load</p>
+          <div class="flex flex-wrap gap-2 max-h-24 overflow-y-auto">
+            <button
+              v-for="tpl in promptTemplates"
+              :key="tpl.id"
+              :class="[
+                'inline-flex items-center gap-1.5 text-xs px-2.5 py-1 rounded-full border transition-colors',
+                selectedGenerateTemplate?.id === tpl.id
+                  ? 'border-blue-500 bg-blue-50 dark:bg-blue-900/30 text-blue-700 dark:text-blue-300'
+                  : 'border-gray-300 dark:border-gray-600 bg-gray-50 dark:bg-slate-700 text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-slate-600'
+              ]"
+              :aria-label="tpl.name"
+              @click="loadGenerateTemplate(tpl)"
+            >
+              <i class="pi pi-bookmark text-xs" />
+              {{ tpl.name }}
+              <span
+                class="ml-0.5 text-gray-400 hover:text-red-500 transition-colors"
+                :aria-label="`Remove ${tpl.name}`"
+                @click.stop="deleteTemplate(tpl)"
+              >
+                <i class="pi pi-times text-xs" />
+              </span>
+            </button>
+          </div>
+        </div>
+
         <div>
           <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
             Additional context <span class="text-gray-400 font-normal">(optional)</span>
           </label>
           <Textarea
+            ref="generateTextarea"
             v-model="aiContext"
             class="w-full"
             rows="4"
             placeholder="e.g. Keep energy high throughout. The bride hates country music. End with something slow."
             auto-resize
           />
+          <!-- Loaded-from indicator -->
+          <div v-if="selectedGenerateTemplate" class="flex items-center gap-1 mt-1 text-xs text-gray-500 dark:text-gray-400">
+            <i class="pi pi-bookmark text-xs" />
+            Loaded from: <span class="font-medium">{{ selectedGenerateTemplate.name }}</span>
+            <button class="ml-1 hover:text-gray-700 dark:hover:text-gray-200" @click="clearGenerateTemplate">clear</button>
+          </div>
+        </div>
+
+        <!-- Save actions -->
+        <div v-if="aiContext.trim()" class="flex flex-col gap-2">
+          <!-- Loaded from a template: Update or Save as new -->
+          <div v-if="selectedGenerateTemplate" class="flex items-center gap-2 flex-wrap">
+            <Button
+              :label="`Update &quot;${selectedGenerateTemplate.name}&quot;`"
+              icon="pi pi-bookmark"
+              size="small"
+              :loading="savingTemplate"
+              @click="updateTemplate('generate')"
+            />
+            <Button
+              label="Save as new…"
+              size="small"
+              severity="secondary"
+              outlined
+              @click="showSaveAsGenerate = !showSaveAsGenerate"
+            />
+          </div>
+          <!-- Fresh text: Save prompt -->
+          <div v-else class="flex items-center gap-2">
+            <InputText
+              v-model="newTemplateName"
+              class="flex-1"
+              size="small"
+              placeholder="Template name…"
+            />
+            <Button
+              label="Save prompt"
+              icon="pi pi-bookmark"
+              size="small"
+              severity="secondary"
+              outlined
+              :disabled="!newTemplateName.trim()"
+              :loading="savingTemplate"
+              @click="saveTemplate('generate')"
+            />
+          </div>
+          <!-- Save as new name field (only when loaded template + expanded) -->
+          <div v-if="selectedGenerateTemplate && showSaveAsGenerate" class="flex items-center gap-2">
+            <InputText
+              v-model="newTemplateName"
+              class="flex-1"
+              size="small"
+              placeholder="New template name…"
+            />
+            <Button
+              label="Save"
+              icon="pi pi-check"
+              size="small"
+              :disabled="!newTemplateName.trim()"
+              :loading="savingTemplate"
+              @click="saveTemplate('generate')"
+            />
+          </div>
         </div>
       </div>
       <template #footer>
@@ -456,22 +599,109 @@
         </div>
 
         <!-- Input -->
-        <div class="flex gap-2 pt-2 border-t border-gray-200 dark:border-gray-700 flex-shrink-0">
-          <Textarea
-            v-model="refineMessage"
-            class="flex-1"
-            rows="2"
-            auto-resize
-            placeholder="What would you like to change?"
-            :disabled="refining"
-            @keydown.enter.exact.prevent="sendRefine"
-          />
-          <Button
-            icon="pi pi-send"
-            :loading="refining"
-            :disabled="!refineMessage.trim()"
-            @click="sendRefine"
-          />
+        <div class="flex flex-col gap-2 pt-2 border-t border-gray-200 dark:border-gray-700 flex-shrink-0">
+          <!-- Saved prompt chips -->
+          <div v-if="promptTemplates.length > 0" class="flex flex-wrap gap-1.5 max-h-20 overflow-y-auto">
+            <p class="w-full text-xs text-gray-400 dark:text-gray-500">Saved prompts — click to load</p>
+            <button
+              v-for="tpl in promptTemplates"
+              :key="tpl.id"
+              :class="[
+                'inline-flex items-center gap-1 text-xs px-2 py-0.5 rounded-full border transition-colors',
+                selectedRefineTemplate?.id === tpl.id
+                  ? 'border-blue-500 bg-blue-50 dark:bg-blue-900/30 text-blue-700 dark:text-blue-300'
+                  : 'border-gray-300 dark:border-gray-600 bg-gray-50 dark:bg-slate-700 text-gray-600 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-slate-600'
+              ]"
+              :aria-label="tpl.name"
+              @click="loadRefineTemplate(tpl)"
+            >
+              <i class="pi pi-bookmark text-xs" />
+              {{ tpl.name }}
+            </button>
+          </div>
+
+          <div class="flex gap-2">
+            <Textarea
+              ref="refineTextarea"
+              v-model="refineMessage"
+              class="flex-1"
+              rows="2"
+              auto-resize
+              placeholder="What would you like to change?"
+              :disabled="refining"
+              @keydown.enter.exact.prevent="sendRefine"
+            />
+            <Button
+              icon="pi pi-send"
+              :loading="refining"
+              :disabled="!refineMessage.trim()"
+              @click="sendRefine"
+            />
+          </div>
+
+          <!-- Loaded-from indicator -->
+          <div v-if="selectedRefineTemplate" class="flex items-center gap-1 text-xs text-gray-500 dark:text-gray-400">
+            <i class="pi pi-bookmark text-xs" />
+            Loaded from: <span class="font-medium">{{ selectedRefineTemplate.name }}</span>
+            <button class="ml-1 hover:text-gray-700 dark:hover:text-gray-200" @click="clearRefineTemplate">clear</button>
+          </div>
+
+          <!-- Save actions -->
+          <div v-if="refineMessage.trim()" class="flex flex-col gap-1.5">
+            <!-- Loaded from template: Update or Save as new -->
+            <div v-if="selectedRefineTemplate" class="flex items-center gap-2 flex-wrap">
+              <Button
+                :label="`Update &quot;${selectedRefineTemplate.name}&quot;`"
+                icon="pi pi-bookmark"
+                size="small"
+                :loading="savingTemplate"
+                @click="updateTemplate('refine')"
+              />
+              <Button
+                label="Save as new…"
+                size="small"
+                severity="secondary"
+                outlined
+                @click="showSaveAsRefine = !showSaveAsRefine"
+              />
+            </div>
+            <!-- Fresh text: Save prompt -->
+            <div v-else class="flex items-center gap-2">
+              <InputText
+                v-model="newTemplateName"
+                class="flex-1"
+                size="small"
+                placeholder="Save as template…"
+              />
+              <Button
+                icon="pi pi-bookmark"
+                size="small"
+                severity="secondary"
+                text
+                :disabled="!newTemplateName.trim()"
+                :loading="savingTemplate"
+                v-tooltip.top="'Save prompt'"
+                @click="saveTemplate('refine')"
+              />
+            </div>
+            <!-- Save as new name field (only when loaded template + expanded) -->
+            <div v-if="selectedRefineTemplate && showSaveAsRefine" class="flex items-center gap-2">
+              <InputText
+                v-model="newTemplateName"
+                class="flex-1"
+                size="small"
+                placeholder="New template name…"
+              />
+              <Button
+                icon="pi pi-check"
+                size="small"
+                :disabled="!newTemplateName.trim()"
+                :loading="savingTemplate"
+                v-tooltip.top="'Save as new'"
+                @click="saveTemplate('refine')"
+              />
+            </div>
+          </div>
         </div>
       </div>
     </Sidebar>
@@ -538,6 +768,7 @@ export default {
 
   props: {
     event: { type: Object, required: true },
+    bandId: { type: Number, required: true },
     setlist: { type: Object, default: null },
     songs: { type: Array, default: () => [] },
     canWrite: { type: Boolean, default: false },
@@ -560,7 +791,21 @@ export default {
       chatHistory: [],       // [{role:'user'|'assistant', content:string}]
       pendingSetlist: null,  // proposed setlist from AI, awaiting accept/dismiss
       previousSetlist: null, // snapshot before proposal, for dismiss
+      // AI sources panel
+      sourcesOpen: false,
+      // Prompt templates
+      promptTemplates: [],
+      newTemplateName: '',
+      savingTemplate: false,
+      selectedGenerateTemplate: null,  // template loaded into the generate dialog
+      showSaveAsGenerate: false,        // true when user expands "Save as new" in generate dialog
+      selectedRefineTemplate: null,    // template loaded into the refine drawer
+      showSaveAsRefine: false,          // true when user expands "Save as new" in refine drawer
     };
+  },
+
+  mounted() {
+    this.loadTemplates();
   },
 
   computed: {
@@ -585,6 +830,19 @@ export default {
   methods: {
     emptyEntryForm() {
       return { type: 'song', song_id: null, custom_title: '', custom_artist: '', notes: '' };
+    },
+
+    imageTypeLabel(type) {
+      return { MARKED_SETLIST: 'Marked setlist', PLAIN_SETLIST: 'Song list', TIMELINE: 'Timeline', OTHER: 'Other' }[type] ?? type;
+    },
+
+    imageTypeClass(type) {
+      return {
+        MARKED_SETLIST: 'bg-blue-100 dark:bg-blue-900/40 text-blue-700 dark:text-blue-300',
+        PLAIN_SETLIST:  'bg-green-100 dark:bg-green-900/40 text-green-700 dark:text-green-300',
+        TIMELINE:       'bg-purple-100 dark:bg-purple-900/40 text-purple-700 dark:text-purple-300',
+        OTHER:          'bg-gray-100 dark:bg-slate-600 text-gray-600 dark:text-gray-300',
+      }[type] ?? 'bg-gray-100 dark:bg-slate-600 text-gray-600 dark:text-gray-300';
     },
 
     // Returns the 1-based song number (ignoring break rows) for display
@@ -628,6 +886,9 @@ export default {
 
     openGenerateDialog() {
       this.aiContext = '';
+      this.selectedGenerateTemplate = null;
+      this.showSaveAsGenerate = false;
+      this.newTemplateName = '';
       this.generateDialogVisible = true;
     },
 
@@ -724,6 +985,7 @@ export default {
         song_key: song?.song_key ?? null,
         genre: song?.genre ?? null,
         bpm: song?.bpm ?? null,
+        energy: song?.energy ?? null,
         lead_singer: song?.lead_singer ?? null,
         notes: this.entryForm.notes || null,
       };
@@ -752,6 +1014,8 @@ export default {
 
       this.chatHistory.push({ role: 'user', content: msg });
       this.refineMessage = '';
+      this.selectedRefineTemplate = null;
+      this.showSaveAsRefine = false;
       this.refining = true;
       this.$nextTick(() => this.scrollChatToBottom());
 
@@ -832,6 +1096,113 @@ export default {
         this.$toast?.add({ severity: 'error', summary: 'Failed to clear setlist', life: 4000 });
       } finally {
         this.saving = false;
+      }
+    },
+
+    async loadTemplates() {
+      try {
+        const { data } = await axios.get(route('setlists.prompt-templates.index', this.bandId));
+        this.promptTemplates = data;
+      } catch {
+        // Non-critical; silently ignore
+      }
+    },
+
+    loadGenerateTemplate(tpl) {
+      this.aiContext = tpl.prompt;
+      this.selectedGenerateTemplate = tpl;
+      this.showSaveAsGenerate = false;
+      this.newTemplateName = '';
+      this.$nextTick(() => this.$refs.generateTextarea?.$el?.focus());
+    },
+
+    clearGenerateTemplate() {
+      this.selectedGenerateTemplate = null;
+      this.showSaveAsGenerate = false;
+      this.newTemplateName = '';
+    },
+
+    loadRefineTemplate(tpl) {
+      this.refineMessage = tpl.prompt;
+      this.selectedRefineTemplate = tpl;
+      this.showSaveAsRefine = false;
+      this.newTemplateName = '';
+      this.$nextTick(() => this.$refs.refineTextarea?.$el?.focus());
+    },
+
+    clearRefineTemplate() {
+      this.selectedRefineTemplate = null;
+      this.showSaveAsRefine = false;
+      this.newTemplateName = '';
+    },
+
+    async updateTemplate(context) {
+      const tpl = context === 'generate' ? this.selectedGenerateTemplate : this.selectedRefineTemplate;
+      const prompt = context === 'generate' ? this.aiContext.trim() : this.refineMessage.trim();
+      if (!tpl || !prompt) return;
+
+      this.savingTemplate = true;
+      try {
+        const { data } = await axios.patch(
+          route('setlists.prompt-templates.update', { band: this.bandId, template: tpl.id }),
+          { prompt }
+        );
+        const idx = this.promptTemplates.findIndex(t => t.id === tpl.id);
+        if (idx !== -1) this.promptTemplates.splice(idx, 1, data);
+        if (context === 'generate') this.selectedGenerateTemplate = data;
+        else this.selectedRefineTemplate = data;
+        this.$toast?.add({ severity: 'success', summary: 'Prompt updated', life: 2000 });
+      } catch {
+        this.$toast?.add({ severity: 'error', summary: 'Could not update prompt', life: 4000 });
+      } finally {
+        this.savingTemplate = false;
+      }
+    },
+
+    async saveTemplate(context) {
+      const prompt = context === 'generate' ? this.aiContext.trim() : this.refineMessage.trim();
+      if (!prompt || !this.newTemplateName.trim()) return;
+
+      this.savingTemplate = true;
+      try {
+        const { data } = await axios.post(route('setlists.prompt-templates.store', this.bandId), {
+          name: this.newTemplateName.trim(),
+          prompt,
+        });
+        this.promptTemplates.push(data);
+        this.promptTemplates.sort((a, b) => a.name.localeCompare(b.name));
+        this.newTemplateName = '';
+        if (context === 'generate') {
+          this.selectedGenerateTemplate = data;
+          this.showSaveAsGenerate = false;
+        } else {
+          this.selectedRefineTemplate = data;
+          this.showSaveAsRefine = false;
+        }
+        this.$toast?.add({ severity: 'success', summary: 'Prompt saved', life: 2000 });
+      } catch {
+        this.$toast?.add({ severity: 'error', summary: 'Could not save prompt', life: 4000 });
+      } finally {
+        this.savingTemplate = false;
+      }
+    },
+
+    async deleteTemplate(tpl) {
+      try {
+        await axios.delete(route('setlists.prompt-templates.destroy', { band: this.bandId, template: tpl.id }));
+        this.promptTemplates = this.promptTemplates.filter(t => t.id !== tpl.id);
+        if (this.selectedGenerateTemplate?.id === tpl.id) {
+          this.selectedGenerateTemplate = null;
+          this.showSaveAsGenerate = false;
+          this.newTemplateName = '';
+        }
+        if (this.selectedRefineTemplate?.id === tpl.id) {
+          this.selectedRefineTemplate = null;
+          this.showSaveAsRefine = false;
+          this.newTemplateName = '';
+        }
+      } catch {
+        this.$toast?.add({ severity: 'error', summary: 'Could not delete prompt', life: 4000 });
       }
     },
   },

--- a/resources/js/Pages/Songs/Index.vue
+++ b/resources/js/Pages/Songs/Index.vue
@@ -156,27 +156,57 @@
 
           <!-- Artist -->
           <div>
-            <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Artist</label>
+            <div class="flex items-center justify-between mb-1">
+              <label class="block text-sm font-medium text-gray-700 dark:text-gray-300">Artist</label>
+              <Button
+                label="Auto-fill"
+                icon="pi pi-sparkles"
+                size="small"
+                text
+                :loading="lookingUp"
+                :disabled="!form.title"
+                @click="autofill"
+              />
+            </div>
             <InputText v-model="form.artist" class="w-full" placeholder="Artist / band name" />
           </div>
 
           <!-- Key -->
           <div>
             <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Key</label>
-            <div class="flex gap-2">
-              <Dropdown
-                v-model="form.keyNote"
-                :options="keyNotes"
-                placeholder="Note"
-                show-clear
-                class="flex-1"
+            <!-- Note buttons: A–G -->
+            <div class="flex flex-wrap gap-2 mb-3">
+              <Button
+                v-for="note in keyNotes"
+                :key="note"
+                :label="note"
+                :outlined="form.keyNote !== note"
+                size="small"
+                @click="form.keyNote = form.keyNote === note ? null : note"
               />
-              <Dropdown
-                v-model="form.keyMode"
-                :options="keyModes"
-                placeholder="maj/min"
-                class="w-28"
-              />
+            </div>
+            <!-- Accidental + Mode toggles -->
+            <div class="flex gap-4">
+              <div class="flex gap-1">
+                <Button
+                  v-for="acc in keyAccidentals"
+                  :key="acc"
+                  :label="acc"
+                  :outlined="form.keyAccidental !== acc"
+                  size="small"
+                  @click="form.keyAccidental = form.keyAccidental === acc ? null : acc"
+                />
+              </div>
+              <div class="flex gap-1">
+                <Button
+                  v-for="mode in keyModes"
+                  :key="mode"
+                  :label="mode"
+                  :outlined="form.keyMode !== mode"
+                  size="small"
+                  @click="form.keyMode = form.keyMode === mode ? null : mode"
+                />
+              </div>
             </div>
           </div>
 
@@ -203,6 +233,38 @@
               :max="999"
               placeholder="Tempo"
             />
+          </div>
+
+          <!-- Rating -->
+          <div>
+            <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">Band Rating</label>
+            <div class="flex gap-1">
+              <Button
+                v-for="n in 10"
+                :key="n"
+                :label="String(n)"
+                :outlined="form.rating !== n"
+                :severity="form.rating >= n ? 'warn' : 'secondary'"
+                size="small"
+                @click="form.rating = form.rating === n ? null : n"
+              />
+            </div>
+          </div>
+
+          <!-- Energy -->
+          <div>
+            <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">Energy</label>
+            <div class="flex gap-1">
+              <Button
+                v-for="n in 10"
+                :key="n"
+                :label="String(n)"
+                :outlined="form.energy !== n"
+                :severity="form.energy >= n ? 'danger' : 'secondary'"
+                size="small"
+                @click="form.energy = form.energy === n ? null : n"
+              />
+            </div>
           </div>
 
           <!-- Lead Singer -->
@@ -297,9 +359,11 @@ export default {
       dialogVisible: false,
       saving: false,
       deleting: false,
+      lookingUp: false,
       editingSong: null,
       form: this.emptyForm(),
-      keyNotes: ['A', 'A#', 'B', 'C', 'C#', 'D', 'D#', 'E', 'F', 'F#', 'G', 'G#'],
+      keyNotes: ['A', 'B', 'C', 'D', 'E', 'F', 'G'],
+      keyAccidentals: ['♯', '♭'],
       keyModes: ['maj', 'min'],
     };
   },
@@ -354,9 +418,12 @@ export default {
         title: '',
         artist: '',
         keyNote: null,
+        keyAccidental: null,
         keyMode: null,
         genre: '',
         bpm: null,
+        rating: null,
+        energy: null,
         notes: '',
         lead_singer_id: null,
         transition_song_id: null,
@@ -365,11 +432,17 @@ export default {
     },
 
     parseSongKey(songKey) {
-      if (!songKey) return { keyNote: null, keyMode: null };
-      const parts = songKey.trim().split(/\s+/);
+      if (!songKey) return { keyNote: null, keyAccidental: null, keyMode: null };
+      // Match: note letter, optional accidental (♯ ♭ # b), optional mode
+      // 'b' after a note letter is a flat, but 'B' alone is the note B
+      const match = songKey.trim().match(/^([A-G])([♯♭#]|b)?(?:\s+(maj|min))?$/i);
+      if (!match) return { keyNote: null, keyAccidental: null, keyMode: null };
+      const accidentalMap = { '#': '♯', 'b': '♭' };
+      const raw = match[2] ?? null;
       return {
-        keyNote: parts[0] ?? null,
-        keyMode: parts[1] ?? null,
+        keyNote: match[1].toUpperCase(),
+        keyAccidental: raw ? (accidentalMap[raw] ?? raw) : null,
+        keyMode: match[3] ? match[3].toLowerCase() : null,
       };
     },
 
@@ -385,14 +458,17 @@ export default {
 
     openEditDialog(song) {
       this.editingSong = song;
-      const { keyNote, keyMode } = this.parseSongKey(song.song_key);
+      const { keyNote, keyAccidental, keyMode } = this.parseSongKey(song.song_key);
       this.form = {
         title: song.title ?? '',
         artist: song.artist ?? '',
         keyNote,
+        keyAccidental,
         keyMode,
         genre: song.genre ?? '',
         bpm: song.bpm ?? null,
+        rating: song.rating ?? null,
+        energy: song.energy ?? null,
         notes: song.notes ?? '',
         lead_singer_id: song.lead_singer_id ?? null,
         transition_song_id: song.transition_song_id ?? null,
@@ -406,6 +482,32 @@ export default {
       this.form = this.emptyForm();
     },
 
+    async autofill() {
+      if (!this.form.title) return;
+      this.lookingUp = true;
+      try {
+        const params = new URLSearchParams({ title: this.form.title });
+        if (this.form.artist) params.append('artist', this.form.artist);
+        const res = await fetch(`/songs/lookup?${params}`);
+        const data = await res.json();
+
+        if (data.artist && !this.form.artist) this.form.artist = data.artist;
+        if (data.bpm)      this.form.bpm = data.bpm;
+        if (data.genre && !this.form.genre)   this.form.genre = data.genre;
+
+        if (data.song_key) {
+          const { keyNote, keyAccidental, keyMode } = this.parseSongKey(data.song_key);
+          if (keyNote)       this.form.keyNote = keyNote;
+          if (keyAccidental) this.form.keyAccidental = keyAccidental;
+          if (keyMode)       this.form.keyMode = keyMode;
+        }
+      } catch (e) {
+        // silently fail — user can fill in manually
+      } finally {
+        this.lookingUp = false;
+      }
+    },
+
     async saveSong() {
       if (!this.form.title.trim()) return;
 
@@ -413,10 +515,11 @@ export default {
       const payload = {
         ...this.form,
         song_key: this.form.keyNote
-          ? [this.form.keyNote, this.form.keyMode].filter(Boolean).join(' ')
+          ? [(this.form.keyNote + (this.form.keyAccidental ?? '')), this.form.keyMode].filter(Boolean).join(' ')
           : null,
       };
       delete payload.keyNote;
+      delete payload.keyAccidental;
       delete payload.keyMode;
 
       try {

--- a/resources/js/Pages/Songs/Index.vue
+++ b/resources/js/Pages/Songs/Index.vue
@@ -88,6 +88,12 @@
           <Column field="song_key" header="Key" sortable style="width: 90px" />
           <Column field="genre" header="Genre" sortable style="width: 130px" />
           <Column field="bpm" header="BPM" sortable style="width: 80px" />
+          <Column field="energy" header="Energy" sortable style="width: 90px">
+            <template #body="{ data }">
+              <span v-if="data.energy">{{ data.energy }}/10</span>
+              <span v-else class="text-gray-400">—</span>
+            </template>
+          </Column>
           <Column header="Lead Singer" style="width: 160px">
             <template #body="{ data }">
               {{ data.lead_singer?.display_name ?? '—' }}

--- a/routes/setlists.php
+++ b/routes/setlists.php
@@ -4,10 +4,17 @@ use App\Http\Controllers\BreakController;
 use App\Http\Controllers\CaptainController;
 use App\Http\Controllers\LiveSessionController;
 use App\Http\Controllers\SetlistController;
+use App\Http\Controllers\SetlistPromptTemplateController;
 use App\Http\Controllers\SetlistSuggestionController;
 use Illuminate\Support\Facades\Route;
 
 Route::middleware(['auth'])->group(function () {
+    // Prompt templates (scoped to band)
+    Route::get('/bands/{band}/setlist-prompt-templates', [SetlistPromptTemplateController::class, 'index'])->name('setlists.prompt-templates.index');
+    Route::post('/bands/{band}/setlist-prompt-templates', [SetlistPromptTemplateController::class, 'store'])->name('setlists.prompt-templates.store');
+    Route::patch('/bands/{band}/setlist-prompt-templates/{template}', [SetlistPromptTemplateController::class, 'update'])->name('setlists.prompt-templates.update');
+    Route::delete('/bands/{band}/setlist-prompt-templates/{template}', [SetlistPromptTemplateController::class, 'destroy'])->name('setlists.prompt-templates.destroy');
+
     // Static setlist
     Route::get('/events/{key}/setlist', [SetlistController::class, 'show'])->name('setlists.show');
     Route::post('/events/{key}/setlist/generate', [SetlistController::class, 'generate'])->name('setlists.generate');

--- a/routes/songs.php
+++ b/routes/songs.php
@@ -19,4 +19,7 @@ Route::middleware(['auth', 'verified'])->group(function () {
     Route::delete('/songs/{song}', [SongsController::class, 'destroy'])
         ->middleware('songs.write')
         ->name('songs.destroy');
+
+    Route::get('/songs/lookup', [SongsController::class, 'lookup'])
+        ->name('songs.lookup');
 });

--- a/tests/Unit/Ai/ClaudeAdapterTest.php
+++ b/tests/Unit/Ai/ClaudeAdapterTest.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace Tests\Unit\Ai;
+
+use App\Services\Ai\Adapters\ClaudeAdapter;
+use GuzzleHttp\Client;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Middleware;
+use GuzzleHttp\Psr7\Response;
+use Tests\TestCase;
+
+class ClaudeAdapterTest extends TestCase
+{
+    private function makeAdapter(array $responses, array &$history = []): ClaudeAdapter
+    {
+        $mock  = new MockHandler($responses);
+        $stack = HandlerStack::create($mock);
+        $stack->push(Middleware::history($history));
+
+        $adapter = new ClaudeAdapter('claude-opus-4-6', 'test-key');
+        $ref = new \ReflectionProperty(ClaudeAdapter::class, 'http');
+        $ref->setAccessible(true);
+        $ref->setValue($adapter, new Client(['handler' => $stack]));
+
+        return $adapter;
+    }
+
+    private function claudeResponse(string $text): Response
+    {
+        return new Response(200, [], json_encode([
+            'content' => [['text' => $text]],
+        ]));
+    }
+
+    public function test_query_sends_text_only_message(): void
+    {
+        $history = [];
+        $adapter = $this->makeAdapter([$this->claudeResponse('hello')], $history);
+
+        $result = $adapter->query('Say hello', 128);
+
+        $this->assertSame('hello', $result);
+
+        $body     = json_decode($history[0]['request']->getBody()->getContents(), true);
+        $messages = $body['messages'];
+
+        $this->assertCount(1, $messages);
+        $this->assertSame('user', $messages[0]['role']);
+        $this->assertSame('Say hello', $messages[0]['content']);
+        $this->assertSame(128, $body['max_tokens']);
+    }
+
+    public function test_query_with_image_sends_image_and_text_content_blocks(): void
+    {
+        $history = [];
+        $adapter = $this->makeAdapter([$this->claudeResponse('OTHER')], $history);
+
+        $image  = ['data' => base64_encode('fake-bytes'), 'media_type' => 'image/png'];
+        $result = $adapter->queryWithImage('Classify this', $image, 64);
+
+        $this->assertSame('OTHER', $result);
+
+        $body    = json_decode($history[0]['request']->getBody()->getContents(), true);
+        $content = $body['messages'][0]['content'];
+
+        $this->assertCount(2, $content);
+        $this->assertSame('image', $content[0]['type']);
+        $this->assertSame('base64', $content[0]['source']['type']);
+        $this->assertSame('image/png', $content[0]['source']['media_type']);
+        $this->assertSame('text', $content[1]['type']);
+        $this->assertSame('Classify this', $content[1]['text']);
+    }
+
+    public function test_query_returns_empty_string_when_response_has_no_content(): void
+    {
+        $history = [];
+        $adapter = $this->makeAdapter([new Response(200, [], json_encode([]))], $history);
+
+        $this->assertSame('', $adapter->query('test'));
+    }
+
+    public function test_request_includes_required_anthropic_headers(): void
+    {
+        $history = [];
+        $adapter = $this->makeAdapter([$this->claudeResponse('ok')], $history);
+
+        $adapter->query('test');
+
+        $headers = $history[0]['request']->getHeaders();
+        $this->assertArrayHasKey('x-api-key', $headers);
+        $this->assertArrayHasKey('anthropic-version', $headers);
+    }
+}

--- a/tests/Unit/Ai/GeminiAdapterTest.php
+++ b/tests/Unit/Ai/GeminiAdapterTest.php
@@ -1,0 +1,104 @@
+<?php
+
+namespace Tests\Unit\Ai;
+
+use App\Services\Ai\Adapters\GeminiAdapter;
+use GuzzleHttp\Client;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Middleware;
+use GuzzleHttp\Psr7\Response;
+use Tests\TestCase;
+
+class GeminiAdapterTest extends TestCase
+{
+    private function makeAdapter(array $responses, array &$history = []): GeminiAdapter
+    {
+        $mock  = new MockHandler($responses);
+        $stack = HandlerStack::create($mock);
+        $stack->push(Middleware::history($history));
+
+        $adapter = new GeminiAdapter('gemini-3.1-pro-preview', 'test-key');
+        $ref = new \ReflectionProperty(GeminiAdapter::class, 'http');
+        $ref->setAccessible(true);
+        $ref->setValue($adapter, new Client(['handler' => $stack]));
+
+        return $adapter;
+    }
+
+    private function geminiResponse(string $text): Response
+    {
+        return new Response(200, [], json_encode([
+            'candidates' => [[
+                'content' => ['parts' => [['text' => $text]]],
+            ]],
+        ]));
+    }
+
+    public function test_query_sends_text_only_request(): void
+    {
+        $history = [];
+        $adapter = $this->makeAdapter([$this->geminiResponse('hello')], $history);
+
+        $result = $adapter->query('Say hello', 128);
+
+        $this->assertSame('hello', $result);
+        $this->assertCount(1, $history);
+
+        $body  = json_decode($history[0]['request']->getBody()->getContents(), true);
+        $parts = $body['contents'][0]['parts'];
+
+        $this->assertCount(1, $parts);
+        $this->assertSame('Say hello', $parts[0]['text']);
+        $this->assertSame(128, $body['generationConfig']['maxOutputTokens']);
+    }
+
+    public function test_query_with_image_sends_image_and_text(): void
+    {
+        $history = [];
+        $adapter = $this->makeAdapter([$this->geminiResponse('MARKED_SETLIST')], $history);
+
+        $image  = ['data' => base64_encode('fake-bytes'), 'media_type' => 'image/jpeg'];
+        $result = $adapter->queryWithImage('Classify this', $image, 64);
+
+        $this->assertSame('MARKED_SETLIST', $result);
+
+        $body  = json_decode($history[0]['request']->getBody()->getContents(), true);
+        $parts = $body['contents'][0]['parts'];
+
+        $this->assertCount(2, $parts);
+        $this->assertArrayHasKey('inline_data', $parts[0]);
+        $this->assertSame('image/jpeg', $parts[0]['inline_data']['mime_type']);
+        $this->assertSame('Classify this', $parts[1]['text']);
+    }
+
+    public function test_query_returns_empty_string_when_response_has_no_text(): void
+    {
+        $history = [];
+        $adapter = $this->makeAdapter([new Response(200, [], json_encode([]))], $history);
+
+        $this->assertSame('', $adapter->query('test'));
+    }
+
+    public function test_query_uses_zero_temperature(): void
+    {
+        $history = [];
+        $adapter = $this->makeAdapter([$this->geminiResponse('ok')], $history);
+
+        $adapter->query('test');
+
+        $body = json_decode($history[0]['request']->getBody()->getContents(), true);
+        $this->assertSame(0, $body['generationConfig']['temperature']);
+    }
+
+    public function test_default_max_tokens_is_256(): void
+    {
+        $history = [];
+        $adapter = $this->makeAdapter([$this->geminiResponse('ok')], $history);
+
+        $adapter->query('test');
+
+        $body = json_decode($history[0]['request']->getBody()->getContents(), true);
+        $this->assertSame(256, $body['generationConfig']['maxOutputTokens']);
+    }
+}

--- a/tests/Unit/Services/SetlistAiServiceTest.php
+++ b/tests/Unit/Services/SetlistAiServiceTest.php
@@ -1,0 +1,282 @@
+<?php
+
+namespace Tests\Unit\Services;
+
+use App\Services\Ai\Contracts\AiAdapterInterface;
+use App\Services\SetlistAiService;
+use Illuminate\Support\Facades\Log;
+use Mockery;
+use Tests\TestCase;
+
+class SetlistAiServiceTest extends TestCase
+{
+    private AiAdapterInterface $adapter;
+    private SetlistAiService $service;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->adapter = Mockery::mock(AiAdapterInterface::class);
+        $this->service = new SetlistAiService($this->adapter, 'test-key');
+        Log::spy();
+    }
+
+    protected function tearDown(): void
+    {
+        Mockery::close();
+        parent::tearDown();
+    }
+
+    // ─── classifyImage ───────────────────────────────────────────────────────
+
+    public function test_classify_image_returns_marked_setlist(): void
+    {
+        $image = ['data' => 'abc', 'media_type' => 'image/jpeg'];
+
+        $this->adapter->shouldReceive('queryWithImage')
+            ->once()
+            ->andReturn('MARKED_SETLIST');
+
+        $result = $this->service->testExtractMarkings([$image], []);
+
+        $this->assertStringContainsString('[Classified as: MARKED_SETLIST]', $result);
+    }
+
+    public function test_classify_image_returns_other_for_unrecognised_response(): void
+    {
+        $image = ['data' => 'abc', 'media_type' => 'image/jpeg'];
+
+        $this->adapter->shouldReceive('queryWithImage')
+            ->andReturn('SOMETHING_UNEXPECTED');
+
+        $result = $this->service->testExtractMarkings([$image], []);
+
+        $this->assertStringContainsString('[Classified as: OTHER]', $result);
+    }
+
+    public function test_classify_image_strips_non_alpha_chars_from_response(): void
+    {
+        $image = ['data' => 'abc', 'media_type' => 'image/jpeg'];
+
+        // Model adds trailing punctuation sometimes
+        $this->adapter->shouldReceive('queryWithImage')
+            ->andReturn("TIMELINE.\n");
+
+        $result = $this->service->testExtractMarkings([$image], []);
+
+        $this->assertStringContainsString('[Classified as: TIMELINE]', $result);
+    }
+
+    // ─── PLAIN_SETLIST extraction ────────────────────────────────────────────
+
+    public function test_plain_setlist_extraction_returns_formatted_song_list(): void
+    {
+        $image = ['data' => 'abc', 'media_type' => 'image/jpeg'];
+
+        $this->adapter->shouldReceive('queryWithImage')
+            ->once()
+            ->andReturn('PLAIN_SETLIST')                          // classify
+            ->shouldReceive('queryWithImage')
+            ->once()
+            ->andReturn('["September", "Uptown Funk", "Happy"]'); // extract
+
+        $result = $this->service->testExtractMarkings([$image], []);
+
+        $this->assertStringContainsString('September', $result);
+        $this->assertStringContainsString('Uptown Funk', $result);
+        $this->assertStringContainsString('CLIENT SONG LIST', $result);
+    }
+
+    public function test_plain_setlist_handles_invalid_json_gracefully(): void
+    {
+        $image = ['data' => 'abc', 'media_type' => 'image/jpeg'];
+
+        $this->adapter->shouldReceive('queryWithImage')
+            ->once()->andReturn('PLAIN_SETLIST')
+            ->shouldReceive('queryWithImage')
+            ->once()->andReturn('not valid json at all');
+
+        $result = $this->service->testExtractMarkings([$image], []);
+
+        $this->assertStringContainsString('None', $result);
+    }
+
+    public function test_plain_setlist_strips_markdown_code_fences(): void
+    {
+        $image = ['data' => 'abc', 'media_type' => 'image/jpeg'];
+
+        $this->adapter->shouldReceive('queryWithImage')
+            ->once()->andReturn('PLAIN_SETLIST')
+            ->shouldReceive('queryWithImage')
+            ->once()->andReturn("```json\n[\"September\"]\n```");
+
+        $result = $this->service->testExtractMarkings([$image], []);
+
+        $this->assertStringContainsString('September', $result);
+    }
+
+    // ─── TIMELINE extraction ─────────────────────────────────────────────────
+
+    public function test_timeline_extraction_returns_formatted_schedule(): void
+    {
+        $image = ['data' => 'abc', 'media_type' => 'image/jpeg'];
+
+        $timeline = json_encode([
+            ['time' => '6:00 PM', 'description' => 'Cocktail hour'],
+            ['time' => '7:00 PM', 'description' => 'Grand entrance'],
+        ]);
+
+        $this->adapter->shouldReceive('queryWithImage')
+            ->once()->andReturn('TIMELINE')
+            ->shouldReceive('queryWithImage')
+            ->once()->andReturn($timeline);
+
+        $result = $this->service->testExtractMarkings([$image], []);
+
+        $this->assertStringContainsString('6:00 PM: Cocktail hour', $result);
+        $this->assertStringContainsString('7:00 PM: Grand entrance', $result);
+        $this->assertStringContainsString('EVENT TIMELINE', $result);
+    }
+
+    public function test_timeline_handles_items_without_time(): void
+    {
+        $image = ['data' => 'abc', 'media_type' => 'image/jpeg'];
+
+        $timeline = json_encode([
+            ['time' => null, 'description' => 'Sound check'],
+        ]);
+
+        $this->adapter->shouldReceive('queryWithImage')
+            ->once()->andReturn('TIMELINE')
+            ->shouldReceive('queryWithImage')
+            ->once()->andReturn($timeline);
+
+        $result = $this->service->testExtractMarkings([$image], []);
+
+        $this->assertStringContainsString('Sound check', $result);
+        $this->assertStringNotContainsString('null', $result);
+    }
+
+    public function test_timeline_handles_invalid_json_gracefully(): void
+    {
+        $image = ['data' => 'abc', 'media_type' => 'image/jpeg'];
+
+        $this->adapter->shouldReceive('queryWithImage')
+            ->once()->andReturn('TIMELINE')
+            ->shouldReceive('queryWithImage')
+            ->once()->andReturn('not json');
+
+        $result = $this->service->testExtractMarkings([$image], []);
+
+        $this->assertStringContainsString('None', $result);
+    }
+
+    // ─── MARKED_SETLIST extraction ───────────────────────────────────────────
+
+    public function test_marked_setlist_parses_highlighted_and_excluded_songs(): void
+    {
+        $image = ['data' => 'abc', 'media_type' => 'image/jpeg'];
+        $songs = [
+            ['id' => 1, 'title' => 'September'],
+            ['id' => 2, 'title' => 'Uptown Funk'],
+            ['id' => 3, 'title' => 'Happy'],
+        ];
+
+        $chunkResponse = implode("\n", [
+            '1. September | HIGHLIGHTED',
+            '2. Uptown Funk | EXCLUDED',
+            '3. Happy | UNMARKED',
+        ]);
+
+        $this->adapter->shouldReceive('queryWithImage')
+            ->once()->andReturn('MARKED_SETLIST')
+            ->shouldReceive('queryWithImage')
+            ->once()->andReturn($chunkResponse);
+
+        $result = $this->service->testExtractMarkings([$image], $songs);
+
+        $this->assertStringContainsString('September', $result);
+        $this->assertStringContainsString('REQUESTED SONGS', $result);
+        $this->assertStringContainsString('Uptown Funk', $result);
+        $this->assertStringContainsString('EXCLUDED SONGS', $result);
+        $this->assertStringNotContainsString('Happy', $result);
+    }
+
+    public function test_marked_setlist_reports_none_when_no_songs_marked(): void
+    {
+        $image = ['data' => 'abc', 'media_type' => 'image/jpeg'];
+        $songs = [['id' => 1, 'title' => 'September']];
+
+        $this->adapter->shouldReceive('queryWithImage')
+            ->once()->andReturn('MARKED_SETLIST')
+            ->shouldReceive('queryWithImage')
+            ->once()->andReturn('1. September | UNMARKED');
+
+        $result = $this->service->testExtractMarkings([$image], $songs);
+
+        $this->assertStringContainsString('REQUESTED SONGS (highlighted/starred by client):', $result);
+        $this->assertStringContainsString('None', $result);
+    }
+
+    public function test_marked_setlist_chunks_large_song_libraries(): void
+    {
+        $image = ['data' => 'abc', 'media_type' => 'image/jpeg'];
+        // 26 songs triggers two chunks at chunkSize=25
+        $songs = array_map(
+            fn ($i) => ['id' => $i, 'title' => "Song {$i}"],
+            range(1, 26)
+        );
+
+        $chunk1 = implode("\n", array_map(fn ($i) => "{$i}. Song {$i} | UNMARKED", range(1, 25)));
+        $chunk2 = "26. Song 26 | HIGHLIGHTED";
+
+        $this->adapter->shouldReceive('queryWithImage')
+            ->once()->andReturn('MARKED_SETLIST') // classify
+            ->shouldReceive('queryWithImage')
+            ->once()->andReturn($chunk1)           // chunk 0
+            ->shouldReceive('queryWithImage')
+            ->once()->andReturn($chunk2);           // chunk 1
+
+        $result = $this->service->testExtractMarkings([$image], $songs);
+
+        $this->assertStringContainsString('Song 26', $result);
+        $this->assertStringContainsString('REQUESTED SONGS', $result);
+    }
+
+    // ─── OTHER ───────────────────────────────────────────────────────────────
+
+    public function test_other_image_type_skips_extraction(): void
+    {
+        $image = ['data' => 'abc', 'media_type' => 'image/jpeg'];
+
+        $this->adapter->shouldReceive('queryWithImage')
+            ->once()->andReturn('OTHER');
+
+        $result = $this->service->testExtractMarkings([$image], []);
+
+        $this->assertStringContainsString('No structured extraction', $result);
+    }
+
+    // ─── multiple images ─────────────────────────────────────────────────────
+
+    public function test_multiple_images_are_each_classified_and_extracted(): void
+    {
+        $image1 = ['data' => 'aaa', 'media_type' => 'image/jpeg'];
+        $image2 = ['data' => 'bbb', 'media_type' => 'image/jpeg'];
+
+        $this->adapter->shouldReceive('queryWithImage')
+            ->once()->andReturn('OTHER')           // classify image1
+            ->shouldReceive('queryWithImage')
+            ->once()->andReturn('TIMELINE')         // classify image2
+            ->shouldReceive('queryWithImage')
+            ->once()->andReturn(json_encode([       // extract timeline
+                ['time' => '8:00 PM', 'description' => 'First dance'],
+            ]));
+
+        $result = $this->service->testExtractMarkings([$image1, $image2], []);
+
+        $this->assertStringContainsString('[Classified as: OTHER]', $result);
+        $this->assertStringContainsString('[Classified as: TIMELINE]', $result);
+        $this->assertStringContainsString('First dance', $result);
+    }
+}


### PR DESCRIPTION
Turns out Claude sucks at OCR. Gemini sucks at everything except interpreting text. That was the biggest problem with the last deployment. 

  - Gemini AI integration for setlist generation — switched to Gemini as the primary AI adapter with Claude as a fallback, leveraging Gemini's vision capabilities for         
  image-based setlist extraction
  - Fuzzy song matching — after AI generates a setlist from an image or prompt, song names are fuzzy-matched against the band's existing song library to auto-link recognized  
  songs                                                                                                                                                                        
  - Autofill key & BPM — added GetSongBpmService that calls an external API to auto-populate key signature and BPM when adding/editing songs; also added rating and energy
  fields to the songs table                                                                                                                                                    
  - Prompt template management — bands can now save and reuse custom AI prompt templates (setlist_prompt_templates table + SetlistPromptTemplateController) to tailor how the
  AI generates setlists                                                                                                                                                        
  - Setlist editor AI panel — expanded the Editor.vue with an AI panel for triggering generation, previewing results, and accepting/rejecting AI-suggested songs