### PR TITLE
fix(events): resolve Google Calendar timeRangeEmpty regression

### DIFF
--- a/app/Models/Events.php
+++ b/app/Models/Events.php
@@ -129,24 +129,39 @@ class Events extends Model implements GoogleCalenderable
 
     public function getEndDateTimeAttribute()
     {
+        $start = Carbon::parse($this->startDateTime);
+
         // Prefer the dedicated end_time column when populated.
         if ($this->end_time) {
             $date = $this->date->toDateString();
             $time = $this->end_time->format('H:i');
-            return Carbon::parse("{$date} {$time}")->isoFormat('YYYY-MM-DDTHH:mm:ss.sss');
+            $end = Carbon::parse("{$date} {$time}");
+
+            // end_time is stored as a TIME (no date). When it falls on or before
+            // the start, assume the event crosses midnight (e.g., 22:00 -> 02:00)
+            // and roll the end forward by a day. Google Calendar rejects events
+            // whose end is not strictly after the start (timeRangeEmpty).
+            if ($end->lessThanOrEqualTo($start)) {
+                $end->addDay();
+            }
+
+            return $end->isoFormat('YYYY-MM-DDTHH:mm:ss.sss');
         }
 
         // Fall back to additional_data->times (legacy data path).
-        $endDateTime = Carbon::parse($this->startDateTime)->addHour()->isoFormat('YYYY-MM-DDTHH:mm:ss.sss');
+        $endDateTime = $start->copy()->addHour();
         try {
             if ($this->additional_data && isset($this->additional_data->times) && $this->additional_data->times) {
                 $endTime = collect($this->additional_data->times)->max('time');
-                $endDateTime = Carbon::parse($endTime)->isoFormat('YYYY-MM-DDTHH:mm:ss.sss');
+                $parsed = Carbon::parse($endTime);
+                if ($parsed->greaterThan($start)) {
+                    $endDateTime = $parsed;
+                }
             }
         } catch (\Exception $e) {
             \Log::error('Error parsing end time for event ID ' . $this->id . ': ' . $e->getMessage());
         }
-        return $endDateTime;
+        return $endDateTime->isoFormat('YYYY-MM-DDTHH:mm:ss.sss');
     }
 
     public function scopePublic($query)

--- a/tests/Feature/EventsToGoogleCalendarTest.php
+++ b/tests/Feature/EventsToGoogleCalendarTest.php
@@ -119,6 +119,40 @@ class EventsToGoogleCalendarTest extends TestCase
         $this->assertInstanceOf(EventDateTime::class, $this->event->getGoogleCalendarEndTime());
     }
 
+    public function test_end_datetime_rolls_to_next_day_when_event_crosses_midnight(): void
+    {
+        // Late-night gig: 22:00 -> 02:00. end_time is a TIME column so it
+        // sits on the same calendar date by default. The accessor must roll
+        // the end forward a day so Google Calendar does not reject the event
+        // with `timeRangeEmpty`.
+        $this->event->date = '2026-06-01';
+        $this->event->start_time = '22:00';
+        $this->event->end_time = '02:00';
+
+        $start = \Carbon\Carbon::parse($this->event->startDateTime);
+        $end = \Carbon\Carbon::parse($this->event->endDateTime);
+
+        $this->assertTrue(
+            $end->greaterThan($start),
+            'End datetime must be strictly after start datetime for midnight-crossing events.'
+        );
+        $this->assertSame('2026-06-02', $end->toDateString());
+    }
+
+    public function test_end_datetime_rolls_forward_when_end_time_equals_start_time(): void
+    {
+        // Defensive case: if start_time == end_time the range is empty;
+        // accessor must produce a non-empty range.
+        $this->event->date = '2026-06-01';
+        $this->event->start_time = '20:00';
+        $this->event->end_time = '20:00';
+
+        $start = \Carbon\Carbon::parse($this->event->startDateTime);
+        $end = \Carbon\Carbon::parse($this->event->endDateTime);
+
+        $this->assertTrue($end->greaterThan($start));
+    }
+
     public function test_does_not_write_to_google_when_calendar_is_missing(): void
     {
         $this->assertFalse($this->event->writeToGoogleCalendar());


### PR DESCRIPTION
## Summary
- `Events::getEndDateTimeAttribute` now rolls the end forward by a day when the stored `end_time` lands on or before `start_time` (midnight-crossing gigs, e.g. 22:00 → 02:00) so Google Calendar no longer rejects the event with `timeRangeEmpty` on `timeMax`.
- The same safety check is applied to the legacy `additional_data->times` fallback path.
- Adds two regression tests covering the midnight-crossing case and the equal-times defensive case.

## Why
Commit `5bf1e0b` (`feat(events): add event-owned date/time/venue/price columns`) replaced the legacy "end = start + 1 hour" fallback with a direct read of the new `end_time` TIME column, but didn't account for events whose end time crosses midnight or equals the start. All four calendar-sync jobs (`ProcessEventCreated/Updated`, `ProcessBookingCreated/Updated`) route through this accessor, so the bug took out both event and booking calendar writes.

Sentry refs: `TTS-BAND-NV` (286 occurrences), `TTS-BAND-NW`, `TTS-BAND-11P` (booking-side), `TTS-BAND-11R`.

## Test plan
- [x] `php artisan test --filter='EventsToGoogleCalendarTest'` — 18 passed, including the two new regression tests.
- [x] `php artisan test --filter='UpdateEventsTest|EventsShowTest|CanCreateEventsTest|GetEventsTest'` — 20 passed.
- [ ] After deploy, confirm Sentry `TTS-BAND-NV` / `TTS-BAND-NW` stop receiving new events on the next `ProcessEventUpdated` cycle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)