### PR TITLE
Fix BandOwners model passed to hasPermissionTo() in members API

### DIFF
--- a/app/Http/Controllers/Api/Mobile/BandSettingsController.php
+++ b/app/Http/Controllers/Api/Mobile/BandSettingsController.php
@@ -58,9 +58,11 @@ class BandSettingsController extends Controller
     {
         setPermissionsTeamId($band->id);
 
-        $ownerIds = $band->owners()->pluck('user_id')->toArray();
+        $ownerIds  = $band->owners()->pluck('user_id')->toArray();
+        $memberIds = $band->members()->pluck('user_id')->toArray();
+        $allUserIds = array_unique(array_merge($ownerIds, $memberIds));
 
-        $members = $band->everyone()->map(function ($user) use ($ownerIds, $band) {
+        $members = User::whereIn('id', $allUserIds)->get()->map(function (User $user) use ($ownerIds) {
             $isOwner = in_array($user->id, $ownerIds);
             $perms = [];
             foreach ($this->allPermissionNames() as $perm) {

--- a/app/Http/Controllers/Api/Mobile/BandSettingsController.php
+++ b/app/Http/Controllers/Api/Mobile/BandSettingsController.php
@@ -58,13 +58,12 @@ class BandSettingsController extends Controller
     {
         setPermissionsTeamId($band->id);
 
-        $ownerIds  = $band->owners()->pluck('user_id')->toArray();
-        $memberIds = $band->members()->pluck('user_id')->toArray();
-        $allUserIds = array_unique(array_merge($ownerIds, $memberIds));
+        $ownerIds = $band->owners()->pluck('user_id')->toArray();
 
-        $members = User::whereIn('id', $allUserIds)->get()->map(function (User $user) use ($ownerIds) {
-            $isOwner = in_array($user->id, $ownerIds);
-            $perms = [];
+        $members = $band->everyone()->map(function ($record) use ($ownerIds) {
+            $isOwner = in_array($record->user_id, $ownerIds);
+            $user    = $record->user;
+            $perms   = [];
             foreach ($this->allPermissionNames() as $perm) {
                 $perms[$perm] = $isOwner || $user->hasPermissionTo($perm);
             }


### PR DESCRIPTION
Bands::everyone() returns BandOwners/BandMembers pivot records, not User
models. The members() endpoint was calling hasPermissionTo() on those
pivot records, causing a BadMethodCallException. Now loads User models
directly from the owner and member user IDs before mapping permissions.

https://claude.ai/code/session_01FCAsHCSrz8DJiZZX6pZ2tj