### PR TITLE
feat(api/mobile): aggregated charts endpoint for library merge

### DIFF
--- a/app/Http/Controllers/Api/Mobile/MusicController.php
+++ b/app/Http/Controllers/Api/Mobile/MusicController.php
@@ -13,7 +13,6 @@ use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use App\Services\Mobile\TokenService;
 use Illuminate\Support\Carbon;
-use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Storage;
 
 class MusicController extends Controller
@@ -72,9 +71,9 @@ class MusicController extends Controller
      * plus a nested `band` block ({id, name, logo_url, is_personal}) so the
      * mobile client can render the band avatar without an extra round trip.
      */
-    public function chartsForUser(Request $_request): JsonResponse
+    public function chartsForUser(Request $request): JsonResponse
     {
-        $user = Auth::user();
+        $user = $request->user();
         $bands = $user->allBands();
         $bandIds = $bands->pluck('id')->all();
 

--- a/app/Http/Controllers/Api/Mobile/MusicController.php
+++ b/app/Http/Controllers/Api/Mobile/MusicController.php
@@ -11,7 +11,9 @@ use App\Models\Charts;
 use App\Models\ChartUploads;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
+use App\Services\Mobile\TokenService;
 use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Storage;
 
 class MusicController extends Controller
@@ -60,6 +62,53 @@ class MusicController extends Controller
                 'public'        => (bool) $ch->public,
                 'uploads_count' => $ch->uploads_count ?? 0,
             ])->values(),
+        ]);
+    }
+
+    /**
+     * List all charts across every band the authenticated user belongs to.
+     *
+     * Each chart is shaped via the same fields as the per-band `charts` method
+     * plus a nested `band` block ({id, name, logo_url, is_personal}) so the
+     * mobile client can render the band avatar without an extra round trip.
+     */
+    public function chartsForUser(Request $_request): JsonResponse
+    {
+        $user = Auth::user();
+        $bands = $user->allBands();
+        $bandIds = $bands->pluck('id')->all();
+
+        if (empty($bandIds)) {
+            return response()->json(['charts' => []]);
+        }
+
+        $bandLookup = $bands->keyBy('id');
+
+        $charts = Charts::whereIn('band_id', $bandIds)
+            ->withCount('uploads')
+            ->orderBy('title')
+            ->get();
+
+        return response()->json([
+            'charts' => $charts->map(function ($ch) use ($bandLookup) {
+                $band = $bandLookup[$ch->band_id] ?? null;
+                return [
+                    'id'            => $ch->id,
+                    'band_id'       => $ch->band_id,
+                    'title'         => $ch->title ?? '',
+                    'composer'      => $ch->composer ?? '',
+                    'description'   => $ch->description ?? '',
+                    'price'         => $ch->price ?? 0,
+                    'public'        => (bool) $ch->public,
+                    'uploads_count' => $ch->uploads_count ?? 0,
+                    'band'          => $band ? [
+                        'id'          => $band->id,
+                        'name'        => $band->name,
+                        'is_personal' => (bool) $band->is_personal,
+                        'logo_url'    => TokenService::resolveLogoUrl($band->logo),
+                    ] : null,
+                ];
+            })->values(),
         ]);
     }
 

--- a/routes/api.php
+++ b/routes/api.php
@@ -77,6 +77,9 @@ Route::prefix('mobile')->group(function () {
         // Dashboard
         Route::get('/dashboard', [App\Http\Controllers\Api\Mobile\DashboardController::class, 'index'])->name('mobile.dashboard');
 
+        // Aggregating charts across all of the user's bands (band-agnostic).
+        Route::get('/charts', [App\Http\Controllers\Api\Mobile\MusicController::class, 'chartsForUser'])->name('mobile.charts.for-user');
+
         // Search (band-agnostic — user's bands are derived from the authenticated user)
         Route::get('/search', [App\Http\Controllers\Api\Mobile\SearchController::class, 'search'])->name('mobile.search');
 

--- a/tests/Feature/Api/Mobile/MobileChartsAggregateTest.php
+++ b/tests/Feature/Api/Mobile/MobileChartsAggregateTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Feature\Api\Mobile;
 
+use App\Models\BandMembers;
 use App\Models\BandOwners;
 use App\Models\Bands;
 use App\Models\Charts;
@@ -66,6 +67,21 @@ class MobileChartsAggregateTest extends TestCase
         $titles = collect($response->json('charts'))->pluck('title');
         $this->assertContains('Mine 1', $titles);
         $this->assertNotContains('Theirs 1', $titles);
+    }
+
+    public function test_band_member_also_sees_charts(): void
+    {
+        $user = User::factory()->create();
+        $band = $this->makeBand('Member Band');
+        BandMembers::create(['user_id' => $user->id, 'band_id' => $band->id]);
+        Charts::create(['band_id' => $band->id, 'title' => 'Member Chart']);
+
+        $token = $user->createToken('test')->plainTextToken;
+        $response = $this->withToken($token)->getJson('/api/mobile/charts');
+
+        $response->assertOk();
+        $titles = collect($response->json('charts'))->pluck('title');
+        $this->assertContains('Member Chart', $titles);
     }
 
     public function test_each_chart_includes_band_block(): void

--- a/tests/Feature/Api/Mobile/MobileChartsAggregateTest.php
+++ b/tests/Feature/Api/Mobile/MobileChartsAggregateTest.php
@@ -1,0 +1,122 @@
+<?php
+
+namespace Tests\Feature\Api\Mobile;
+
+use App\Models\BandOwners;
+use App\Models\Bands;
+use App\Models\Charts;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class MobileChartsAggregateTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function makeBand(string $name, bool $isPersonal = false): Bands
+    {
+        return Bands::create([
+            'name'        => $name,
+            'site_name'   => str()->slug($name) . '-' . uniqid(),
+            'is_personal' => $isPersonal,
+        ]);
+    }
+
+    public function test_returns_charts_from_all_user_bands(): void
+    {
+        $user = User::factory()->create();
+
+        $bandA = $this->makeBand('Band A');
+        $bandB = $this->makeBand('Band B');
+        BandOwners::create(['user_id' => $user->id, 'band_id' => $bandA->id]);
+        BandOwners::create(['user_id' => $user->id, 'band_id' => $bandB->id]);
+
+        Charts::create(['band_id' => $bandA->id, 'title' => 'A1']);
+        Charts::create(['band_id' => $bandA->id, 'title' => 'A2']);
+        Charts::create(['band_id' => $bandA->id, 'title' => 'A3']);
+        Charts::create(['band_id' => $bandB->id, 'title' => 'B1']);
+        Charts::create(['band_id' => $bandB->id, 'title' => 'B2']);
+        Charts::create(['band_id' => $bandB->id, 'title' => 'B3']);
+
+        $token = $user->createToken('test')->plainTextToken;
+        $response = $this->withToken($token)->getJson('/api/mobile/charts');
+
+        $response->assertOk();
+        $charts = $response->json('charts');
+        $this->assertCount(6, $charts);
+    }
+
+    public function test_excludes_charts_from_bands_user_is_not_in(): void
+    {
+        $user = User::factory()->create();
+        $other = User::factory()->create();
+
+        $userBand = $this->makeBand('Mine');
+        $otherBand = $this->makeBand('Theirs');
+        BandOwners::create(['user_id' => $user->id, 'band_id' => $userBand->id]);
+        BandOwners::create(['user_id' => $other->id, 'band_id' => $otherBand->id]);
+
+        Charts::create(['band_id' => $userBand->id, 'title' => 'Mine 1']);
+        Charts::create(['band_id' => $otherBand->id, 'title' => 'Theirs 1']);
+
+        $token = $user->createToken('test')->plainTextToken;
+        $response = $this->withToken($token)->getJson('/api/mobile/charts');
+
+        $response->assertOk();
+        $titles = collect($response->json('charts'))->pluck('title');
+        $this->assertContains('Mine 1', $titles);
+        $this->assertNotContains('Theirs 1', $titles);
+    }
+
+    public function test_each_chart_includes_band_block(): void
+    {
+        $user = User::factory()->create();
+        $band = $this->makeBand('My Band');
+        BandOwners::create(['user_id' => $user->id, 'band_id' => $band->id]);
+
+        Charts::create(['band_id' => $band->id, 'title' => 'Stardust']);
+
+        $token = $user->createToken('test')->plainTextToken;
+        $response = $this->withToken($token)->getJson('/api/mobile/charts');
+
+        $response->assertOk();
+        $chart = $response->json('charts.0');
+
+        $this->assertArrayHasKey('band', $chart);
+        $this->assertSame($band->id, $chart['band']['id']);
+        $this->assertSame('My Band', $chart['band']['name']);
+        $this->assertFalse($chart['band']['is_personal']);
+        $this->assertArrayHasKey('logo_url', $chart['band']);
+    }
+
+    public function test_includes_personal_band_charts_with_is_personal_true(): void
+    {
+        $user = User::factory()->create();
+        $personal = $this->makeBand("{$user->name}'s Band", isPersonal: true);
+        BandOwners::create(['user_id' => $user->id, 'band_id' => $personal->id]);
+
+        Charts::create(['band_id' => $personal->id, 'title' => 'Solo Etude']);
+
+        $token = $user->createToken('test')->plainTextToken;
+        $response = $this->withToken($token)->getJson('/api/mobile/charts');
+
+        $response->assertOk();
+        $chart = $response->json('charts.0');
+        $this->assertTrue($chart['band']['is_personal']);
+    }
+
+    public function test_unauthenticated_user_returns_401(): void
+    {
+        $response = $this->getJson('/api/mobile/charts');
+        $response->assertStatus(401);
+    }
+
+    public function test_returns_empty_array_when_user_has_no_bands(): void
+    {
+        $user = User::factory()->create();
+        $token = $user->createToken('test')->plainTextToken;
+        $response = $this->withToken($token)->getJson('/api/mobile/charts');
+        $response->assertOk();
+        $this->assertSame([], $response->json('charts'));
+    }
+}

--- a/tests/Feature/Api/Mobile/MobileChartsAggregateTest.php
+++ b/tests/Feature/Api/Mobile/MobileChartsAggregateTest.php
@@ -4,6 +4,7 @@ namespace Tests\Feature\Api\Mobile;
 
 use App\Models\BandMembers;
 use App\Models\BandOwners;
+use App\Models\BandSubs;
 use App\Models\Bands;
 use App\Models\Charts;
 use App\Models\User;
@@ -82,6 +83,21 @@ class MobileChartsAggregateTest extends TestCase
         $response->assertOk();
         $titles = collect($response->json('charts'))->pluck('title');
         $this->assertContains('Member Chart', $titles);
+    }
+
+    public function test_band_sub_also_sees_charts(): void
+    {
+        $user = User::factory()->create();
+        $band = $this->makeBand('Sub Band');
+        BandSubs::create(['user_id' => $user->id, 'band_id' => $band->id]);
+        Charts::create(['band_id' => $band->id, 'title' => 'Sub Chart']);
+
+        $token = $user->createToken('test')->plainTextToken;
+        $response = $this->withToken($token)->getJson('/api/mobile/charts');
+
+        $response->assertOk();
+        $titles = collect($response->json('charts'))->pluck('title');
+        $this->assertContains('Sub Chart', $titles);
     }
 
     public function test_each_chart_includes_band_block(): void


### PR DESCRIPTION
## Summary

Adds `GET /api/mobile/charts` — a band-agnostic endpoint that returns every chart across all bands the authenticated user belongs to (owners + members + subs), with a nested `band` block per chart so the mobile client can render avatars and apply filters without an extra round trip.

This is the backend half of the Library aggregation feature. The Flutter half is in TTS-App `feature/library-aggregation`.

- New method `MusicController::chartsForUser` scopes via `Auth::user()->allBands()`.
- Route added at `/api/mobile/charts`, alongside `/api/mobile/dashboard` (auth:sanctum, no per-band middleware).
- Existing per-band routes untouched — creation, deletion, uploads still use `/api/mobile/bands/{band}/charts/...`.
- Response per chart: existing chart fields + `band: {id, name, is_personal, logo_url}`.

## Test Plan

- [x] `php artisan test --filter MobileChartsAggregateTest` — 8 tests, 20 assertions
- [x] Full mobile suite — 75 tests, 303 assertions, all green
- [ ] Manual smoke from the Flutter app once the matching client PR is in

🤖 Generated with [Claude Code](https://claude.com/claude-code)