### PR TITLE
Fix media folders response format for Flutter app

### DIFF
--- a/app/Http/Controllers/Api/Mobile/MediaController.php
+++ b/app/Http/Controllers/Api/Mobile/MediaController.php
@@ -36,27 +36,17 @@ class MediaController extends Controller
 
         $paginated = $query->paginate($perPage)->withQueryString();
 
-        $folders = $this->mediaService->getSubfoldersOf($band->id, $filters['folder_path'] ?? null);
-
-        $folderItems = array_map(fn ($f) => [
-            'is_folder'         => true,
-            'filename'          => $f['name'],
-            'path'              => $f['path'],
-            'file_count'        => $f['file_count'],
-            'is_drive_synced'   => $f['is_drive_synced'],
-            'drive_folder_name' => $f['drive_folder_name'],
-        ], $folders);
-
-        $fileItems = $paginated->getCollection()->map(fn ($m) => $this->formatFile($m))->all();
+        $subfolders = $this->mediaService->getSubfoldersOf($band->id, $filters['folder_path'] ?? null);
 
         return response()->json([
-            'data' => array_merge($folderItems, $fileItems),
+            'data' => $paginated->getCollection()->map(fn ($m) => $this->formatFile($m)),
             'meta' => [
                 'current_page' => $paginated->currentPage(),
                 'last_page'    => $paginated->lastPage(),
                 'per_page'     => $paginated->perPage(),
                 'total'        => $paginated->total(),
             ],
+            'folders' => array_column($subfolders, 'path'),
         ]);
     }
 
@@ -226,7 +216,6 @@ class MediaController extends Controller
     private function formatFile(MediaFile $m, bool $detailed = false): array
     {
         $data = [
-            'is_folder'      => false,
             'id'             => $m->id,
             'filename'       => $m->filename,
             'title'          => $m->title,


### PR DESCRIPTION
## Summary

Fixes the regression introduced in #340 where the media index endpoint was crashing the Flutter app with `type 'Null' is not a subtype of type 'int' in type cast`.

The previous fix incorrectly merged folder items into `data` with `id: null`. The Flutter `MediaFile` model requires `id` to be a non-null `int`, causing the crash.

The Flutter app actually expects:
- `data` — files only, each with a required non-null `int` id
- `folders` — a top-level array of **path strings** (e.g. `["2028", "Test", "weddings"]`), not objects

`folders` is now returned as `array_column($subfolders, 'path')`.

## Test plan

- [ ] Media screen loads without crashing in the Flutter app
- [ ] Folder names display correctly (not as raw JSON objects)
- [ ] Tapping a folder navigates into it and shows its contents

https://claude.ai/code/session_01FCAsHCSrz8DJiZZX6pZ2tj

---
_Generated by [Claude Code](https://claude.ai/code/session_01FCAsHCSrz8DJiZZX6pZ2tj)_