### PR TITLE
fix(api/mobile): render default contract on the fly for draft download

### DIFF
--- a/app/Http/Controllers/Api/Mobile/BookingsController.php
+++ b/app/Http/Controllers/Api/Mobile/BookingsController.php
@@ -413,24 +413,49 @@ class BookingsController extends Controller
     public function downloadContract(Bands $band, Bookings $booking)
     {
         $contract = $booking->contract;
-        if (!$contract || !$contract->asset_url) {
+
+        if ($contract && $contract->asset_url) {
+            $filePath = $contract->getFilePath();
+            if (!Storage::disk('s3')->exists($filePath)) {
+                abort(404, 'Contract file not found');
+            }
+
+            $stream = Storage::disk('s3')->readStream($filePath);
+
+            return response()->stream(
+                function () use ($stream) { fpassthru($stream); },
+                200,
+                [
+                    'Content-Type'        => 'application/pdf',
+                    'Content-Disposition' => 'attachment; filename="' . basename($filePath) . '"',
+                ]
+            );
+        }
+
+        if (($booking->contract_option ?? 'default') !== 'default') {
             abort(404, 'Contract not found');
         }
 
-        $filePath = $contract->getFilePath();
-        if (!Storage::disk('s3')->exists($filePath)) {
-            abort(404, 'Contract file not found');
+        try {
+            $pdf = $booking->getContractPdf();
+        } catch (\InvalidArgumentException $e) {
+            return response()->json([
+                'error'   => 'Band address incomplete',
+                'message' => $e->getMessage(),
+            ], 422);
+        } catch (\Throwable $e) {
+            return response()->json([
+                'error'   => 'Contract generation failed',
+                'message' => $e->getMessage(),
+            ], 500);
         }
 
-        $stream = Storage::disk('s3')->readStream($filePath);
+        $filename = Str::slug($booking->name . '_Contract', '_') . '.pdf';
 
-        return response()->stream(
-            function () use ($stream) { fpassthru($stream); },
-            200,
-            [
-                'Content-Type'        => 'application/pdf',
-                'Content-Disposition' => 'attachment; filename="' . basename($filePath) . '"',
-            ]
+        return response()->streamDownload(
+            function () use ($pdf) { echo $pdf; },
+            $filename,
+            ['Content-Type' => 'application/pdf'],
         );
     }
 

--- a/tests/Feature/Api/Mobile/BookingContractDownloadTest.php
+++ b/tests/Feature/Api/Mobile/BookingContractDownloadTest.php
@@ -58,7 +58,7 @@ class BookingContractDownloadTest extends TestCase
             ->assertUnauthorized();
     }
 
-    public function test_missing_contract_returns_404(): void
+    public function test_external_contract_without_asset_returns_404(): void
     {
         Storage::fake('s3');
 
@@ -67,11 +67,11 @@ class BookingContractDownloadTest extends TestCase
         $band->owners()->create(['user_id' => $user->id]);
 
         $booking = Bookings::factory()->create([
-            'band_id' => $band->id,
-            'status'  => 'draft',
+            'band_id'         => $band->id,
+            'status'          => 'draft',
+            'contract_option' => 'external',
         ]);
 
-        // Contract exists but has no asset_url
         $booking->contract()->create([
             'author_id' => $user->id,
             'status'    => 'pending',


### PR DESCRIPTION
## Summary
- Mobile `downloadContract` 404'd on draft bookings using the default (generated) contract option because it only streamed an uploaded `asset_url`.
- Falls back to `Bookings::getContractPdf()` when no asset exists and `contract_option` is `default`, matching the web client.
- External-mode bookings with no uploaded PDF still 404.

## Test plan
- [x] `php artisan test --filter=BookingContractDownloadTest` — 3 pass
- [ ] Mobile: tap "Download PDF" on a draft default-contract booking → receive a generated PDF (not a Dio error)
- [ ] Mobile: tap "Download PDF" on a confirmed booking with an uploaded contract → still streams the stored asset
- [ ] Mobile: external booking with no upload still surfaces a 404

🤖 Generated with [Claude Code](https://claude.com/claude-code)