### PR TITLE
fix(bookings): consolidate booking show header, fix off-by-one date

### DIFF
--- a/resources/js/Components/NavSubmenu.vue
+++ b/resources/js/Components/NavSubmenu.vue
@@ -8,23 +8,36 @@
     >
       <template #header>
         <div class="booking-header dark:bg-slate-700 p-4 border-b grid max-w-full">
-          <div class="flex items-center gap-2 flex-wrap py-2">
-            <h1 class="text-3xl font-semibold text-gray-700 truncate">
-              <span class="text-black dark:text-white">{{
-                booking.name
-              }}</span>
-            </h1>
+          <div class="flex justify-between items-start gap-3 flex-wrap">
+            <div class="min-w-0">
+              <div class="flex items-center gap-2 flex-wrap">
+                <h1 class="text-2xl font-bold text-gray-900 dark:text-gray-50 truncate">
+                  {{ booking.name }}
+                </h1>
+                <span
+                  v-if="booking.is_multi_event"
+                  class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-200"
+                >
+                  {{ booking.event_count }} events
+                </span>
+              </div>
+              <div
+                v-if="eventType"
+                class="inline-block bg-blue-100 dark:bg-blue-900 text-blue-800 dark:text-blue-200 px-2 py-1 rounded text-xs font-medium mt-2"
+              >
+                <i class="pi pi-tag mr-1" />
+                {{ eventType.name }}
+              </div>
+            </div>
             <span
-              v-if="booking.is_multi_event"
-              class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-200"
+              data-test="status-pill"
+              :class="statusClass"
+              class="px-3 py-1 rounded-full text-xs font-semibold uppercase tracking-wide whitespace-nowrap"
             >
-              {{ booking.event_count }} events
+              {{ booking.status }}
             </span>
           </div>
-          <EngagementSummary :booking="booking" />
-          <span
-            class="mt-1 text-xs text-gray-500 dark:text-gray-50"
-          >Status: {{ booking.status }}</span>
+          <EngagementSummary :booking="booking" class="mt-2" />
         </div>
       </template>
     </ResponsiveSubNav>
@@ -33,6 +46,7 @@
 
 <script setup>
 import { computed } from "vue";
+import { useStore } from "vuex";
 import ResponsiveSubNav from "@/Components/ResponsiveSubNav.vue";
 import EngagementSummary from "@/Pages/Bookings/Components/EngagementSummary.vue";
 
@@ -45,6 +59,23 @@ const props = defineProps({
         type: Object,
         required: true,
     },
+});
+
+const store = useStore();
+
+const eventType = computed(() => {
+    const types = store.getters["eventTypes/getAllEventTypes"];
+    return types.find((type) => type.id === props.booking.event_type_id);
+});
+
+const statusClass = computed(() => {
+    const statusClasses = {
+        draft: "bg-gray-200 text-gray-800 dark:bg-gray-700 dark:text-gray-200",
+        pending: "bg-yellow-200 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-200",
+        confirmed: "bg-green-200 text-green-800 dark:bg-green-900 dark:text-green-200",
+        cancelled: "bg-red-200 text-red-800 dark:bg-red-900 dark:text-red-200",
+    };
+    return statusClasses[props.booking.status] || statusClasses.draft;
 });
 
 const items = computed(() => {
@@ -62,6 +93,5 @@ const items = computed(() => {
 .booking-layout {
     display: flex;
     flex-direction: column;
-    /* min-height: 100vh; */
 }
 </style>

--- a/resources/js/Pages/Bookings/Components/BookingDetails.vue
+++ b/resources/js/Pages/Bookings/Components/BookingDetails.vue
@@ -1,32 +1,6 @@
 <template>
   <Container class="p-4">
     <div class="space-y-4">
-      <!-- Header Section with Title and Status -->
-      <div class="bg-white dark:bg-slate-800 rounded-lg shadow-md p-4">
-        <div class="flex justify-between items-start mb-3">
-          <div>
-            <h1 class="text-2xl font-bold text-gray-900 dark:text-gray-50">
-              {{ booking.name }}
-            </h1>
-            <div
-              v-if="eventType"
-              class="inline-block bg-blue-100 dark:bg-blue-900 text-blue-800 dark:text-blue-200 px-2 py-1 rounded text-xs font-medium mt-2"
-            >
-              <i class="pi pi-tag mr-1" />
-              {{ eventType.name }}
-            </div>
-          </div>
-          <span
-            :class="statusClass"
-            class="px-3 py-1 rounded-full text-xs font-semibold uppercase tracking-wide"
-          >
-            {{ booking.status }}
-          </span>
-        </div>
-        <!-- Engagement summary: dates, venue, event-type at a glance -->
-        <EngagementSummary :booking="booking" />
-      </div>
-
       <!-- Quick Info Grid -->
       <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
         <!-- Date & Time + Venue -->
@@ -559,12 +533,10 @@ import { router, Link } from '@inertiajs/vue3'
 import Container from '@/Components/Container.vue'
 import Button from 'primevue/button'
 import BookingPayout from './BookingPayout.vue'
-import EngagementSummary from './EngagementSummary.vue'
 import EventList from './EventList.vue'
 import Dialog from 'primevue/dialog'
 import Select from 'primevue/select'
 import SubmissionPreview from '@/Components/Questionnaires/SubmissionPreview.vue'
-import { useStore } from 'vuex'
 import { DateTime } from 'luxon'
 
 const props = defineProps({
@@ -596,23 +568,6 @@ const props = defineProps({
     type: Array,
     default: () => []
   }
-})
-
-const store = useStore()
-
-const eventType = computed(() => {
-  const types = store.getters['eventTypes/getAllEventTypes']
-  return types.find(type => type.id === props.booking.event_type_id)
-})
-
-const statusClass = computed(() => {
-  const statusClasses = {
-    draft: 'bg-gray-200 text-gray-800 dark:bg-gray-700 dark:text-gray-200',
-    pending: 'bg-yellow-200 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-200',
-    confirmed: 'bg-green-200 text-green-800 dark:bg-green-900 dark:text-green-200',
-    cancelled: 'bg-red-200 text-red-800 dark:bg-red-900 dark:text-red-200'
-  }
-  return statusClasses[props.booking.status] || statusClasses.draft
 })
 
 const duration = computed(() => {

--- a/resources/js/Pages/Bookings/Components/EngagementSummary.vue
+++ b/resources/js/Pages/Bookings/Components/EngagementSummary.vue
@@ -12,7 +12,7 @@
 
 <script setup>
 import { computed } from 'vue';
-import { formatDate, formatDateRange } from '@/utils/formatters';
+import { formatDate, formatDateRange, formatWeekday } from '@/utils/formatters';
 
 const props = defineProps({
     booking: {
@@ -30,7 +30,7 @@ const dateRangeLabel = computed(() => {
     const start = props.booking.start_date;
     const end = props.booking.end_date;
     if (!start) return 'No date';
-    if (!end || start === end) return formatDate(start);
+    if (!end || start === end) return `${formatWeekday(start)} ${formatDate(start)}`;
     return formatDateRange(start, end);
 });
 

--- a/resources/js/tests/components/engagementsummary.test.js
+++ b/resources/js/tests/components/engagementsummary.test.js
@@ -1,0 +1,19 @@
+import EngagementSummary from '@/Pages/Bookings/Components/EngagementSummary.vue';
+import { mount } from '@vue/test-utils';
+import { describe, expect, it } from 'vitest';
+
+describe('EngagementSummary', () => {
+  it('prefixes the date with the short weekday', () => {
+    const wrapper = mount(EngagementSummary, {
+      props: {
+        booking: {
+          start_date: '2026-10-15', // Thursday
+          events: [{}],
+        },
+      },
+    });
+    // Bug context: booking date was rendering with no weekday and shifted off
+    // by one in CST. Both must be fixed.
+    expect(wrapper.text()).toContain('Thu 10/15/2026');
+  });
+});

--- a/resources/js/tests/components/navsubmenu.test.js
+++ b/resources/js/tests/components/navsubmenu.test.js
@@ -1,0 +1,73 @@
+import NavSubmenu from '@/Components/NavSubmenu.vue';
+import { mount } from '@vue/test-utils';
+import { describe, expect, it, vi } from 'vitest';
+
+global.route = vi.fn((name, params) => `/mock-route/${name}`);
+
+vi.mock('vuex', () => ({
+  useStore: () => ({
+    getters: {
+      'eventTypes/getAllEventTypes': [
+        { id: 7, name: 'Wedding' },
+      ],
+    },
+  }),
+}));
+
+const stubs = {
+  ResponsiveSubNav: { template: '<div><slot name="header" /></div>' },
+  EngagementSummary: { template: '<div data-test="engagement-summary"></div>' },
+};
+
+const baseBooking = {
+  id: 42,
+  name: 'Wedding Reception',
+  status: 'confirmed',
+  event_type_id: 7,
+  start_date: '2026-10-15',
+  events: [{}],
+};
+
+function mountNav(booking = baseBooking) {
+  return mount(NavSubmenu, {
+    props: {
+      routes: {},
+      booking,
+    },
+    global: {
+      stubs,
+      config: { globalProperties: { route: global.route } },
+    },
+  });
+}
+
+describe('NavSubmenu header', () => {
+  it('renders the booking title', () => {
+    const wrapper = mountNav();
+    expect(wrapper.text()).toContain('Wedding Reception');
+  });
+
+  it('renders the event-type tag', () => {
+    const wrapper = mountNav();
+    expect(wrapper.text()).toContain('Wedding');
+  });
+
+  it('renders a status pill with the booking status', () => {
+    const wrapper = mountNav();
+    const pill = wrapper.find('[data-test="status-pill"]');
+    expect(pill.exists()).toBe(true);
+    expect(pill.text().toLowerCase()).toContain('confirmed');
+  });
+
+  it('renders the engagement summary', () => {
+    const wrapper = mountNav();
+    expect(wrapper.find('[data-test="engagement-summary"]').exists()).toBe(true);
+  });
+
+  it('does not render the old "Status:" label line', () => {
+    const wrapper = mountNav();
+    // The previous header used the literal "Status: confirmed" inline label;
+    // the new design surfaces status as a pill instead.
+    expect(wrapper.text()).not.toMatch(/Status:\s/);
+  });
+});

--- a/resources/js/tests/utils/formatters.test.js
+++ b/resources/js/tests/utils/formatters.test.js
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+import { formatDate, formatDateRange } from '@/utils/formatters';
+
+describe('formatters', () => {
+  describe('formatDate', () => {
+    it('renders an ISO date-only string as the same calendar day in any timezone', () => {
+      // Bug: `new Date('2026-10-15')` parses as UTC midnight, then renders as
+      // 10/14/2026 in any timezone west of UTC. Date-only strings must be
+      // treated as local dates so the calendar day never shifts.
+      expect(formatDate('2026-10-15')).toBe('10/15/2026');
+    });
+
+    it('formats a Date object', () => {
+      const d = new Date(2026, 9, 15); // local-time Oct 15, 2026
+      expect(formatDate(d)).toBe('10/15/2026');
+    });
+  });
+
+  describe('formatDateRange', () => {
+    it('does not shift a single-day range off by one for date-only strings', () => {
+      expect(formatDateRange('2026-10-15', '2026-10-15')).toBe('10/15/2026');
+    });
+  });
+});

--- a/resources/js/utils/formatters.js
+++ b/resources/js/utils/formatters.js
@@ -7,14 +7,30 @@
  * @param {string|Date} value - Date to format
  * @returns {string} Formatted date string
  */
+// `new Date('YYYY-MM-DD')` parses the string as UTC midnight, which renders
+// as the previous day in any timezone west of UTC. Promote date-only strings
+// to local time so the calendar day never shifts.
+function parseLocalDate(value) {
+    if (value instanceof Date) return value;
+    if (typeof value === 'string' && /^\d{4}-\d{2}-\d{2}$/.test(value)) {
+        const [y, m, d] = value.split('-').map(Number);
+        return new Date(y, m - 1, d);
+    }
+    return new Date(value);
+}
+
 export function formatDate(value) {
     if (!value) return '';
-    const date = new Date(value);
-    return date.toLocaleDateString('en-US', {
+    return parseLocalDate(value).toLocaleDateString('en-US', {
         day: '2-digit',
         month: '2-digit',
         year: 'numeric'
     });
+}
+
+export function formatWeekday(value) {
+    if (!value) return '';
+    return parseLocalDate(value).toLocaleDateString('en-US', { weekday: 'short' });
 }
 
 /**
@@ -73,9 +89,9 @@ export function formatTime(timeString) {
  */
 export function formatDateRange(start, end) {
     if (!start) return '';
-    const startDate = new Date(start);
+    const startDate = parseLocalDate(start);
     if (!end) return formatDate(start);
-    const endDate = new Date(end);
+    const endDate = parseLocalDate(end);
     const sameDay = startDate.toDateString() === endDate.toDateString();
     if (sameDay) return formatDate(start);
     const sameMonth =


### PR DESCRIPTION
## Summary
- The booking show page was rendering the same header data twice — once in the layout's `NavSubmenu` and again in the body of `BookingDetails`. The `NavSubmenu` now owns the richer header (title, multi-event badge, event-type tag, status pill, and engagement summary), and the duplicate card was removed from `BookingDetails`.
- Fixed an off-by-one bug in `formatDate` / `formatDateRange`: ISO date-only strings like `2026-10-15` were parsed as UTC midnight, so they rendered as `10/14/2026` in any timezone west of UTC. Date-only strings are now parsed as local time so the calendar day never shifts.
- `EngagementSummary` now prefixes single-day bookings with the short weekday → `Thu 10/15/2026`.

## Test plan
- [x] `npx vitest run` — all 105 frontend tests pass
- [x] `php artisan test tests/Feature/BookingsControllerTest.php tests/Feature/BookingNavigationTest.php` — 29 passing, 143 assertions
- [x] New regression tests added: `formatters.test.js`, `engagementsummary.test.js`, `navsubmenu.test.js`
- [ ] Visually verify the booking show page header renders once (no duplication) and the date shows the correct day with weekday prefix

🤖 Generated with [Claude Code](https://claude.com/claude-code)