### PR TITLE
feat: mobile API — registration/onboarding + band settings phase 1

### DIFF
--- a/app/Http/Controllers/Api/Mobile/BandSettingsController.php
+++ b/app/Http/Controllers/Api/Mobile/BandSettingsController.php
@@ -27,7 +27,7 @@ class BandSettingsController extends Controller
                 'city'     => $band->city ?? '',
                 'state'    => $band->state ?? '',
                 'zip'      => $band->zip ?? '',
-                'logo_url' => $band->logo_url ?? null,
+                'logo_url' => $band->logo ? asset('storage/' . ltrim($band->logo, '/')) : null,
             ],
         ]);
     }
@@ -50,8 +50,8 @@ class BandSettingsController extends Controller
     {
         $request->validate(['logo' => 'required|image|max:5120']);
         $path = $request->file('logo')->store("bands/{$band->id}/logo", 'public');
-        $band->update(['logo_url' => asset('storage/' . $path)]);
-        return response()->json(['logo_url' => $band->logo_url]);
+        $band->update(['logo' => $path]);
+        return response()->json(['logo_url' => asset('storage/' . $path)]);
     }
 
     public function members(Bands $band): JsonResponse
@@ -60,7 +60,7 @@ class BandSettingsController extends Controller
 
         $ownerIds = $band->owners()->pluck('user_id')->toArray();
 
-        $members = $band->everyone()->get()->map(function ($user) use ($ownerIds, $band) {
+        $members = $band->everyone()->map(function ($user) use ($ownerIds, $band) {
             $isOwner = in_array($user->id, $ownerIds);
             $perms = [];
             foreach ($this->allPermissionNames() as $perm) {

--- a/app/Http/Controllers/Api/Mobile/BandSettingsController.php
+++ b/app/Http/Controllers/Api/Mobile/BandSettingsController.php
@@ -61,7 +61,6 @@ class BandSettingsController extends Controller
         $ownerIds = $band->owners()->pluck('user_id')->toArray();
 
         $members = $band->everyone()->get()->map(function ($user) use ($ownerIds, $band) {
-            setPermissionsTeamId($band->id);
             $isOwner = in_array($user->id, $ownerIds);
             $perms = [];
             foreach ($this->allPermissionNames() as $perm) {
@@ -121,6 +120,7 @@ class BandSettingsController extends Controller
 
     public function revokeInvitation(Bands $band, Invitations $invitation): JsonResponse
     {
+        abort_if($invitation->band_id !== $band->id, 403);
         $invitation->update(['pending' => false]);
         return response()->json(null, 204);
     }

--- a/app/Http/Controllers/Api/Mobile/BandSettingsController.php
+++ b/app/Http/Controllers/Api/Mobile/BandSettingsController.php
@@ -1,0 +1,142 @@
+<?php
+
+namespace App\Http\Controllers\Api\Mobile;
+
+use App\Http\Controllers\Controller;
+use App\Models\Bands;
+use App\Models\Invitations;
+use App\Models\User;
+use App\Services\BandMemberRemovalService;
+use Illuminate\Http\Request;
+use Illuminate\Http\JsonResponse;
+
+class BandSettingsController extends Controller
+{
+    public function __construct(
+        private BandMemberRemovalService $removalService
+    ) {}
+
+    public function show(Bands $band): JsonResponse
+    {
+        return response()->json([
+            'band' => [
+                'id'       => $band->id,
+                'name'     => $band->name,
+                'site_name'=> $band->site_name,
+                'address'  => $band->address ?? '',
+                'city'     => $band->city ?? '',
+                'state'    => $band->state ?? '',
+                'zip'      => $band->zip ?? '',
+                'logo_url' => $band->logo_url ?? null,
+            ],
+        ]);
+    }
+
+    public function update(Request $request, Bands $band): JsonResponse
+    {
+        $data = $request->validate([
+            'name'      => 'required|string|max:255',
+            'site_name' => 'required|string|max:255|unique:bands,site_name,' . $band->id,
+            'address'   => 'nullable|string|max:255',
+            'city'      => 'nullable|string|max:100',
+            'state'     => 'nullable|string|max:100',
+            'zip'       => 'nullable|string|max:20',
+        ]);
+        $band->update($data);
+        return response()->json(['band' => $band->fresh()]);
+    }
+
+    public function uploadLogo(Request $request, Bands $band): JsonResponse
+    {
+        $request->validate(['logo' => 'required|image|max:5120']);
+        $path = $request->file('logo')->store("bands/{$band->id}/logo", 'public');
+        $band->update(['logo_url' => asset('storage/' . $path)]);
+        return response()->json(['logo_url' => $band->logo_url]);
+    }
+
+    public function members(Bands $band): JsonResponse
+    {
+        setPermissionsTeamId($band->id);
+
+        $ownerIds = $band->owners()->pluck('user_id')->toArray();
+
+        $members = $band->everyone()->get()->map(function ($user) use ($ownerIds, $band) {
+            setPermissionsTeamId($band->id);
+            $isOwner = in_array($user->id, $ownerIds);
+            $perms = [];
+            foreach ($this->allPermissionNames() as $perm) {
+                $perms[$perm] = $isOwner || $user->hasPermissionTo($perm);
+            }
+            return [
+                'id'          => $user->id,
+                'name'        => $user->name,
+                'is_owner'    => $isOwner,
+                'permissions' => $perms,
+            ];
+        });
+
+        return response()->json(['members' => $members]);
+    }
+
+    public function removeMember(Bands $band, int $userId): JsonResponse
+    {
+        $user = User::findOrFail($userId);
+        $this->removalService->removeFromBand($band, $user);
+        return response()->json(null, 204);
+    }
+
+    public function setPermission(Request $request, Bands $band, int $userId): JsonResponse
+    {
+        $data = $request->validate([
+            'permission' => 'required|string',
+            'granted'    => 'required|boolean',
+        ]);
+
+        $user = User::findOrFail($userId);
+        setPermissionsTeamId($band->id);
+
+        if ($data['granted']) {
+            $user->givePermissionTo($data['permission']);
+        } else {
+            $user->revokePermissionTo($data['permission']);
+        }
+
+        return response()->json(['ok' => true]);
+    }
+
+    public function invitations(Bands $band): JsonResponse
+    {
+        $invitations = $band->invitations()
+            ->where('pending', true)
+            ->get()
+            ->map(fn($inv) => [
+                'id'          => $inv->id,
+                'email'       => $inv->email,
+                'invite_type' => $inv->invite_type_id === 1 ? 'owner' : 'member',
+                'key'         => $inv->key,
+            ]);
+
+        return response()->json(['invitations' => $invitations]);
+    }
+
+    public function revokeInvitation(Bands $band, Invitations $invitation): JsonResponse
+    {
+        $invitation->update(['pending' => false]);
+        return response()->json(null, 204);
+    }
+
+    private function allPermissionNames(): array
+    {
+        return [
+            'read:events', 'write:events',
+            'read:bookings', 'write:bookings',
+            'read:rehearsals', 'write:rehearsals',
+            'read:charts', 'write:charts',
+            'read:songs', 'write:songs',
+            'read:media', 'write:media',
+            'read:invoices', 'write:invoices',
+            'read:proposals', 'write:proposals',
+            'read:colors', 'write:colors',
+        ];
+    }
+}

--- a/app/Http/Controllers/Api/Mobile/OnboardingController.php
+++ b/app/Http/Controllers/Api/Mobile/OnboardingController.php
@@ -34,7 +34,7 @@ class OnboardingController extends Controller
             'name'                  => 'required|string|max:255',
             'email'                 => 'required|string|email|max:255|unique:users',
             'password'              => 'required|string|min:8|confirmed',
-            'device_name'           => 'required|string',
+            'device_name'           => 'required|string|max:255',
         ]);
 
         $user = User::create([
@@ -131,7 +131,7 @@ class OnboardingController extends Controller
     public function inviteMembers(Request $request, Bands $band): JsonResponse
     {
         $request->validate([
-            'emails'   => 'required|array|min:1',
+            'emails'   => 'required|array|min:1|max:50',
             'emails.*' => 'required|email',
         ]);
 
@@ -146,6 +146,10 @@ class OnboardingController extends Controller
 
         $service = new InvitationServices();
         foreach ($request->emails as $email) {
+            $existingUser = \App\Models\User::where('email', $email)->first();
+            if ($existingUser && ($existingUser->ownsBand($band->id) || $existingUser->bandMember->contains('id', $band->id))) {
+                continue; // Already a member — skip silently
+            }
             $service->inviteUser($email, $band->id, false);
         }
 
@@ -207,19 +211,14 @@ class OnboardingController extends Controller
         }
 
         // Get or create a pending member invitation for this band
-        $invitation = Invitations::where('band_id', $band->id)
-            ->where('invite_type_id', static::MEMBER_INVITE_TYPE)
-            ->where('pending', true)
-            ->whereNull('email') // reusable invite has no email
-            ->first();
-
-        if (!$invitation) {
-            $invitation = Invitations::create([
-                'email'          => null,
+        $invitation = Invitations::firstOrCreate(
+            [
                 'band_id'        => $band->id,
                 'invite_type_id' => static::MEMBER_INVITE_TYPE,
-            ]);
-        }
+                'pending'        => true,
+                'email'          => null,
+            ]
+        );
 
         return response()->json(['key' => $invitation->key]);
     }
@@ -229,6 +228,17 @@ class OnboardingController extends Controller
     public function goSolo(Request $request): JsonResponse
     {
         $user = $request->user();
+
+        // Idempotency: return existing personal band if one already exists
+        $existing = Bands::whereHas('owners', fn ($q) => $q->where('user_id', $user->id))
+            ->where('is_personal', true)
+            ->first();
+
+        if ($existing) {
+            return response()->json([
+                'bands' => $this->tokenService->formatBands($user),
+            ]);
+        }
 
         $name     = "{$user->name}'s Band";
         $siteName = $this->uniqueSiteName(Str::slug($name));

--- a/app/Http/Controllers/Api/Mobile/OnboardingController.php
+++ b/app/Http/Controllers/Api/Mobile/OnboardingController.php
@@ -1,0 +1,270 @@
+<?php
+
+namespace App\Http\Controllers\Api\Mobile;
+
+use App\Http\Controllers\Controller;
+use App\Models\BandMembers;
+use App\Models\BandOwners;
+use App\Models\Bands;
+use App\Models\Invitations;
+use App\Services\InvitationServices;
+use App\Services\Mobile\TokenService;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Str;
+use Illuminate\Validation\ValidationException;
+use App\Models\User;
+use App\Models\EventSubs;
+use App\Services\SubInvitationService;
+
+class OnboardingController extends Controller
+{
+    const OWNER_INVITE_TYPE = 1;
+    const MEMBER_INVITE_TYPE = 2;
+
+    public function __construct(private readonly TokenService $tokenService) {}
+
+    // ── POST /api/mobile/auth/register ────────────────────────────────────────
+
+    public function register(Request $request): JsonResponse
+    {
+        $request->validate([
+            'name'                  => 'required|string|max:255',
+            'email'                 => 'required|string|email|max:255|unique:users',
+            'password'              => 'required|string|min:8|confirmed',
+            'device_name'           => 'required|string',
+        ]);
+
+        $user = User::create([
+            'name'     => $request->name,
+            'email'    => $request->email,
+            'password' => Hash::make($request->password),
+        ]);
+
+        // Apply any pending sub-invitations
+        $subInvitations = EventSubs::where('email', $user->email)
+            ->where('pending', true)
+            ->get();
+
+        if ($subInvitations->isNotEmpty()) {
+            $service = new SubInvitationService();
+            foreach ($subInvitations as $eventSub) {
+                $service->acceptInvitation($eventSub->invitation_key, $user);
+            }
+        }
+
+        // Apply any pending band invitations
+        $invitations = Invitations::where('email', $user->email)
+            ->where('pending', true)
+            ->get();
+
+        foreach ($invitations as $invitation) {
+            if ($invitation->invite_type_id === static::OWNER_INVITE_TYPE) {
+                BandOwners::create([
+                    'user_id' => $user->id,
+                    'band_id' => $invitation->band_id,
+                ]);
+                setPermissionsTeamId($invitation->band_id);
+                $user->assignRole('band-owner');
+                setPermissionsTeamId(null);
+            }
+            if ($invitation->invite_type_id === static::MEMBER_INVITE_TYPE) {
+                BandMembers::create([
+                    'user_id' => $user->id,
+                    'band_id' => $invitation->band_id,
+                ]);
+                $user->assignBandMemberDefaults($invitation->band_id);
+            }
+            $invitation->pending = false;
+            $invitation->save();
+        }
+
+        $abilities = $this->tokenService->buildAbilities($user);
+        $token     = $user->createToken($request->device_name, $abilities)->plainTextToken;
+
+        return response()->json([
+            'token' => $token,
+            'user'  => $this->tokenService->formatUser($user),
+            'bands' => $this->tokenService->formatBands($user),
+        ], 201);
+    }
+
+    // ── POST /api/mobile/bands ────────────────────────────────────────────────
+
+    public function createBand(Request $request): JsonResponse
+    {
+        $request->validate([
+            'name' => 'required|string|max:255',
+        ]);
+
+        $user = $request->user();
+
+        $siteName = $this->uniqueSiteName(Str::slug($request->name));
+
+        $band = Bands::create([
+            'name'      => $request->name,
+            'site_name' => $siteName,
+        ]);
+
+        BandOwners::create([
+            'user_id' => $user->id,
+            'band_id' => $band->id,
+        ]);
+
+        setPermissionsTeamId($band->id);
+        $user->assignRole('band-owner');
+        setPermissionsTeamId(null);
+
+        return response()->json([
+            'band' => [
+                'id'       => $band->id,
+                'name'     => $band->name,
+                'is_owner' => true,
+            ],
+        ], 201);
+    }
+
+    // ── POST /api/mobile/bands/{band}/invite ──────────────────────────────────
+
+    public function inviteMembers(Request $request, Bands $band): JsonResponse
+    {
+        $request->validate([
+            'emails'   => 'required|array|min:1',
+            'emails.*' => 'required|email',
+        ]);
+
+        $user = $request->user();
+
+        if (!$user->ownsBand($band->id)) {
+            return response()->json(['message' => 'Forbidden.'], 403);
+        }
+
+        // Temporarily set auth so InvitationServices can read Auth::user()
+        Auth::setUser($user);
+
+        $service = new InvitationServices();
+        foreach ($request->emails as $email) {
+            $service->inviteUser($email, $band->id, false);
+        }
+
+        return response()->json(['message' => 'Invitations sent.']);
+    }
+
+    // ── POST /api/mobile/bands/join ───────────────────────────────────────────
+
+    public function joinBand(Request $request): JsonResponse
+    {
+        $request->validate([
+            'key' => 'required|string',
+        ]);
+
+        $invitation = Invitations::where('key', $request->key)
+            ->where('pending', true)
+            ->first();
+
+        if (!$invitation) {
+            throw ValidationException::withMessages([
+                'key' => ['Invalid or expired invite code.'],
+            ]);
+        }
+
+        $user = $request->user();
+
+        if ($invitation->invite_type_id === static::OWNER_INVITE_TYPE) {
+            BandOwners::firstOrCreate([
+                'user_id' => $user->id,
+                'band_id' => $invitation->band_id,
+            ]);
+            setPermissionsTeamId($invitation->band_id);
+            $user->assignRole('band-owner');
+            setPermissionsTeamId(null);
+        } else {
+            BandMembers::firstOrCreate([
+                'user_id' => $user->id,
+                'band_id' => $invitation->band_id,
+            ]);
+            $user->assignBandMemberDefaults($invitation->band_id);
+        }
+
+        $invitation->pending = false;
+        $invitation->save();
+
+        return response()->json([
+            'bands' => $this->tokenService->formatBands($user),
+        ]);
+    }
+
+    // ── GET /api/mobile/bands/{band}/invite-qr ────────────────────────────────
+
+    public function inviteQr(Request $request, Bands $band): JsonResponse
+    {
+        $user = $request->user();
+
+        if (!$user->ownsBand($band->id)) {
+            return response()->json(['message' => 'Forbidden.'], 403);
+        }
+
+        // Get or create a pending member invitation for this band
+        $invitation = Invitations::where('band_id', $band->id)
+            ->where('invite_type_id', static::MEMBER_INVITE_TYPE)
+            ->where('pending', true)
+            ->whereNull('email') // reusable invite has no email
+            ->first();
+
+        if (!$invitation) {
+            $invitation = Invitations::create([
+                'email'          => null,
+                'band_id'        => $band->id,
+                'invite_type_id' => static::MEMBER_INVITE_TYPE,
+            ]);
+        }
+
+        return response()->json(['key' => $invitation->key]);
+    }
+
+    // ── POST /api/mobile/bands/solo ───────────────────────────────────────────
+
+    public function goSolo(Request $request): JsonResponse
+    {
+        $user = $request->user();
+
+        $name     = "{$user->name}'s Band";
+        $siteName = $this->uniqueSiteName(Str::slug($name));
+
+        $band = Bands::create([
+            'name'        => $name,
+            'site_name'   => $siteName,
+            'is_personal' => true,
+        ]);
+
+        BandOwners::create([
+            'user_id' => $user->id,
+            'band_id' => $band->id,
+        ]);
+
+        setPermissionsTeamId($band->id);
+        $user->assignRole('band-owner');
+        setPermissionsTeamId(null);
+
+        return response()->json([
+            'bands' => $this->tokenService->formatBands($user),
+        ], 201);
+    }
+
+    // ── Helpers ───────────────────────────────────────────────────────────────
+
+    private function uniqueSiteName(string $base): string
+    {
+        $candidate = $base ?: 'band';
+        $suffix    = 1;
+
+        while (Bands::where('site_name', $candidate)->exists()) {
+            $candidate = "{$base}-{$suffix}";
+            $suffix++;
+        }
+
+        return $candidate;
+    }
+}

--- a/app/Models/Bands.php
+++ b/app/Models/Bands.php
@@ -16,7 +16,7 @@ class Bands extends Model
         return 'id';
     }
 
-    protected $fillable = ['name', 'site_name', 'address', 'city', 'state', 'zip'];
+    protected $fillable = ['name', 'site_name', 'address', 'city', 'state', 'zip', 'is_personal'];
 
     public function owner()
     {

--- a/app/Models/Bands.php
+++ b/app/Models/Bands.php
@@ -18,6 +18,10 @@ class Bands extends Model
 
     protected $fillable = ['name', 'site_name', 'address', 'city', 'state', 'zip', 'is_personal'];
 
+    protected $casts = [
+        'is_personal' => 'boolean',
+    ];
+
     public function owner()
     {
         return $this->hasMany(BandOwners::class, 'band_id')->orderBy('created_at')->limit(1);

--- a/app/Models/Bands.php
+++ b/app/Models/Bands.php
@@ -16,7 +16,7 @@ class Bands extends Model
         return 'id';
     }
 
-    protected $fillable = ['name', 'site_name', 'address', 'city', 'state', 'zip', 'is_personal'];
+    protected $fillable = ['name', 'site_name', 'address', 'city', 'state', 'zip', 'is_personal', 'logo'];
 
     protected $casts = [
         'is_personal' => 'boolean',

--- a/database/migrations/2026_04_18_000001_add_is_personal_to_bands_table.php
+++ b/database/migrations/2026_04_18_000001_add_is_personal_to_bands_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('bands', function (Blueprint $table) {
+            $table->boolean('is_personal')->default(false)->after('zip');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('bands', function (Blueprint $table) {
+            $table->dropColumn('is_personal');
+        });
+    }
+};

--- a/database/migrations/2026_04_18_000002_make_invitations_email_nullable.php
+++ b/database/migrations/2026_04_18_000002_make_invitations_email_nullable.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('invitations', function (Blueprint $table) {
+            $table->string('email')->nullable()->change();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('invitations', function (Blueprint $table) {
+            $table->string('email')->nullable(false)->change();
+        });
+    }
+};

--- a/routes/api.php
+++ b/routes/api.php
@@ -60,6 +60,9 @@ Route::prefix('mobile')->group(function () {
     // Public: login
     Route::post('/auth/token', [MobileAuthController::class, 'token'])->name('mobile.auth.token');
 
+    // Registration
+    Route::post('/auth/register', [App\Http\Controllers\Api\Mobile\OnboardingController::class, 'register'])->name('mobile.auth.register');
+
     // Authenticated
     Route::middleware('auth:sanctum')->group(function () {
         Route::get('/auth/me', [MobileAuthController::class, 'me'])->name('mobile.auth.me');
@@ -83,6 +86,13 @@ Route::prefix('mobile')->group(function () {
         Route::post('/events/{event}/members/{memberId}/sub', [App\Http\Controllers\Api\Mobile\EventsController::class, 'assignSub'])->name('mobile.events.members.sub');
         Route::post('/events/{event}/attachments', [App\Http\Controllers\Api\Mobile\EventsController::class, 'uploadAttachment'])->name('mobile.events.attachments.store');
         Route::delete('/events/{event}/attachments/{attachment}', [App\Http\Controllers\Api\Mobile\EventsController::class, 'deleteAttachment'])->name('mobile.events.attachments.destroy');
+
+        // Band onboarding
+        Route::post('/bands', [App\Http\Controllers\Api\Mobile\OnboardingController::class, 'createBand'])->name('mobile.bands.create');
+        Route::post('/bands/join', [App\Http\Controllers\Api\Mobile\OnboardingController::class, 'joinBand'])->name('mobile.bands.join');
+        Route::post('/bands/solo', [App\Http\Controllers\Api\Mobile\OnboardingController::class, 'goSolo'])->name('mobile.bands.solo');
+        Route::post('/bands/{band}/invite', [App\Http\Controllers\Api\Mobile\OnboardingController::class, 'inviteMembers'])->name('mobile.bands.invite');
+        Route::get('/bands/{band}/invite-qr', [App\Http\Controllers\Api\Mobile\OnboardingController::class, 'inviteQr'])->name('mobile.bands.invite-qr');
 
         // ── Events (read) ──────────────────────────────────────────────
         Route::middleware('mobile.band:read:events')->group(function () {

--- a/routes/api.php
+++ b/routes/api.php
@@ -14,6 +14,7 @@ use App\Http\Controllers\ChartsController;
 use App\Http\Controllers\RehearsalController;
 use App\Http\Controllers\ChunkedUploadController;
 use App\Http\Controllers\Api\Mobile\AuthController as MobileAuthController;
+use App\Http\Controllers\Api\Mobile\BandSettingsController;
 
 /*
 |--------------------------------------------------------------------------
@@ -93,6 +94,18 @@ Route::prefix('mobile')->group(function () {
         Route::post('/bands/solo', [App\Http\Controllers\Api\Mobile\OnboardingController::class, 'goSolo'])->name('mobile.bands.solo');
         Route::post('/bands/{band}/invite', [App\Http\Controllers\Api\Mobile\OnboardingController::class, 'inviteMembers'])->name('mobile.bands.invite');
         Route::get('/bands/{band}/invite-qr', [App\Http\Controllers\Api\Mobile\OnboardingController::class, 'inviteQr'])->name('mobile.bands.invite-qr');
+
+        // ── Band settings (owner-only) ─────────────────────────────────
+        Route::middleware('owner')->group(function () {
+            Route::get('/bands/{band}', [BandSettingsController::class, 'show'])->name('mobile.bands.show');
+            Route::patch('/bands/{band}', [BandSettingsController::class, 'update'])->name('mobile.bands.update');
+            Route::post('/bands/{band}/logo', [BandSettingsController::class, 'uploadLogo'])->name('mobile.bands.logo');
+            Route::get('/bands/{band}/members', [BandSettingsController::class, 'members'])->name('mobile.bands.members');
+            Route::delete('/bands/{band}/members/{userId}', [BandSettingsController::class, 'removeMember'])->name('mobile.bands.members.remove');
+            Route::patch('/bands/{band}/members/{userId}/permissions', [BandSettingsController::class, 'setPermission'])->name('mobile.bands.members.permissions');
+            Route::get('/bands/{band}/invitations', [BandSettingsController::class, 'invitations'])->name('mobile.bands.invitations');
+            Route::delete('/bands/{band}/invitations/{invitation}', [BandSettingsController::class, 'revokeInvitation'])->name('mobile.bands.invitations.revoke');
+        });
 
         // ── Events (read) ──────────────────────────────────────────────
         Route::middleware('mobile.band:read:events')->group(function () {


### PR DESCRIPTION
## Summary

- **Onboarding API**: New endpoints for mobile registration, create band, join band (by invite key), go solo (personal band), invite members, and invite QR — wiring up existing `RegisteredUserController` / `InvitationServices` / `BandMemberRemovalService` logic
- **Band Settings API**: 8 new owner-only endpoints (band detail, update, logo upload, members list with Spatie permissions, remove member, set permission, invitations list, revoke invitation)
- **Bug fixes**: `logo` column (not `logo_url`), `everyone()->get()` crash on members endpoint, scope check on `revokeInvitation`, hardened `OnboardingController` against 500s on back/redirect

## New Endpoints

| Method | Path | Purpose |
|--------|------|---------|
| `POST` | `/api/mobile/auth/register` | Register + return token |
| `POST` | `/api/mobile/bands` | Create band |
| `POST` | `/api/mobile/bands/join` | Join by invite key |
| `POST` | `/api/mobile/bands/solo` | Create personal band |
| `POST` | `/api/mobile/bands/{band}/invite` | Send email invites |
| `GET` | `/api/mobile/bands/{band}/invite-qr` | Invite key for QR |
| `GET` | `/api/mobile/bands/{band}` | Band detail |
| `PATCH` | `/api/mobile/bands/{band}` | Update band info |
| `POST` | `/api/mobile/bands/{band}/logo` | Upload logo |
| `GET` | `/api/mobile/bands/{band}/members` | Members + permissions |
| `DELETE` | `/api/mobile/bands/{band}/members/{user}` | Remove member |
| `PATCH` | `/api/mobile/bands/{band}/members/{user}/permissions` | Set single permission |
| `GET` | `/api/mobile/bands/{band}/invitations` | Pending invitations |
| `DELETE` | `/api/mobile/bands/{band}/invitations/{invitation}` | Revoke invitation |

## Test Plan

- [ ] Register a new account via mobile API, confirm token returned and pending invitations auto-applied
- [ ] Create band, join band by key, go solo — confirm band/owner records created correctly
- [ ] As owner: fetch band detail, update name/site_name, upload logo — confirm `logo` column written and URL returned
- [ ] Fetch members list — confirm permissions map populated via Spatie team scoping
- [ ] Toggle a permission — confirm `hasPermissionTo` reflects change
- [ ] Remove a member — confirm `BandMemberRemovalService` fires
- [ ] Send invite, list invitations, revoke invitation — confirm `pending` flag updated and scope check prevents cross-band revocation

🤖 Generated with [Claude Code](https://claude.com/claude-code)