### PR TITLE
Fix/event subs restore on duplicate

### DIFF
--- a/app/Http/Controllers/EventMemberController.php
+++ b/app/Http/Controllers/EventMemberController.php
@@ -144,6 +144,14 @@ class EventMemberController extends Controller
             }
         }
 
+        // If a slot was specified but band_role_id is still unset, inherit from the slot
+        if ($data['slot_id'] && empty($data['band_role_id'])) {
+            $slot = \App\Models\RosterSlot::find($data['slot_id']);
+            if ($slot?->band_role_id) {
+                $data['band_role_id'] = $slot->band_role_id;
+            }
+        }
+
         if ($existing) {
             $existing->restore();
             $existing->update($data);

--- a/app/Http/Controllers/EventMembersController.php
+++ b/app/Http/Controllers/EventMembersController.php
@@ -116,9 +116,15 @@ class EventMembersController extends Controller
             $bandRoleId = $slot?->band_role_id;
         }
 
-        $eventMember = EventMember::create([
-            'event_id'          => $event->id,
+        // Resolve user_id from email so the member record links to the registered user
+        $userId = null;
+        if (!empty($validated['email'])) {
+            $userId = User::where('email', $validated['email'])->value('id');
+        }
+
+        $data = [
             'band_id'           => $band->id,
+            'user_id'           => $userId,
             'name'              => $validated['name'] ?? null,
             'email'             => $validated['email'] ?? null,
             'phone'             => $validated['phone'] ?? null,
@@ -126,7 +132,23 @@ class EventMembersController extends Controller
             'slot_id'           => $slotId,
             'band_role_id'      => $bandRoleId,
             'attendance_status' => $validated['attendance_status'] ?? 'confirmed',
-        ]);
+        ];
+
+        // Restore a soft-deleted record rather than crash on the unique constraint
+        $existing = EventMember::withTrashed()
+            ->where('event_id', $event->id)
+            ->when($userId, fn($q) => $q->where('user_id', $userId))
+            ->when(!$userId && isset($validated['roster_member_id']), fn($q) => $q->where('roster_member_id', $validated['roster_member_id']))
+            ->whereNotNull('deleted_at')
+            ->first();
+
+        if ($existing) {
+            $existing->restore();
+            $existing->update($data);
+            $eventMember = $existing;
+        } else {
+            $eventMember = EventMember::create(['event_id' => $event->id] + $data);
+        }
 
         return response()->json(['message' => 'Member added', 'member' => $eventMember], 201);
     }

--- a/app/Services/SubInvitationService.php
+++ b/app/Services/SubInvitationService.php
@@ -43,19 +43,26 @@ class SubInvitationService
         // Check if user exists
         $user = User::where('email', $email)->first();
 
-        // Create event_subs record
-        $eventSub = EventSubs::create([
-            'event_id' => $eventId,
-            'band_id' => $bandId,
-            'band_role_id' => $bandRoleId,
-            'user_id' => $user?->id,
-            'email' => $email,
-            'name' => $name,
-            'phone' => $phone,
-            'payout_amount' => $payoutAmount,
-            'notes' => $notes,
-            'pending' => true,
-        ]);
+        // Upsert event_subs record — a prior invitation may already exist for this user/event.
+        // Match on user_id when we have one (covers the unique constraint); fall back to email.
+        $matchKey = $user
+            ? ['event_id' => $eventId, 'user_id' => $user->id]
+            : ['event_id' => $eventId, 'email'   => $email];
+
+        $eventSub = EventSubs::updateOrCreate(
+            $matchKey,
+            [
+                'band_id'       => $bandId,
+                'band_role_id'  => $bandRoleId,
+                'user_id'       => $user?->id,
+                'email'         => $email,
+                'name'          => $name,
+                'phone'         => $phone,
+                'payout_amount' => $payoutAmount,
+                'notes'         => $notes,
+                'pending'       => true,
+            ]
+        );
 
         // If user exists, add them to band_subs if not already there
         if ($user) {

--- a/public/.well-known/apple-app-site-association
+++ b/public/.well-known/apple-app-site-association
@@ -1,0 +1,5 @@
+{
+  "webcredentials": {
+    "apps": ["FBE5WVZKNK.band.tts.mate"]
+  }
+}

--- a/resources/js/Pages/Bookings/Components/EventEditor/RosterSection.vue
+++ b/resources/js/Pages/Bookings/Components/EventEditor/RosterSection.vue
@@ -748,6 +748,7 @@ const addMember = async () => {
   if (!props.modelValue.id || !newMember.value.name) return;
 
   try {
+    const isReusedSub = !!(newMember.value.roster_member_id || newMember.value.user_id);
     const response = await axios.post(`/events/${props.modelValue.id}/members`, {
       roster_member_id: newMember.value.roster_member_id || null,
       user_id: newMember.value.user_id || null,
@@ -757,7 +758,7 @@ const addMember = async () => {
       email: newMember.value.email,
       phone: newMember.value.phone,
       attendance_status: 'confirmed',
-      invite_substitute: newMember.value.invite_substitute,
+      ...(isReusedSub ? {} : { invite_substitute: newMember.value.invite_substitute }),
     });
 
     if (response.data.invited) {

--- a/tests/Feature/EventMemberStoreTest.php
+++ b/tests/Feature/EventMemberStoreTest.php
@@ -120,6 +120,78 @@ class EventMemberStoreTest extends TestCase
     }
 
     /**
+     * When a registered user is added by email without invite_substitute,
+     * the event_member record must be linked to their user_id so their
+     * name resolves correctly rather than falling back to the name field.
+     * Bug: the controller never resolved email → user_id for direct adds.
+     */
+    public function test_adding_registered_user_by_email_links_user_id(): void
+    {
+        $existingUser = User::factory()->create([
+            'name'  => 'Registered Player',
+            'email' => 'registered@example.com',
+        ]);
+
+        $response = $this->actingAs($this->owner)
+            ->postJson("/events/{$this->event->id}/members", [
+                'name'              => 'Registered Player',
+                'email'             => 'registered@example.com',
+                'attendance_status' => 'confirmed',
+                'slot_id'           => $this->slot->id,
+                // invite_substitute intentionally omitted (false by default)
+            ]);
+
+        $response->assertStatus(201);
+
+        $this->assertDatabaseHas('event_members', [
+            'event_id' => $this->event->id,
+            'user_id'  => $existingUser->id,
+            'email'    => 'registered@example.com',
+        ]);
+    }
+
+    /**
+     * Re-adding a registered user who was previously soft-deleted from the event
+     * must restore the record rather than crash with a unique-key violation.
+     * This mirrors the restore logic already in EventMemberController (singular).
+     */
+    public function test_readding_soft_deleted_user_restores_record(): void
+    {
+        $existingUser = User::factory()->create([
+            'name'  => 'Returning Member',
+            'email' => 'returning@example.com',
+        ]);
+
+        // Simulate a previously removed event member (soft-deleted)
+        $member = \App\Models\EventMember::create([
+            'event_id' => $this->event->id,
+            'band_id'  => $this->band->id,
+            'user_id'  => $existingUser->id,
+            'email'    => 'returning@example.com',
+        ]);
+        $member->delete();
+
+        $response = $this->actingAs($this->owner)
+            ->postJson("/events/{$this->event->id}/members", [
+                'name'              => 'Returning Member',
+                'email'             => 'returning@example.com',
+                'attendance_status' => 'confirmed',
+                'slot_id'           => $this->slot->id,
+            ]);
+
+        $response->assertStatus(201);
+
+        // Only one event_member for this user/event (the restored one)
+        $this->assertDatabaseCount('event_members', 1);
+        $this->assertDatabaseHas('event_members', [
+            'event_id'   => $this->event->id,
+            'user_id'    => $existingUser->id,
+            'slot_id'    => $this->slot->id,
+            'deleted_at' => null,
+        ]);
+    }
+
+    /**
      * Sending invite_substitute without an email must be rejected with 422 and
      * must not create an event_subs record or send mail.
      * Bug: a call-list entry with null custom_email sent invite_substitute=true

--- a/tests/Feature/EventMemberSubInvitationTest.php
+++ b/tests/Feature/EventMemberSubInvitationTest.php
@@ -145,6 +145,44 @@ class EventMemberSubInvitationTest extends TestCase
         ]);
     }
 
+    /**
+     * Re-inviting a sub who already has an event_subs record for this event
+     * must not throw a duplicate-key error. It should update the existing record
+     * and re-send the invitation instead of attempting a second INSERT.
+     */
+    public function test_reinviting_existing_sub_updates_record_instead_of_failing(): void
+    {
+        Mail::fake();
+
+        $existingUser = User::factory()->create(['email' => 'returning@example.com']);
+
+        // Pre-existing accepted invitation (e.g. from a previous invite flow)
+        EventSubs::create([
+            'event_id'       => $this->event->id,
+            'band_id'        => $this->band->id,
+            'user_id'        => $existingUser->id,
+            'email'          => 'returning@example.com',
+            'name'           => 'Returning Sub',
+            'pending'        => false,
+            'invitation_key' => \Illuminate\Support\Str::random(36),
+        ]);
+
+        // Re-invite the same user — should not throw a duplicate-key error
+        $response = $this->actingAs($this->owner)
+            ->postJson("/events/{$this->event->id}/members", [
+                'name'              => 'Returning Sub',
+                'email'             => 'returning@example.com',
+                'invite_substitute' => true,
+            ]);
+
+        $response->assertStatus(201);
+
+        // Still only one event_subs record for this event/user
+        $this->assertDatabaseCount('event_subs', 1);
+
+        Mail::assertSent(SubInvitation::class);
+    }
+
     public function test_event_member_invitation_requires_email()
     {
         $response = $this->actingAs($this->owner)


### PR DESCRIPTION
   - **EventMembersController::store** restores soft-deleted `event_member` records rather than crashing on `(event_id, user_id)` unique constraint
   - **Email → user_id resolution** on direct-add path so the record is linked to the registered user (previously left `user_id` null)
   - **Slot role inheritance** — `band_role_id` is pulled from the slot when not explicitly supplied, fixing the "unassigned role" regression for dashboard
   popup adds
   - **SubInvitationService** uses `updateOrCreate` so re-inviting an existing sub updates the pending record instead of throwing a duplicate-key error on
   `event_subs`
   - **RosterSection.vue** skips the `invite_substitute` flag when adding a reused roster member/user so the direct-add path is taken instead of the
   invitation path