### PR TITLE
Gate public Google calendar on confirmed bookings

### DIFF
--- a/app/Jobs/ProcessEventCreated.php
+++ b/app/Jobs/ProcessEventCreated.php
@@ -2,6 +2,7 @@
 
 namespace App\Jobs;
 
+use App\Models\Bookings;
 use App\Models\Events;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Queue\SerializesModels;
@@ -45,9 +46,9 @@ class ProcessEventCreated implements ShouldQueue, ShouldBeUniqueUntilProcessing
                 $this->event->storeGoogleEventId($this->event->getGoogleCalendar(), $event->id);
             }
 
-            if($this->event->additional_data && $this->event->additional_data->public)
+            if ($this->event->additional_data && $this->event->additional_data->public && $this->shouldSyncToPublicCalendar())
             {
-                Log::info('Event is public, writing to public calendar for event ID: ' . $this->event->id);
+                Log::info('Event is public and eligible, writing to public calendar for event ID: ' . $this->event->id);
                 $publicEvent = $this->event->writeToGoogleCalendar($this->event->getPublicGoogleCalendar());
                 if ($publicEvent) {
                     $this->event->storeGoogleEventId($this->event->getPublicGoogleCalendar(), $publicEvent->id);
@@ -59,5 +60,16 @@ class ProcessEventCreated implements ShouldQueue, ShouldBeUniqueUntilProcessing
         } catch (\Exception $e) {
             Log::error('Failed to create event in calendar: ' . $e->getMessage());
         }
+    }
+
+    private function shouldSyncToPublicCalendar(): bool
+    {
+        $eventable = $this->event->eventable;
+
+        if ($eventable instanceof Bookings) {
+            return $eventable->status === 'confirmed';
+        }
+
+        return true;
     }
 }

--- a/app/Jobs/ProcessEventUpdated.php
+++ b/app/Jobs/ProcessEventUpdated.php
@@ -2,6 +2,7 @@
 
 namespace App\Jobs;
 
+use App\Models\BandCalendars;
 use App\Models\Bookings;
 use App\Models\BandEvents;
 use App\Models\Events;
@@ -42,14 +43,48 @@ class ProcessEventUpdated implements ShouldQueue, ShouldBeUniqueUntilProcessing
 
         $this->writeToGoogleCalendar($this->event->getGoogleCalendar());
 
-        if ($this->event->additional_data && is_object($this->event->additional_data) && isset($this->event->additional_data->public) && $this->event->additional_data->public) {
-            Log::info('Event is public, writing to public calendar for event ID: ' . $this->event->id);
-            $this->writeToGoogleCalendar($this->event->getPublicGoogleCalendar());
-        }
+        $this->syncPublicCalendar();
 
         CalculateEventDistances::dispatch($this->event);
 
         $this->SendNotification();
+    }
+
+    private function syncPublicCalendar(): void
+    {
+        $isPublic = $this->event->additional_data
+            && is_object($this->event->additional_data)
+            && !empty($this->event->additional_data->public);
+
+        $publicCalendar = $this->event->getPublicGoogleCalendar();
+
+        if (!$publicCalendar) {
+            return;
+        }
+
+        if ($isPublic && $this->isEligibleForPublicCalendar()) {
+            Log::info('Event is public and eligible, writing to public calendar for event ID: ' . $this->event->id);
+            $this->writeToGoogleCalendar($publicCalendar);
+            return;
+        }
+
+        // Booking is no longer eligible (downgraded from confirmed, or public flag cleared);
+        // clean up any existing public calendar entry.
+        if ($this->event->getGoogleEvent($publicCalendar)) {
+            Log::info('Event no longer eligible for public calendar, deleting existing entry for event ID: ' . $this->event->id);
+            $this->event->deleteFromGoogleCalendar($publicCalendar);
+        }
+    }
+
+    private function isEligibleForPublicCalendar(): bool
+    {
+        $eventable = $this->event->eventable;
+
+        if ($eventable instanceof Bookings) {
+            return $eventable->status === 'confirmed';
+        }
+
+        return true;
     }
 
     public function writeToGoogleCalendar($calendar)

--- a/app/Models/Bookings.php
+++ b/app/Models/Bookings.php
@@ -577,8 +577,12 @@ class Bookings extends Model implements Contractable, GoogleCalenderable
         return $this->band->bookingCalendar;
     }
 
-    public function getGoogleCalendarSummary(): ?string
+    public function getGoogleCalendarSummary(BandCalendars $bandCalendar = null): ?string
     {
+        if ($bandCalendar?->type === 'public') {
+            return $this->name;
+        }
+
         return $this->name . ' (' . ucfirst($this->status) . ')';
     }
 

--- a/app/Models/Events.php
+++ b/app/Models/Events.php
@@ -275,8 +275,12 @@ class Events extends Model implements GoogleCalenderable
         return $this->eventable->band->publicCalendar ?? null;
     }
 
-    public function getGoogleCalendarSummary(): string|null
+    public function getGoogleCalendarSummary(BandCalendars $bandCalendar = null): string|null
     {
+        if ($bandCalendar?->type === 'public') {
+            return $this->title;
+        }
+
         if ($this->eventable_type === 'App\\Models\\Bookings' && $this->eventable) {
             return $this->title . ' (' . ucfirst($this->eventable->status) . ')';
         }

--- a/app/Models/Interfaces/GoogleCalenderable.php
+++ b/app/Models/Interfaces/GoogleCalenderable.php
@@ -9,7 +9,7 @@ interface GoogleCalenderable
 {
     public function getGoogleEvent(BandCalendars $bandCalendar): GoogleEvents|null;
     public function getGoogleCalendar(): BandCalendars|null;
-    public function getGoogleCalendarSummary(): string|null;
+    public function getGoogleCalendarSummary(BandCalendars $bandCalendar = null): string|null;
     public function getGoogleCalendarDescription(): string|null;
     public function getGoogleCalendarStartTime(): \Google\Service\Calendar\EventDateTime;
     public function getGoogleCalendarLocation(): string|null;

--- a/app/Models/Rehearsal.php
+++ b/app/Models/Rehearsal.php
@@ -107,7 +107,7 @@ class Rehearsal extends Model implements GoogleCalenderable
         return $this->band->eventCalendar;
     }
 
-    public function getGoogleCalendarSummary(): string|null
+    public function getGoogleCalendarSummary(BandCalendars $bandCalendar = null): string|null
     {
         // Get the first event or use schedule name
         $event = $this->events()->first();

--- a/app/Models/Traits/GoogleCalendarWritable.php
+++ b/app/Models/Traits/GoogleCalendarWritable.php
@@ -38,7 +38,7 @@ trait GoogleCalendarWritable
                         $result = $googleCalendarService->updateEvent(
                             $bandCalendar->calendar_id,
                             $existingGoogleEvent->google_event_id,
-                            $this->getEventData()
+                            $this->getEventData($bandCalendar)
                         );
                         $lock->release();
                         return $result;
@@ -50,7 +50,7 @@ trait GoogleCalendarWritable
                 }
 
                 \Log::info("Creating new Google Calendar event for " . get_class($this) . " ID: {$this->id} in calendar {$bandCalendar->id}");
-                $result = $googleCalendarService->insertEvent($bandCalendar->calendar_id, $this->getEventData());
+                $result = $googleCalendarService->insertEvent($bandCalendar->calendar_id, $this->getEventData($bandCalendar));
                 $lock->release();
                 return $result;
 
@@ -66,12 +66,12 @@ trait GoogleCalendarWritable
                     return $googleCalendarService->updateEvent(
                         $bandCalendar->calendar_id,
                         $existingGoogleEvent->google_event_id,
-                        $this->getEventData()
+                        $this->getEventData($bandCalendar)
                     );
                 }
 
                 \Log::warning("Proceeding with insert after lock timeout for " . get_class($this) . " ID: {$this->id}");
-                return $googleCalendarService->insertEvent($bandCalendar->calendar_id, $this->getEventData());
+                return $googleCalendarService->insertEvent($bandCalendar->calendar_id, $this->getEventData($bandCalendar));
             }
         } catch (\Exception $e) {
             $lock->release();
@@ -105,16 +105,16 @@ trait GoogleCalendarWritable
         return !is_null($this->getGoogleEvent($bandCalendar));
     }
 
-    protected function getEventData(): GoogleEvent
+    protected function getEventData(BandCalendars $bandCalendar = null): GoogleEvent
     {
         $event = new GoogleEvent([]);
         $event->setLocation($this->getGoogleCalendarLocation());
         $event->setColorId($this->getGoogleCalendarColor());
-        $event->setSummary($this->getGoogleCalendarSummary());
+        $event->setSummary($this->getGoogleCalendarSummary($bandCalendar));
         $event->setDescription($this->getGoogleCalendarDescription());
         $event->setStart($this->getGoogleCalendarStartTime());
         $event->setEnd($this->getGoogleCalendarEndTime());
-        
+
         return $event;
     }
 

--- a/tests/Feature/BookingCreationPreventsDuplicateCalendarEventsTest.php
+++ b/tests/Feature/BookingCreationPreventsDuplicateCalendarEventsTest.php
@@ -177,9 +177,12 @@ class BookingCreationPreventsDuplicateCalendarEventsTest extends TestCase
         $this->app->instance(GoogleCalendarService::class, $mockService);
 
         
+        // Booking must be confirmed for an existing public-calendar entry to be
+        // *updated* rather than *deleted* by the public-calendar sync rules.
         $booking = Bookings::factory()->create([
             'band_id' => $this->band->id,
             'event_type_id' => $this->eventType->id,
+            'status' => 'confirmed',
         ]);
 
         $event = Events::withoutEvents(function () use ($booking) {

--- a/tests/Feature/BookingsToGoogleCalendarTest.php
+++ b/tests/Feature/BookingsToGoogleCalendarTest.php
@@ -78,11 +78,24 @@ class BookingsToGoogleCalendarTest extends TestCase
     }
 
     public function test_returns_google_calendar_summary(): void
-    {   
+    {
         $detailsThatShouldBeThere = [$this->booking->name, $this->booking->status];
         foreach ($detailsThatShouldBeThere as $detail) {
             $this->assertStringContainsString(Str::lower($detail), Str::lower($this->booking->getGoogleCalendarSummary()));
         }
+    }
+
+    public function test_summary_omits_status_when_writing_to_public_calendar(): void
+    {
+        $publicCalendar = BandCalendars::factory()->create([
+            'band_id' => $this->booking->band->id,
+            'type'    => 'public',
+        ]);
+
+        $summary = $this->booking->getGoogleCalendarSummary($publicCalendar);
+
+        $this->assertEquals($this->booking->name, $summary);
+        $this->assertStringNotContainsString('(', $summary);
     }
 
     public function test_returns_google_calendar_description(): void

--- a/tests/Feature/EventsToGoogleCalendarTest.php
+++ b/tests/Feature/EventsToGoogleCalendarTest.php
@@ -99,6 +99,20 @@ class EventsToGoogleCalendarTest extends TestCase
         $this->assertEquals('Test Event', $summary);
     }
 
+    public function test_summary_omits_booking_status_when_writing_to_public_calendar(): void
+    {
+        $this->event->title = 'Test Event';
+        $this->event->eventable->status = 'confirmed';
+        $this->event->eventable->save();
+
+        $publicCalendar = BandCalendars::factory()->create([
+            'band_id' => $this->event->eventable->band->id,
+            'type'    => 'public',
+        ]);
+
+        $this->assertEquals('Test Event', $this->event->getGoogleCalendarSummary($publicCalendar));
+    }
+
     public function test_returns_google_calendar_description(): void
     {
         $this->event->notes = 'Test Description';

--- a/tests/Feature/PublicCalendarSyncTest.php
+++ b/tests/Feature/PublicCalendarSyncTest.php
@@ -1,0 +1,240 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Jobs\ProcessEventCreated;
+use App\Jobs\ProcessEventUpdated;
+use App\Models\BandCalendars;
+use App\Models\Bands;
+use App\Models\Bookings;
+use App\Models\EventTypes;
+use App\Models\Events;
+use App\Models\GoogleEvents;
+use App\Services\GoogleCalendarService;
+use Google\Service\Calendar\Event as GoogleEvent;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Mockery;
+use Tests\TestCase;
+
+class PublicCalendarSyncTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected Bands $band;
+    protected BandCalendars $eventCalendar;
+    protected BandCalendars $publicCalendar;
+    protected EventTypes $eventType;
+
+    /**
+     * Tracks calls into the mocked GoogleCalendarService, keyed by method:
+     * ['insertEvent' => [[$calId, GoogleEvent], ...], 'updateEvent' => [...], 'deleteEvent' => [...]]
+     *
+     * @var array<string,array<int,array<int,mixed>>>
+     */
+    protected array $calendarCalls = [];
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->band = Bands::factory()->create();
+
+        $this->eventCalendar = BandCalendars::factory()->create([
+            'band_id'     => $this->band->id,
+            'type'        => 'event',
+            'calendar_id' => 'event-cal',
+        ]);
+
+        $this->publicCalendar = BandCalendars::factory()->create([
+            'band_id'     => $this->band->id,
+            'type'        => 'public',
+            'calendar_id' => 'public-cal',
+        ]);
+
+        $this->eventType = EventTypes::factory()->create();
+    }
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+        Mockery::close();
+    }
+
+    private function mockCalendarService(): void
+    {
+        $this->calendarCalls = ['insertEvent' => [], 'updateEvent' => [], 'deleteEvent' => []];
+
+        $mockService = Mockery::mock(GoogleCalendarService::class);
+
+        $mockService->shouldReceive('insertEvent')
+            ->andReturnUsing(function (string $calendarId, GoogleEvent $event) {
+                $this->calendarCalls['insertEvent'][] = [$calendarId, $event];
+                $result = new GoogleEvent();
+                $result->setId($calendarId . '-inserted-' . count($this->calendarCalls['insertEvent']));
+                return $result;
+            });
+
+        $mockService->shouldReceive('updateEvent')
+            ->andReturnUsing(function (string $calendarId, string $googleEventId, GoogleEvent $event) {
+                $this->calendarCalls['updateEvent'][] = [$calendarId, $googleEventId, $event];
+                $result = new GoogleEvent();
+                $result->setId($googleEventId);
+                return $result;
+            });
+
+        $mockService->shouldReceive('deleteEvent')
+            ->andReturnUsing(function (string $calendarId, string $googleEventId) {
+                $this->calendarCalls['deleteEvent'][] = [$calendarId, $googleEventId];
+                return true;
+            });
+
+        $this->app->instance(GoogleCalendarService::class, $mockService);
+    }
+
+    private function callsForCalendar(string $method, string $calendarId): array
+    {
+        return array_values(array_filter(
+            $this->calendarCalls[$method] ?? [],
+            fn(array $call) => $call[0] === $calendarId,
+        ));
+    }
+
+    private function makeEventForBooking(Bookings $booking, bool $public): Events
+    {
+        return Events::factory()->create([
+            'eventable_id'    => $booking->id,
+            'eventable_type'  => Bookings::class,
+            'event_type_id'   => $this->eventType->id,
+            'date'            => now()->addDays(10)->format('Y-m-d'),
+            'additional_data' => ['public' => $public],
+        ]);
+    }
+
+    public function test_pending_public_event_does_not_sync_to_public_calendar(): void
+    {
+        $this->mockCalendarService();
+
+        $booking = Bookings::factory()->create([
+            'band_id' => $this->band->id,
+            'status'  => 'pending',
+        ]);
+        $event = $this->makeEventForBooking($booking, public: true);
+
+        (new ProcessEventCreated($event))->handle();
+
+        $this->assertCount(1, $this->callsForCalendar('insertEvent', $this->eventCalendar->calendar_id));
+        $this->assertCount(0, $this->callsForCalendar('insertEvent', $this->publicCalendar->calendar_id));
+        $this->assertDatabaseMissing('google_events', [
+            'google_eventable_id'   => $event->id,
+            'google_eventable_type' => Events::class,
+            'band_calendar_id'      => $this->publicCalendar->id,
+        ]);
+    }
+
+    public function test_confirmed_public_event_syncs_to_public_calendar(): void
+    {
+        $this->mockCalendarService();
+
+        $booking = Bookings::factory()->create([
+            'band_id' => $this->band->id,
+            'status'  => 'confirmed',
+        ]);
+        $event = $this->makeEventForBooking($booking, public: true);
+
+        (new ProcessEventCreated($event))->handle();
+
+        $this->assertCount(1, $this->callsForCalendar('insertEvent', $this->publicCalendar->calendar_id));
+        $this->assertDatabaseHas('google_events', [
+            'google_eventable_id'   => $event->id,
+            'google_eventable_type' => Events::class,
+            'band_calendar_id'      => $this->publicCalendar->id,
+        ]);
+    }
+
+    public function test_downgrade_from_confirmed_deletes_existing_public_entry(): void
+    {
+        $this->mockCalendarService();
+
+        $booking = Bookings::factory()->create([
+            'band_id' => $this->band->id,
+            'status'  => 'pending',
+        ]);
+        $event = $this->makeEventForBooking($booking, public: true);
+
+        GoogleEvents::create([
+            'google_eventable_id'   => $event->id,
+            'google_eventable_type' => Events::class,
+            'band_calendar_id'      => $this->publicCalendar->id,
+            'google_event_id'       => 'stale-public-id',
+        ]);
+
+        (new ProcessEventUpdated($event, $event->getOriginal()))->handle();
+
+        $deletes = $this->callsForCalendar('deleteEvent', $this->publicCalendar->calendar_id);
+        $this->assertCount(1, $deletes);
+        $this->assertSame('stale-public-id', $deletes[0][1]);
+        $this->assertDatabaseMissing('google_events', [
+            'google_eventable_id'   => $event->id,
+            'google_eventable_type' => Events::class,
+            'band_calendar_id'      => $this->publicCalendar->id,
+        ]);
+    }
+
+    public function test_clearing_public_flag_deletes_existing_public_entry(): void
+    {
+        $this->mockCalendarService();
+
+        $booking = Bookings::factory()->create([
+            'band_id' => $this->band->id,
+            'status'  => 'confirmed',
+        ]);
+        $event = $this->makeEventForBooking($booking, public: false);
+
+        GoogleEvents::create([
+            'google_eventable_id'   => $event->id,
+            'google_eventable_type' => Events::class,
+            'band_calendar_id'      => $this->publicCalendar->id,
+            'google_event_id'       => 'stale-public-id-2',
+        ]);
+
+        (new ProcessEventUpdated($event, $event->getOriginal()))->handle();
+
+        $deletes = $this->callsForCalendar('deleteEvent', $this->publicCalendar->calendar_id);
+        $this->assertCount(1, $deletes);
+        $this->assertSame('stale-public-id-2', $deletes[0][1]);
+        $this->assertDatabaseMissing('google_events', [
+            'google_eventable_id'   => $event->id,
+            'google_eventable_type' => Events::class,
+            'band_calendar_id'      => $this->publicCalendar->id,
+        ]);
+    }
+
+    public function test_public_calendar_event_summary_omits_status_suffix(): void
+    {
+        $this->mockCalendarService();
+
+        $booking = Bookings::factory()->create([
+            'band_id' => $this->band->id,
+            'status'  => 'confirmed',
+        ]);
+        $event = Events::factory()->create([
+            'eventable_id'    => $booking->id,
+            'eventable_type'  => Bookings::class,
+            'event_type_id'   => $this->eventType->id,
+            'date'            => now()->addDays(10)->format('Y-m-d'),
+            'additional_data' => ['public' => true],
+            'title'           => 'My Gig',
+        ]);
+
+        (new ProcessEventCreated($event))->handle();
+
+        $eventCalCall = $this->callsForCalendar('insertEvent', $this->eventCalendar->calendar_id);
+        $publicCalCall = $this->callsForCalendar('insertEvent', $this->publicCalendar->calendar_id);
+
+        $this->assertCount(1, $eventCalCall);
+        $this->assertCount(1, $publicCalCall);
+
+        $this->assertSame('My Gig (Confirmed)', $eventCalCall[0][1]->getSummary());
+        $this->assertSame('My Gig', $publicCalCall[0][1]->getSummary());
+    }
+}


### PR DESCRIPTION
## Summary
- Public calendar entries are now written only when the parent booking has `status = 'confirmed'`. Pending/draft/cancelled bookings stay off the public calendar even when their event is marked public.
- If a previously-confirmed booking is downgraded (or the event's public flag is cleared), the existing public-calendar entry is deleted on the next update.
- Dropped the `(Pending)` / `(Confirmed)` suffix from public-calendar event titles. The internal booking and event calendars still show the status suffix.

Non-booking eventables (legacy `BandEvents`) keep their current behavior — gating applies only when the eventable is a `Bookings`.

## Test plan
- [x] `php artisan test tests/Feature/PublicCalendarSyncTest.php` — new feature tests for gating + cleanup + summary
- [x] `php artisan test tests/Feature/EventsToGoogleCalendarTest.php tests/Feature/BookingsToGoogleCalendarTest.php tests/Feature/EventGoogleCalendarUpdateTest.php tests/Feature/BookingDeletionTest.php tests/Feature/BookingCreationPreventsDuplicateCalendarEventsTest.php` — adjacent calendar tests still pass
- [x] Full backend suite (1019 tests) green locally
- [ ] After deploy, verify on a staging band: pending booking → no public entry; mark confirmed → public entry appears with bare title; downgrade to pending → public entry disappears.

> Note: pre-existing public entries on bookings that were confirmed-then-downgraded *before* this ships won't be cleaned up automatically — they'll be removed on the booking's next update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)