### PR TITLE
fix(mobile): stop orphaning Google Calendar entries on booking delete

### DIFF
--- a/app/Http/Controllers/Api/Mobile/BookingsController.php
+++ b/app/Http/Controllers/Api/Mobile/BookingsController.php
@@ -181,7 +181,6 @@ class BookingsController extends Controller
     public function destroy(Request $request, Bands $band, Bookings $booking): JsonResponse
     {
         $booking->contacts()->detach();
-        $booking->events()->delete();
         $booking->delete();
 
         return response()->json(['message' => 'Booking deleted']);

--- a/tests/Feature/Api/Mobile/BookingsTest.php
+++ b/tests/Feature/Api/Mobile/BookingsTest.php
@@ -2,6 +2,8 @@
 
 namespace Tests\Feature\Api\Mobile;
 
+use App\Jobs\ProcessBookingDeleted;
+use App\Jobs\ProcessEventDeleted;
 use App\Models\BandOwners;
 use App\Models\Bands;
 use App\Models\Bookings;
@@ -10,11 +12,13 @@ use App\Models\Events;
 use App\Models\EventTypes;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Bus;
+use Tests\Concerns\AccessesProtectedProperties;
 use Tests\TestCase;
 
 class BookingsTest extends TestCase
 {
-    use RefreshDatabase;
+    use RefreshDatabase, AccessesProtectedProperties;
 
     // -------------------------------------------------------------------------
     // Helpers
@@ -255,5 +259,49 @@ class BookingsTest extends TestCase
             'name'    => 'Personal gig',
             'band_id' => $headerBand->id,
         ]);
+    }
+
+    public function test_destroy_dispatches_event_deletion_for_each_child_event(): void
+    {
+        [
+            'band'    => $band,
+            'booking' => $booking,
+            'token'   => $token,
+        ] = $this->createUserWithBandAndBooking();
+
+        $eventType = EventTypes::factory()->create();
+
+        $event1 = Events::withoutEvents(fn () => Events::factory()->create([
+            'eventable_id'   => $booking->id,
+            'eventable_type' => Bookings::class,
+            'event_type_id'  => $eventType->id,
+            'date'           => $booking->date,
+            'title'          => 'Event 1',
+        ]));
+
+        $event2 = Events::withoutEvents(fn () => Events::factory()->create([
+            'eventable_id'   => $booking->id,
+            'eventable_type' => Bookings::class,
+            'event_type_id'  => $eventType->id,
+            'date'           => $booking->date,
+            'title'          => 'Event 2',
+        ]));
+
+        Bus::fake();
+
+        $response = $this->withToken($token)
+            ->withHeaders(['X-Band-ID' => $band->id])
+            ->deleteJson("/api/mobile/bands/{$band->id}/bookings/{$booking->id}");
+
+        $response->assertOk()->assertJson(['message' => 'Booking deleted']);
+
+        Bus::assertDispatched(ProcessEventDeleted::class, 2);
+        Bus::assertDispatched(ProcessEventDeleted::class, fn ($job) =>
+            $this->getProtectedProperty($job, 'event')->id === $event1->id
+        );
+        Bus::assertDispatched(ProcessEventDeleted::class, fn ($job) =>
+            $this->getProtectedProperty($job, 'event')->id === $event2->id
+        );
+        Bus::assertDispatched(ProcessBookingDeleted::class, 1);
     }
 }


### PR DESCRIPTION
## Summary
- The mobile API booking-delete path mass-deleted child events via the query builder (`$booking->events()->delete()`), bypassing Eloquent model events. `EventObserver::deleted` never fired, `ProcessEventDeleted` never ran, and event-calendar / public-calendar entries became orphans on Google.
- Mirrors the web-controller fix already merged via #357. Removes the redundant mass delete; `BookingObserver::deleting` already iterates child events and calls `\$event->delete()` per event, firing the observer chain correctly.
- Adds `test_destroy_dispatches_event_deletion_for_each_child_event` to `tests/Feature/Api/Mobile/BookingsTest.php`, hitting the real `DELETE /api/mobile/bands/{band}/bookings/{booking}` route end-to-end. Uses `Bus::fake()` because `ProcessEventDeleted` / `ProcessBookingDeleted` run synchronously (they don't `implements ShouldQueue`).

## Test plan
- [x] `php artisan test --filter=test_destroy_dispatches_event_deletion_for_each_child_event` passes (6 assertions)
- [x] `php artisan test tests/Feature/Api/Mobile/BookingsTest.php` — all 10 tests pass (59 assertions)
- [x] `php artisan test --filter=BookingDeletionTest` — web-side regression check, all 4 tests still pass
- [ ] Manual smoke: delete a booking from the mobile app, confirm both the public calendar entry and the event-calendar entry are removed from Google Calendar (in addition to the booking-calendar entry that was already being cleaned up correctly).

🤖 Generated with [Claude Code](https://claude.com/claude-code)