### PR TITLE
fix(contracts): download contract via window.location, not Inertia ro…

### DIFF
--- a/resources/js/Pages/Bookings/Components/ContractEditor.vue
+++ b/resources/js/Pages/Bookings/Components/ContractEditor.vue
@@ -64,12 +64,10 @@ const generatePDF = async () => {
     if (unsavedChanges.value) {
         await saveContract();
     }
-    router.get(
-        route("Download Booking Contract", {
-            band: props.band.id,
-            booking: props.booking.id,
-        })
-    );
+    window.location.href = route("Download Booking Contract", {
+        band: props.band.id,
+        booking: props.booking.id,
+    });
 };
 
 // Navigation guard


### PR DESCRIPTION
…uter

router.get() sends X-Inertia: true, which causes Inertia's server middleware to inspect the StreamedResponse for empty content (StreamedResponse::getContent() returns false → empty() is true) and redirect back via Redirect::back(). The PDF was generated successfully on the server (~150KB) but never reached the browser; the user landed back on the contract editor page instead.

Switch the download trigger to window.location.href so the request goes out as a plain browser navigation with no X-Inertia header, letting the Inertia middleware bail out early and the StreamedResponse flow through to the browser as a normal PDF download.