### PR TITLE
feat(contracts): multi-event WYSIWYG parity + Blade + Dusk coverage

### DIFF
--- a/resources/js/Pages/Bookings/Components/EditableContractWYSIWYG.vue
+++ b/resources/js/Pages/Bookings/Components/EditableContractWYSIWYG.vue
@@ -57,10 +57,32 @@
           Details of engagement:
         </h2>
         <ul class="list-disc pl-5">
-          <li><span class="font-bold">Date:</span> {{ formattedDate }}</li>
-          <li><span class="font-bold">Performance Length:</span> {{ booking.total_duration }} hours</li>
-          <li><span class="font-bold">Sound Check Time:</span> at least 1 hour before performance</li>
-          <li><span class="font-bold">Venue:</span> {{ booking.venue_summary }}</li>
+          <template v-if="booking.is_multi_event">
+            <li>
+              <span class="font-bold">Performances:</span>
+              <ul class="list-disc pl-5">
+                <li
+                  v-for="event in sortedEvents"
+                  :key="event.id"
+                >
+                  {{ formatEventDate(event.date) }} —
+                  {{ event.title }}
+                  <span v-if="event.venue_name"> at {{ event.venue_name }}</span>
+                  <span v-if="event.start_time && event.end_time">
+                    ({{ formatEventTime(event.start_time) }} – {{ formatEventTime(event.end_time) }})
+                  </span>
+                </li>
+              </ul>
+            </li>
+            <li><span class="font-bold">Total Performance Length:</span> {{ booking.total_duration }} hours</li>
+            <li><span class="font-bold">Sound Check Time:</span> at least 1 hour before each performance</li>
+          </template>
+          <template v-else>
+            <li><span class="font-bold">Date:</span> {{ formattedDate || 'TBD' }}</li>
+            <li><span class="font-bold">Performance Length:</span> {{ booking.total_duration }} hours</li>
+            <li><span class="font-bold">Sound Check Time:</span> at least 1 hour before performance</li>
+            <li><span class="font-bold">Venue:</span> {{ booking.venue_summary || 'TBD' }}</li>
+          </template>
           <li>
             <span class="font-bold">Point(s) of Contact:</span>
             <ul class="list-disc pl-5">
@@ -99,9 +121,9 @@
             payment shall be made to {{ band.name }} and must be received at least ten (10) days prior to Performance. If Buyer elects to pay via Invoice, Venmo, or credit card,
             payment shall be made to {{ band.name }} ten (10) days prior to the Performance. (Additional fees may apply to credit card payments.)</strong> In the event that Buyer requests
           that Artist perform past the end time set forth in this Agreement, and Artist chooses to continue performing, Buyer shall pay Artist <span
-            :title="`(price/duration) x 1.5 = (${booking.price} / ${booking.total_duration}) * 1.5 = $${((booking.price / booking.total_duration)*1.5).toFixed(2)}`"
+            :title="overtimeTitle"
             class="font-bold cursor-help"
-          >${{ ((booking.price / booking.total_duration)*1.5).toFixed(2) }}</span> directly for each additional sixty minutes
+          >${{ overtimeRate }}</span> directly for each additional sixty minutes
           of the Performance, limited to one additional hour, payable immediately following the Performance.
         </p>
       </div>
@@ -244,7 +266,64 @@ import { DateTime } from 'luxon';
   const editMode = ref(false);
 
   const formattedDate = computed(() => {
-    return DateTime.fromISO(props.booking.start_date).toFormat('MM/dd/yyyy');
+    if (!props.booking.start_date) return null;
+    const dt = DateTime.fromISO(props.booking.start_date);
+    if (!dt.isValid) return null;
+    return dt.toFormat('MM/dd/yyyy');
+  });
+
+  // Sorted events for the multi-event "Performances:" list. Mirrors the
+  // Blade template's $booking->events->sortBy(['date', 'id']) ordering.
+  const sortedEvents = computed(() => {
+    const events = props.booking.events ?? [];
+    return [...events].sort((a, b) => {
+      const dateA = a.date ?? '';
+      const dateB = b.date ?? '';
+      if (dateA !== dateB) return dateA.localeCompare(dateB);
+      return (a.id ?? 0) - (b.id ?? 0);
+    });
+  });
+
+  // Matches the Blade's Carbon format('D n/j/Y') — e.g. "Wed 6/12/2026".
+  const formatEventDate = (dateStr) => {
+    if (!dateStr) return '';
+    const dt = DateTime.fromISO(dateStr);
+    if (!dt.isValid) return '';
+    return dt.toFormat('ccc M/d/yyyy');
+  };
+
+  // Matches the Blade's Carbon format('g:i A') — e.g. "7:30 PM".
+  // Accepts "HH:mm" or "HH:mm:ss" strings.
+  const formatEventTime = (timeStr) => {
+    if (!timeStr) return '';
+    const parts = timeStr.split(':');
+    if (parts.length < 2) return timeStr;
+    const dt = DateTime.fromObject({
+      hour: parseInt(parts[0], 10),
+      minute: parseInt(parts[1], 10),
+    });
+    if (!dt.isValid) return timeStr;
+    return dt.toFormat('h:mm a');
+  };
+
+  // Mirrors the PDF Blade's overtime formula:
+  //   (price / total_duration) * 1.5 / event_count
+  // Single-event bookings (event_count == 1) collapse to today's value
+  // identically; multi-event bookings divide the per-hour overtime evenly
+  // across each performance so the contract states one rate, once.
+  const overtimeRate = computed(() => {
+    const price = parseFloat(props.booking.price) || 0;
+    const duration = parseFloat(props.booking.total_duration) || 0;
+    const eventCount = props.booking.event_count ?? 0;
+    if (duration <= 0 || eventCount <= 0) return '0.00';
+    return ((price / duration) * 1.5 / eventCount).toFixed(2);
+  });
+
+  const overtimeTitle = computed(() => {
+    const price = parseFloat(props.booking.price) || 0;
+    const duration = parseFloat(props.booking.total_duration) || 0;
+    const eventCount = props.booking.event_count ?? 0;
+    return `(price/duration) x 1.5 / events = (${price} / ${duration}) * 1.5 / ${eventCount} = $${overtimeRate.value}`;
   });
 
   onMounted(() => {

--- a/tests/Browser/ContractWysiwygTest.php
+++ b/tests/Browser/ContractWysiwygTest.php
@@ -1,0 +1,224 @@
+<?php
+
+namespace Tests\Browser;
+
+use App\Models\Bands;
+use App\Models\Bookings;
+use App\Models\Contacts;
+use App\Models\Contracts;
+use App\Models\Events;
+use App\Models\User;
+use Illuminate\Foundation\Testing\DatabaseMigrations;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\Hash;
+use Laravel\Dusk\Browser;
+use Spatie\Permission\Models\Role;
+use Spatie\Permission\PermissionRegistrar;
+use Tests\DuskTestCase;
+
+class ContractWysiwygTest extends DuskTestCase
+{
+    use DatabaseMigrations;
+
+    private User $owner;
+    private Bands $band;
+
+    /**
+     * Skip the parent's teardown migrate:rollback, which fails on this
+     * codebase's irreversible drop_proposal_tables migration. The next
+     * test's migrate:fresh resets state cleanly.
+     */
+    protected function tearDown(): void
+    {
+        // Intentionally empty.
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Artisan::call('db:seed', ['--class' => 'EventTypeSeeder', '--force' => true]);
+        Artisan::call('db:seed', ['--class' => 'StatesTableSeeder', '--force' => true]);
+
+        $this->band = Bands::factory()->create([
+            'name' => 'Contract WYSIWYG Band',
+            'address' => '1 Main St',
+            'city' => 'Testville',
+            'state' => 'LA',
+            'zip' => '70001',
+        ]);
+
+        $this->owner = User::factory()->create([
+            'name' => 'Wendy Owner',
+            'email' => 'contract-wysiwyg-owner@test.local',
+            'password' => Hash::make('password'),
+        ]);
+        $this->band->owners()->create(['user_id' => $this->owner->id]);
+
+        app()[PermissionRegistrar::class]->forgetCachedPermissions();
+        $ownerRole = Role::where('name', 'band-owner')->where('guard_name', 'web')->first();
+        if ($ownerRole) {
+            setPermissionsTeamId($this->band->id);
+            $this->owner->assignRole($ownerRole);
+            setPermissionsTeamId(0);
+        }
+    }
+
+    private function makeBookingWithEvents(array $bookingAttrs, array $eventsAttrs): Bookings
+    {
+        // The WYSIWYG renders only when contract_option = 'default' AND
+        // status is neither 'confirmed' nor 'pending'. Default to draft so
+        // the editor is rendered for every test.
+        $booking = Bookings::factory()->create(array_merge([
+            'band_id' => $this->band->id,
+            'author_id' => $this->owner->id,
+            'name' => 'Contract WYSIWYG Booking',
+            'price' => 5000,
+            'status' => 'draft',
+            'contract_option' => 'default',
+            'event_type_id' => 2,
+        ], $bookingAttrs));
+
+        Contracts::factory()->create([
+            'contractable_type' => Bookings::class,
+            'contractable_id' => $booking->id,
+            'author_id' => $this->owner->id,
+            'status' => 'pending',
+            'custom_terms' => [],
+        ]);
+
+        $primaryContact = Contacts::factory()->create([
+            'band_id' => $this->band->id,
+            'name' => 'Connie Buyer',
+            'email' => 'connie-buyer@test.local',
+        ]);
+        $booking->contacts()->attach($primaryContact, ['is_primary' => true]);
+
+        foreach ($eventsAttrs as $eventAttrs) {
+            Events::factory()->create(array_merge([
+                'eventable_type' => Bookings::class,
+                'eventable_id' => $booking->id,
+            ], $eventAttrs));
+        }
+
+        return $booking;
+    }
+
+    public function test_single_event_wysiwyg_renders_today_wording(): void
+    {
+        $booking = $this->makeBookingWithEvents(
+            ['name' => 'Anniversary Gig'],
+            [[
+                'title' => 'Anniversary Performance',
+                'date' => '2026-06-13',
+                'start_time' => '19:00',
+                'end_time' => '22:00',
+                'venue_name' => 'Symphony Hall',
+            ]]
+        );
+
+        $this->browse(function (Browser $browser) use ($booking) {
+            $browser->loginAs($this->owner)
+                ->visit("/bands/{$this->band->id}/booking/{$booking->id}/contract")
+                ->waitForText('Details of engagement', 10)
+                // Single-event branch: Date / Performance Length / Venue.
+                ->assertSee('Date:')
+                ->assertSee('06/13/2026')
+                ->assertSee('Performance Length:')
+                ->assertSee('3 hours')
+                ->assertSee('Venue:')
+                ->assertSee('Symphony Hall')
+                // The multi-event header must NOT appear on a single-event booking.
+                ->assertDontSee('Performances:')
+                ->assertDontSee('Total Performance Length')
+                // Sound-check copy is singular for single-event.
+                ->assertSee('at least 1 hour before performance');
+
+            // Overtime: (5000 / 3) * 1.5 / 1 = 2500.00. Look for the dollar
+            // amount in the rendered overtime span.
+            $browser->assertSee('2500.00');
+        });
+        $this->assertTrue(true, 'browser assertions completed');
+    }
+
+    public function test_multi_event_wysiwyg_renders_performances_list(): void
+    {
+        $booking = $this->makeBookingWithEvents(
+            ['name' => 'Three Show Run'],
+            [
+                [
+                    'title' => 'Rehearsal',
+                    'date' => '2026-06-12',
+                    'start_time' => '19:00',
+                    'end_time' => '21:00',
+                    'venue_name' => 'Symphony Hall',
+                ],
+                [
+                    'title' => 'Saturday performance',
+                    'date' => '2026-06-13',
+                    'start_time' => '19:00',
+                    'end_time' => '21:00',
+                    'venue_name' => 'Symphony Hall',
+                ],
+                [
+                    'title' => 'Sunday performance',
+                    'date' => '2026-06-14',
+                    'start_time' => '19:00',
+                    'end_time' => '21:00',
+                    'venue_name' => 'Symphony Hall',
+                ],
+            ]
+        );
+
+        $this->browse(function (Browser $browser) use ($booking) {
+            $browser->loginAs($this->owner)
+                ->visit("/bands/{$this->band->id}/booking/{$booking->id}/contract")
+                ->waitForText('Details of engagement', 10)
+                // Multi-event branch.
+                ->assertSee('Performances:')
+                ->assertSee('Total Performance Length:')
+                ->assertSee('6 hours')
+                ->assertSee('Rehearsal')
+                ->assertSee('Saturday performance')
+                ->assertSee('Sunday performance')
+                // Sound-check copy is plural for multi-event.
+                ->assertSee('at least 1 hour before each performance')
+                // Single-event labels MUST NOT appear at the top level.
+                // (The chip in the engagement summary uses "Date" only in
+                // single-event mode; with the engagement summary not visible
+                // on this page, the only "Date:" occurrence would be the
+                // single-event details block.)
+                ->assertDontSee('Date:</span> 06/');
+
+            // Overtime: 5000 / 6 * 1.5 / 3 = 416.666... → toFixed(2) = 416.67
+            $browser->assertSee('416.67');
+        });
+        $this->assertTrue(true, 'browser assertions completed');
+    }
+
+    public function test_single_event_wysiwyg_falls_back_to_tbd_for_missing_venue(): void
+    {
+        // A draft booking whose single event has no venue at all should
+        // render "Venue: TBD" — confirms the new || 'TBD' fallback.
+        $booking = $this->makeBookingWithEvents(
+            ['name' => 'No Venue Yet'],
+            [[
+                'title' => 'Placeholder event',
+                'date' => '2026-08-01',
+                'start_time' => '19:00',
+                'end_time' => '22:00',
+                'venue_name' => null,
+                'venue_address' => null,
+            ]]
+        );
+
+        $this->browse(function (Browser $browser) use ($booking) {
+            $browser->loginAs($this->owner)
+                ->visit("/bands/{$this->band->id}/booking/{$booking->id}/contract")
+                ->waitForText('Details of engagement', 10)
+                ->assertSee('Venue:')
+                ->assertSee('TBD');
+        });
+        $this->assertTrue(true, 'browser assertions completed');
+    }
+}

--- a/tests/Feature/Pdf/BookingContractRenderTest.php
+++ b/tests/Feature/Pdf/BookingContractRenderTest.php
@@ -1,0 +1,152 @@
+<?php
+
+namespace Tests\Feature\Pdf;
+
+use App\Models\Bands;
+use App\Models\Bookings;
+use App\Models\Contacts;
+use App\Models\Contracts;
+use App\Models\Events;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class BookingContractRenderTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /**
+     * Render the bookingContract.blade.php view with the given booking
+     * and a fresh signer, returning the resulting HTML string. The
+     * Blade requires a logoDataUri prop, so we stub it with a 1x1 PNG.
+     */
+    private function renderContract(Bookings $booking, Contacts $signer): string
+    {
+        return view('pdf.bookingContract', [
+            'booking' => $booking->fresh(['band', 'events', 'contacts', 'contract']),
+            'logoDataUri' => 'data:image/png;base64,iVBORw0KGgo=',
+            'signer' => $signer,
+        ])->render();
+    }
+
+    private function makeBookingWithContract(array $bookingAttrs = []): Bookings
+    {
+        $band = Bands::factory()->create([
+            'name' => 'Test Band',
+            'address' => '1 Test Way',
+            'city' => 'Testville',
+            'state' => 'LA',
+            'zip' => '70001',
+        ]);
+
+        $user = User::factory()->create();
+
+        $booking = Bookings::factory()->create(array_merge([
+            'band_id' => $band->id,
+            'author_id' => $user->id,
+            'name' => 'Contract Render Test',
+            'price' => 5000,
+            'status' => 'pending',
+            'contract_option' => 'default',
+            'event_type_id' => 2, // anything other than 1 to skip the wedding "SPECIAL INSTRUCTIONS" branch
+        ], $bookingAttrs));
+
+        // Bookings::factory does not create a contract automatically — the Blade's
+        // `$booking->contract->custom_terms` access requires one.
+        if (!$booking->contract) {
+            Contracts::factory()->create([
+                'contractable_type' => Bookings::class,
+                'contractable_id' => $booking->id,
+                'author_id' => $user->id,
+                'status' => 'pending',
+                'custom_terms' => [],
+            ]);
+            $booking->refresh();
+        }
+
+        return $booking;
+    }
+
+    private function makeSigner(Bands $band, Bookings $booking): Contacts
+    {
+        $contact = Contacts::factory()->create([
+            'band_id' => $band->id,
+            'name' => 'Jane Buyer',
+            'email' => 'jane@example.test',
+        ]);
+        $booking->contacts()->attach($contact, ['is_primary' => true]);
+        return $contact;
+    }
+
+    public function test_single_event_contract_renders_today_wording(): void
+    {
+        $booking = $this->makeBookingWithContract();
+        $signer = $this->makeSigner($booking->band, $booking);
+
+        Events::factory()->create([
+            'eventable_type' => Bookings::class,
+            'eventable_id' => $booking->id,
+            'title' => 'Anniversary Performance',
+            'date' => '2026-06-13',
+            'start_time' => '19:00',
+            'end_time' => '22:00', // 3 hours
+            'venue_name' => 'Symphony Hall',
+        ]);
+
+        $html = $this->renderContract($booking, $signer);
+
+        $this->assertStringContainsString('Date:</span> 06/13/2026', $html);
+        $this->assertStringContainsString('Performance Length:</span> 3 hours', $html);
+        $this->assertStringContainsString('Venue:</span> Symphony Hall', $html);
+
+        // Overtime rate for single-event: (5000 / 3) * 1.5 / 1 = 2500.00
+        $this->assertStringContainsString('2,500.00', $html);
+
+        // Multi-event markers must NOT appear.
+        $this->assertStringNotContainsString('Performances:', $html);
+        $this->assertStringNotContainsString('Total Performance Length:', $html);
+    }
+
+    public function test_multi_event_contract_renders_performances_list_and_total_duration(): void
+    {
+        $booking = $this->makeBookingWithContract();
+        $signer = $this->makeSigner($booking->band, $booking);
+
+        $eventDates = [
+            ['date' => '2026-06-12', 'title' => 'Rehearsal'],
+            ['date' => '2026-06-13', 'title' => 'Saturday performance'],
+            ['date' => '2026-06-14', 'title' => 'Sunday performance'],
+        ];
+        foreach ($eventDates as $row) {
+            Events::factory()->create([
+                'eventable_type' => Bookings::class,
+                'eventable_id' => $booking->id,
+                'title' => $row['title'],
+                'date' => $row['date'],
+                'start_time' => '19:00',
+                'end_time' => '21:00', // 2 hours each → 6 total
+                'venue_name' => 'Symphony Hall',
+            ]);
+        }
+
+        $html = $this->renderContract($booking, $signer);
+
+        $this->assertStringContainsString('Performances:', $html);
+        $this->assertStringContainsString('Total Performance Length:</span> 6 hours', $html);
+        $this->assertStringContainsString('Rehearsal', $html);
+        $this->assertStringContainsString('Saturday performance', $html);
+        $this->assertStringContainsString('Sunday performance', $html);
+        // Each event row carries the Blade's date format D n/j/Y.
+        $this->assertStringContainsString('6/12/2026', $html);
+        $this->assertStringContainsString('6/13/2026', $html);
+        $this->assertStringContainsString('6/14/2026', $html);
+
+        // Overtime: 5000 / 6 * 1.5 / 3 = 416.67
+        $this->assertStringContainsString('416.67', $html);
+
+        // The single-event "Date:" / "Venue:" labels must NOT appear in
+        // the multi-event branch.
+        $this->assertStringNotContainsString('Date:</span> 06', $html);
+        $this->assertStringNotContainsString('Venue:</span> Symphony Hall', $html);
+    }
+}


### PR DESCRIPTION
## Summary

Chunk 7 of the bookings/events redesign. Brings the in-app WYSIWYG contract editor to parity with the PDF Blade's two-branch rendering (single-event preserves today's wording; multi-event renders a Performances list + Total Performance Length). Locks both rendering paths with PHPUnit Blade tests AND Dusk browser tests.

- **EditableContractWYSIWYG.vue:** new `v-if=\"booking.is_multi_event\"` conditional in the "Details of engagement" block; new `sortedEvents`, `formatEventDate`, `formatEventTime` helpers matching the Blade's Carbon formats; null-safe `formattedDate` and `|| 'TBD'` fallbacks; overtime rate now `(price / total_duration) * 1.5 / event_count` with a zero-guard, extracted to a computed.
- **tests/Feature/Pdf/BookingContractRenderTest.php (new):** renders `pdf.bookingContract` via the Blade view helper for single-event and multi-event fixtures. 17 assertions across two methods.
- **tests/Browser/ContractWysiwygTest.php (new):** Dusk coverage of the in-browser WYSIWYG preview. 24 assertions across three scenarios: single-event today-wording, multi-event Performances list + plural sound-check copy + 416.67 overtime, and the TBD venue fallback.

PandaDocService and the other contract Vue surfaces were audited clean during Chunk 4 — nothing else to touch. The substantive multi-event contract wording (Performances bullet list + Total Performance Length) is now consistent across the Blade PDF, the in-app WYSIWYG, and the regression suite.

## Test plan

- [x] PHPUnit full suite: 964 passed (Chunk 4 baseline 962 + 2 new tests).
- [x] Dusk: 3/3 ContractWysiwygTest scenarios pass.
- [ ] Manual: open contract editor on a real single-event booking → confirm wording unchanged from pre-PR.
- [ ] Manual: open contract editor on a multi-event booking (e.g. booking 668 in local data) → confirm Performances list renders with each event's date/title/venue/time.
- [ ] Manual: generate the PDF for both and verify the WYSIWYG and PDF match line-for-line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)