### PR TITLE
fix(contracts): contract PDF download regresses to 302 back to editor

### DIFF
--- a/resources/js/Pages/Bookings/Components/ContractEditor.vue
+++ b/resources/js/Pages/Bookings/Components/ContractEditor.vue
@@ -64,12 +64,10 @@ const generatePDF = async () => {
     if (unsavedChanges.value) {
         await saveContract();
     }
-    router.get(
-        route("Download Booking Contract", {
-            band: props.band.id,
-            booking: props.booking.id,
-        })
-    );
+    window.location.href = route("Download Booking Contract", {
+        band: props.band.id,
+        booking: props.booking.id,
+    });
 };
 
 // Navigation guard

--- a/resources/js/tests/components/contracteditor.test.js
+++ b/resources/js/tests/components/contracteditor.test.js
@@ -155,28 +155,40 @@ describe('ContractEditor', () => {
     expect(mockRouter.post).toHaveBeenCalled();
   });
 
-  it('should call router.get when generate-pdf event is emitted', async () => {
-    const wrapper = mount(ContractEditor, {
-      props: {
-        booking: mockBooking,
-        band: mockBand
-      },
-      global: {
-        stubs: {
-          EditableContractWYSIWYG: {
-            name: 'EditableContractWYSIWYG',
-            template: '<div class="wysiwyg"></div>',
-            emits: ['generate-pdf']
-          },
-          SendContractPopup: true
+  it('should navigate to download URL when generate-pdf event is emitted', async () => {
+    // PDF download must be a plain browser navigation (no X-Inertia header),
+    // otherwise Inertia's server middleware sees the StreamedResponse as
+    // empty and 302s back to the editor instead of streaming the PDF.
+    const originalLocation = window.location;
+    delete window.location;
+    window.location = { href: '' };
+
+    try {
+      const wrapper = mount(ContractEditor, {
+        props: {
+          booking: mockBooking,
+          band: mockBand
+        },
+        global: {
+          stubs: {
+            EditableContractWYSIWYG: {
+              name: 'EditableContractWYSIWYG',
+              template: '<div class="wysiwyg"></div>',
+              emits: ['generate-pdf']
+            },
+            SendContractPopup: true
+          }
         }
-      }
-    });
+      });
 
-    const wysiwyg = wrapper.findComponent({ name: 'EditableContractWYSIWYG' });
-    await wysiwyg.vm.$emit('generate-pdf');
+      const wysiwyg = wrapper.findComponent({ name: 'EditableContractWYSIWYG' });
+      await wysiwyg.vm.$emit('generate-pdf');
 
-    expect(mockRouter.get).toHaveBeenCalled();
+      expect(window.location.href).toContain('Download Booking Contract');
+      expect(mockRouter.get).not.toHaveBeenCalled();
+    } finally {
+      window.location = originalLocation;
+    }
   });
 
   it('should handle update:terms event', async () => {


### PR DESCRIPTION
## Summary
- Pre-PandaDoc contract PDF download was returning **302 back to the contract editor** instead of the PDF.
- Root cause: `ContractEditor.vue` triggered the download via `router.get(...)` (Inertia), which sends `X-Inertia: true`. Inertia's server middleware (`vendor/inertiajs/inertia-laravel/src/Middleware.php:98-100`) sees the response as "empty" because `StreamedResponse::getContent()` returns `false` and converts it into a `Redirect::back()`. The PDF generated successfully on the server (~150KB verified locally for booking 604), it just never reached the browser.
- Fix: trigger the download via `window.location.href` so the request goes out as a plain browser navigation (no `X-Inertia` header). Inertia middleware bails out early and the `StreamedResponse` flows through normally.

## Verification
Local repro before/after on booking 604 (draft, valid band address, full event data):

| | Status | Headers |
|---|---|---|
| Before (`router.get` → `X-Inertia: true`) | `302` | `location: https://localhost` |
| After (`window.location.href`, no Inertia header) | `200` | `content-type: application/pdf`, `content-disposition: attachment; filename=...`, 153,429 bytes streamed, body starts with `%PDF` |

Audited every other web-facing streaming endpoint to confirm no other latent occurrences:

| Endpoint | Frontend trigger | Status |
|---|---|---|
| `Download Booking Contract` | this fix | fixed |
| `bookingpaymentpdf` | `window.open(...)` in `Finances.vue` | safe |
| `View Booking Contract` | `<iframe :src=...>` in `Contract.vue` / `ContractExternal.vue` | safe |
| `publicView`, `EventsController@createPDF`/`downloadPDF`, `portal.booking.contract` | not invoked from the SPA | safe |

## Test plan
- [ ] `npm run build` (or `npm run dev`) so the change reaches the browser
- [ ] Open a booking with a valid band address + signed-state-eligible data, click **Download PDF** in the contract editor
- [ ] Browser downloads `<booking-name>_Contract.pdf` (no redirect, no bounce back to editor)
- [ ] Existing PHPUnit `test_contract_download_succeeds_*` tests still pass (they bypass Inertia headers and were not catching this regression class)

## Follow-up worth considering (not in this PR)
The PHPUnit tests don't send `X-Inertia: true`, which is why this regression slipped through. A targeted feature test that asserts the download endpoint returns `200` + `Content-Type: application/pdf` even when the request carries the `X-Inertia` header would prevent recurrence. Happy to add as a separate PR if you want.

🤖 Generated with [Claude Code](https://claude.com/claude-code)