### PR TITLE
Fix band settings access and media folder display for mobile app

### DIFF
--- a/app/Http/Controllers/Api/Mobile/MediaController.php
+++ b/app/Http/Controllers/Api/Mobile/MediaController.php
@@ -36,15 +36,27 @@ class MediaController extends Controller
 
         $paginated = $query->paginate($perPage)->withQueryString();
 
+        $folders = $this->mediaService->getSubfoldersOf($band->id, $filters['folder_path'] ?? null);
+
+        $folderItems = array_map(fn ($f) => [
+            'is_folder'         => true,
+            'filename'          => $f['name'],
+            'path'              => $f['path'],
+            'file_count'        => $f['file_count'],
+            'is_drive_synced'   => $f['is_drive_synced'],
+            'drive_folder_name' => $f['drive_folder_name'],
+        ], $folders);
+
+        $fileItems = $paginated->getCollection()->map(fn ($m) => $this->formatFile($m))->all();
+
         return response()->json([
-            'data' => $paginated->getCollection()->map(fn ($m) => $this->formatFile($m)),
+            'data' => array_merge($folderItems, $fileItems),
             'meta' => [
                 'current_page' => $paginated->currentPage(),
                 'last_page'    => $paginated->lastPage(),
                 'per_page'     => $paginated->perPage(),
                 'total'        => $paginated->total(),
             ],
-            'folders' => $this->mediaService->getSubfoldersOf($band->id, $filters['folder_path'] ?? null),
         ]);
     }
 
@@ -214,6 +226,7 @@ class MediaController extends Controller
     private function formatFile(MediaFile $m, bool $detailed = false): array
     {
         $data = [
+            'is_folder'      => false,
             'id'             => $m->id,
             'filename'       => $m->filename,
             'title'          => $m->title,


### PR DESCRIPTION
## Summary

- **Band settings members API:** `Bands::everyone()` returns `BandOwners`/`BandMembers` pivot records, not `User` models. The `members()` endpoint was calling `hasPermissionTo()` on those pivot records, causing a `BadMethodCallException`. Fixed by using `$record->user_id` for the owner check and `$record->user` to load the actual `User` model. Since owners short-circuit the `||`, `hasPermissionTo()` is never called on them — only on member `User` models that actually have the Spatie trait.

- **Media folders API:** The mobile media index was returning a separate `folders` key with objects using a `name` field, while file objects use `filename`. The mobile app rendered raw folder objects as `{path: ..., name: ..., ...}` strings. Folders are now merged into `data` (prepended before files) with `filename` set to the folder name and `is_folder: true`, giving the app a single unified list with a consistent shape. The web app uses `MediaLibraryController` via Inertia and is unaffected.

## Test plan

- [ ] As a band owner, navigate to band settings → Members tab in the mobile app — verify members and their permissions load correctly
- [ ] Verify owners show all permissions as true without errors
- [ ] Navigate to Media in the mobile app — verify folders display their names correctly (not raw JSON)
- [ ] Tap a folder — verify it navigates into the folder and shows its contents
- [ ] Verify the web media library still works normally (no regression)

https://claude.ai/code/session_01FCAsHCSrz8DJiZZX6pZ2tj

---
_Generated by [Claude Code](https://claude.ai/code/session_01FCAsHCSrz8DJiZZX6pZ2tj)_