### PR TITLE
fix(mobile-api): accept events array on booking create

### DIFF
--- a/app/Http/Controllers/Api/Mobile/BookingsController.php
+++ b/app/Http/Controllers/Api/Mobile/BookingsController.php
@@ -22,10 +22,10 @@ use App\Models\Payments;
 use App\Services\BookingActivityService;
 use App\Services\Mobile\BookingFormatter;
 use App\Services\Mobile\BookingService;
-use Carbon\Carbon;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Facades\URL;
 use Illuminate\Support\Str;
@@ -142,35 +142,42 @@ class BookingsController extends Controller
     {
         $validated = $request->validated();
 
-        $startDt = Carbon::parse($validated['date'] . ' ' . $validated['start_time']);
-        $endDt   = $startDt->copy()->addHours((float) $validated['duration']);
-        $endTime = $endDt->format('H:i');
-
         $status = ($validated['contract_option'] ?? 'default') === 'none' ? 'confirmed' : 'draft';
 
-        // date/start_time/end_time/venue_name/venue_address now live on events,
-        // not bookings. Store only booking-level fields here.
-        $attrs = [
-            'band_id'         => $band->id,
-            'author_id'       => Auth::id(),
-            'name'            => $validated['name'],
-            'event_type_id'   => $validated['event_type_id'],
-            'price'           => $validated['price'] ?? null,
-            'contract_option' => $validated['contract_option'] ?? 'default',
-            'notes'           => $validated['notes'] ?? null,
-            'status'          => $status,
-        ];
-        $booking = Bookings::create($attrs);
+        // date/start_time/end_time/venue_name/venue_address live on events,
+        // not bookings. Store only booking-level fields here; each entry in
+        // the `events` array becomes its own Event row.
+        $booking = DB::transaction(function () use ($validated, $band, $status) {
+            $booking = Bookings::create([
+                'band_id'         => $band->id,
+                'author_id'       => Auth::id(),
+                'name'            => $validated['name'],
+                'event_type_id'   => $validated['event_type_id'],
+                'price'           => $validated['price'] ?? null,
+                'contract_option' => $validated['contract_option'] ?? 'default',
+                'notes'           => $validated['notes'] ?? null,
+                'status'          => $status,
+            ]);
 
-        $booking->contract()->create([
-            'author_id'    => Auth::id(),
-            'status'       => 'pending',
-            'custom_terms' => $this->bookingService->getInitialTerms(),
-        ]);
+            $booking->contract()->create([
+                'author_id'    => Auth::id(),
+                'status'       => 'pending',
+                'custom_terms' => $this->bookingService->getInitialTerms(),
+            ]);
 
-        $additionalData = $this->bookingService->buildAdditionalData($validated, $startDt, $endDt);
-        $this->bookingService->createInitialEvent($booking, $validated, $additionalData);
-        $this->bookingService->redistributeEventValues($booking->fresh());
+            foreach ($validated['events'] as $eventData) {
+                $this->bookingService->createBookingEvent(
+                    $booking,
+                    $eventData,
+                    $validated['event_type_id'],
+                );
+            }
+
+            // Split the booking price evenly across the events created above.
+            $this->bookingService->redistributeEventValues($booking->fresh());
+
+            return $booking;
+        });
 
         return response()->json([
             'booking' => $this->formatter->format(

--- a/app/Http/Requests/Mobile/StoreBookingRequest.php
+++ b/app/Http/Requests/Mobile/StoreBookingRequest.php
@@ -16,14 +16,22 @@ class StoreBookingRequest extends FormRequest
         return [
             'name'            => 'required|string|max:255',
             'event_type_id'   => 'required|integer|exists:event_types,id',
-            'date'            => 'required|date',
-            'start_time'      => 'required|date_format:H:i',
-            'duration'        => 'required|numeric|min:0.5|max:24',
             'price'           => 'nullable|numeric|min:0',
-            'venue_name'      => 'nullable|string|max:255',
-            'venue_address'   => 'nullable|string',
             'contract_option' => 'nullable|in:default,none,external',
             'notes'           => 'nullable|string',
+
+            // Date / time / venue now live on events, not the booking. A
+            // booking is created with one or more events; start_time is
+            // required so the additional_data schedule can be anchored.
+            'events'                 => 'required|array|min:1',
+            'events.*.title'         => 'required|string|max:255',
+            'events.*.date'          => 'required|date',
+            'events.*.start_time'    => 'required|date_format:H:i',
+            'events.*.end_time'      => 'nullable|date_format:H:i',
+            'events.*.venue_name'    => 'nullable|string|max:255',
+            'events.*.venue_address' => 'nullable|string',
+            'events.*.price'         => 'nullable|numeric|min:0',
+
             'deposit_type'  => 'sometimes|required|in:percent,amount',
             'deposit_value' => [
                 'sometimes', 'required', 'numeric', 'min:0',
@@ -37,6 +45,15 @@ class StoreBookingRequest extends FormRequest
                     }
                 },
             ],
+        ];
+    }
+
+    public function messages(): array
+    {
+        return [
+            'events.required'              => 'A booking must include at least one event.',
+            'events.min'                   => 'A booking must include at least one event.',
+            'events.*.start_time.required' => 'Each event needs a start time.',
         ];
     }
 }

--- a/app/Services/Mobile/BookingService.php
+++ b/app/Services/Mobile/BookingService.php
@@ -8,7 +8,11 @@ use Illuminate\Support\Str;
 
 class BookingService
 {
-    public function buildAdditionalData(array $validated, Carbon $startDt, Carbon $endDt): array
+    /**
+     * Build the per-event `additional_data` blob (load-in / soundcheck / etc.)
+     * anchored to a single event's start and end.
+     */
+    public function buildAdditionalData(int $eventTypeId, Carbon $startDt, Carbon $endDt): array
     {
         $additionalData = [
             'times' => [
@@ -30,7 +34,7 @@ class BookingService
             ],
         ];
 
-        if ((int) $validated['event_type_id'] === 1) {
+        if ($eventTypeId === 1) {
             $additionalData['wedding'] = [
                 'onsite' => true,
                 'dances' => [
@@ -71,31 +75,41 @@ class BookingService
         return [];
     }
 
-    public function createInitialEvent(Bookings $booking, array $validated, array $additionalData): void
+    /**
+     * Create a single Event under a booking from one entry of the create
+     * payload's `events` array.
+     *
+     * @param  array  $eventData  Validated event fields: title, date,
+     *                            start_time (required), end_time?, venue_name?,
+     *                            venue_address?, price?.
+     */
+    public function createBookingEvent(Bookings $booking, array $eventData, int $eventTypeId): void
     {
         $defaultRoster = $booking->band->defaultRoster ?? null;
 
-        $startDt = \Carbon\Carbon::parse($validated['date'] . ' ' . $validated['start_time']);
-        $endDt   = $startDt->copy()->addHours((float) ($validated['duration'] ?? 2));
-        $endTime = $endDt->format('H:i');
+        $startDt = Carbon::parse($eventData['date'] . ' ' . $eventData['start_time']);
+        // end_time is optional; when absent, default the event to two hours.
+        $endTime = $eventData['end_time']
+            ?? $startDt->copy()->addHours(2)->format('H:i');
+        $endDt = Carbon::parse($eventData['date'] . ' ' . $endTime);
 
         $eventAttrs = [
-            'title'           => $booking->name,
-            'date'            => $validated['date'],
-            'start_time'      => $validated['start_time'],
+            'title'           => $eventData['title'],
+            'date'            => $eventData['date'],
+            'start_time'      => $eventData['start_time'],
             'end_time'        => $endTime,
-            'venue_address'   => $validated['venue_address'] ?? null,
-            'event_type_id'   => $validated['event_type_id'],
-            'value'           => $validated['price'] ?? 0,
-            'additional_data' => $additionalData,
+            'venue_address'   => $eventData['venue_address'] ?? null,
+            'event_type_id'   => $eventTypeId,
+            'value'           => $eventData['price'] ?? 0,
+            'additional_data' => $this->buildAdditionalData($eventTypeId, $startDt, $endDt),
             'key'             => Str::uuid()->toString(),
             'roster_id'       => $defaultRoster?->id,
         ];
 
         // venue_name defaults to 'TBD' at schema level; omit when blank so the
         // default fires rather than inserting null into a NOT NULL column.
-        if (!empty($validated['venue_name'])) {
-            $eventAttrs['venue_name'] = $validated['venue_name'];
+        if (!empty($eventData['venue_name'])) {
+            $eventAttrs['venue_name'] = $eventData['venue_name'];
         }
 
         $booking->events()->create($eventAttrs);

--- a/tests/Feature/Api/Mobile/BookingOptionalFieldsTest.php
+++ b/tests/Feature/Api/Mobile/BookingOptionalFieldsTest.php
@@ -25,6 +25,19 @@ class BookingOptionalFieldsTest extends TestCase
         return compact('user', 'band', 'token');
     }
 
+    /**
+     * Build a single-event `events` array entry for the booking-create
+     * payload. Extra keys (e.g. venue_name) merge over the defaults.
+     */
+    private function eventEntry(array $overrides = []): array
+    {
+        return array_merge([
+            'title'      => 'Main Event',
+            'date'       => '2026-06-01',
+            'start_time' => '19:00',
+        ], $overrides);
+    }
+
     public function test_create_booking_without_price_succeeds_and_defaults_to_zero(): void
     {
         ['band' => $band, 'token' => $token] = $this->makeUserAndBand();
@@ -37,9 +50,7 @@ class BookingOptionalFieldsTest extends TestCase
                 [
                     'name'          => 'Cheap Gig',
                     'event_type_id' => $eventType->id,
-                    'date'          => '2026-06-01',
-                    'start_time'    => '19:00',
-                    'duration'      => 3,
+                    'events'        => [$this->eventEntry()],
                     // No 'price' key — testing that the validator no longer rejects this.
                 ],
             );
@@ -66,9 +77,7 @@ class BookingOptionalFieldsTest extends TestCase
                 [
                     'name'          => 'Free Gig',
                     'event_type_id' => $eventType->id,
-                    'date'          => '2026-06-02',
-                    'start_time'    => '19:00',
-                    'duration'      => 3,
+                    'events'        => [$this->eventEntry(['date' => '2026-06-02'])],
                     'price'         => null,
                 ],
             );
@@ -109,9 +118,7 @@ class BookingOptionalFieldsTest extends TestCase
                 [
                     'name'          => 'Bad',
                     'event_type_id' => $eventType->id,
-                    'date'          => '2026-06-01',
-                    'start_time'    => '19:00',
-                    'duration'      => 3,
+                    'events'        => [$this->eventEntry()],
                     'price'         => -10,
                 ],
             );
@@ -131,10 +138,8 @@ class BookingOptionalFieldsTest extends TestCase
                 [
                     'name'          => 'No Venue',
                     'event_type_id' => $eventType->id,
-                    'date'          => '2026-06-01',
-                    'start_time'    => '19:00',
-                    'duration'      => 3,
-                    // No venue_name — schema default of 'TBD' should kick in.
+                    // No venue_name on the event — schema default of 'TBD' kicks in.
+                    'events'        => [$this->eventEntry()],
                 ],
             );
 
@@ -160,10 +165,9 @@ class BookingOptionalFieldsTest extends TestCase
                 [
                     'name'          => 'Null Venue',
                     'event_type_id' => $eventType->id,
-                    'date'          => '2026-06-02',
-                    'start_time'    => '19:00',
-                    'duration'      => 3,
-                    'venue_name'    => null,
+                    'events'        => [
+                        $this->eventEntry(['date' => '2026-06-02', 'venue_name' => null]),
+                    ],
                 ],
             );
 
@@ -187,10 +191,9 @@ class BookingOptionalFieldsTest extends TestCase
                 [
                     'name'          => 'Empty Venue',
                     'event_type_id' => $eventType->id,
-                    'date'          => '2026-06-03',
-                    'start_time'    => '19:00',
-                    'duration'      => 3,
-                    'venue_name'    => '',
+                    'events'        => [
+                        $this->eventEntry(['date' => '2026-06-03', 'venue_name' => '']),
+                    ],
                 ],
             );
 

--- a/tests/Feature/Api/Mobile/BookingsTest.php
+++ b/tests/Feature/Api/Mobile/BookingsTest.php
@@ -240,9 +240,13 @@ class BookingsTest extends TestCase
         $payload = [
             'name'          => 'Personal gig',
             'event_type_id' => $eventType->id,
-            'date'          => '2030-01-15',
-            'start_time'    => '20:00',
-            'duration'      => 2,
+            'events'        => [
+                [
+                    'title'      => 'Personal gig',
+                    'date'       => '2030-01-15',
+                    'start_time' => '20:00',
+                ],
+            ],
         ];
 
         $this->withToken($token)
@@ -303,5 +307,94 @@ class BookingsTest extends TestCase
             $this->getProtectedProperty($job, 'event')->id === $event2->id
         );
         Bus::assertDispatched(ProcessBookingDeleted::class, 1);
+    }
+
+    // -------------------------------------------------------------------------
+    // bookings.store — multi-event create
+    // -------------------------------------------------------------------------
+
+    public function test_bookings_store_creates_one_event_per_events_entry(): void
+    {
+        $user = User::factory()->create();
+        $band = Bands::factory()->create();
+        $band->owners()->create(['user_id' => $user->id]);
+        $eventType = EventTypes::factory()->create();
+        $token = $user->createToken('test-device')->plainTextToken;
+
+        $payload = [
+            'name'          => 'Two-night run',
+            'event_type_id' => $eventType->id,
+            'events'        => [
+                [
+                    'title'      => 'Night One',
+                    'date'       => '2030-03-01',
+                    'start_time' => '20:00',
+                    'end_time'   => '23:00',
+                    'venue_name' => 'The Blue Note',
+                ],
+                [
+                    'title'      => 'Night Two',
+                    'date'       => '2030-03-02',
+                    'start_time' => '21:00',
+                ],
+            ],
+        ];
+
+        $response = $this->withToken($token)
+            ->withHeaders(['X-Band-ID' => $band->id])
+            ->postJson("/api/mobile/bands/{$band->id}/bookings", $payload)
+            ->assertCreated();
+
+        $bookingId = $response->json('booking.id');
+        $events = Events::where('eventable_type', Bookings::class)
+            ->where('eventable_id', $bookingId)
+            ->orderBy('date')
+            ->get();
+
+        $this->assertCount(2, $events, 'One event per events[] entry');
+        $this->assertSame('Night One', $events[0]->title);
+        $this->assertSame('23:00', $events[0]->end_time->format('H:i'));
+        // end_time omitted on Night Two — service defaults it to start + 2h.
+        $this->assertSame('23:00', $events[1]->end_time->format('H:i'));
+    }
+
+    public function test_bookings_store_rejects_event_without_start_time(): void
+    {
+        $user = User::factory()->create();
+        $band = Bands::factory()->create();
+        $band->owners()->create(['user_id' => $user->id]);
+        $eventType = EventTypes::factory()->create();
+        $token = $user->createToken('test-device')->plainTextToken;
+
+        $this->withToken($token)
+            ->withHeaders(['X-Band-ID' => $band->id])
+            ->postJson("/api/mobile/bands/{$band->id}/bookings", [
+                'name'          => 'No start time',
+                'event_type_id' => $eventType->id,
+                'events'        => [
+                    ['title' => 'Mystery gig', 'date' => '2030-03-01'],
+                ],
+            ])
+            ->assertStatus(422)
+            ->assertJsonValidationErrors('events.0.start_time');
+    }
+
+    public function test_bookings_store_rejects_empty_events_array(): void
+    {
+        $user = User::factory()->create();
+        $band = Bands::factory()->create();
+        $band->owners()->create(['user_id' => $user->id]);
+        $eventType = EventTypes::factory()->create();
+        $token = $user->createToken('test-device')->plainTextToken;
+
+        $this->withToken($token)
+            ->withHeaders(['X-Band-ID' => $band->id])
+            ->postJson("/api/mobile/bands/{$band->id}/bookings", [
+                'name'          => 'Eventless',
+                'event_type_id' => $eventType->id,
+                'events'        => [],
+            ])
+            ->assertStatus(422)
+            ->assertJsonValidationErrors('events');
     }
 }


### PR DESCRIPTION
## Summary

The mobile booking-create endpoint (`POST /api/mobile/bands/{band}/bookings`) still expected the **old single-event shape** — top-level `date`, `start_time`, and `duration`. The mobile app was rewritten for multi-event editing and now sends a multi-event `events` array, so creating a booking from the app failed validation, asking for date / start time / duration fields the app no longer sends.

This migrates the endpoint to accept the `events` array — the same per-event shape the `storeEvent` subresource already uses.

## Changes

- **`StoreBookingRequest`** — validates an `events` array (`events.*.title`, `date`, `start_time` required; `end_time`, `venue_name`, `venue_address`, `price` nullable). Top-level `date` / `start_time` / `duration` / `venue_*` rules removed. A booking must include at least one event.
- **`BookingsController::store()`** — loops the `events` array, creating one `Event` per entry. Booking + contract + events now commit inside a single `DB::transaction`.
- **`BookingService`** — `createInitialEvent` replaced by `createBookingEvent`, which builds one event from an `events[]` entry; `buildAdditionalData` is anchored to each event's own start/end. `end_time` defaults to start + 2h when omitted.
- `start_time` is **required per event** so the `additional_data` schedule (load-in / soundcheck / etc.) can be anchored.

## Notes

- This endpoint is mobile-only (`App\Http\Requests\Mobile`, `mobile.band` middleware). The web booking controllers are separate and unaffected.
- The hardcoded `additional_data` schedule values are carried over unchanged; revisiting which events warrant that scaffold is tracked separately.
- A coordinated mobile-app change makes start time required on the booking form.

## Test Plan

- [x] `BookingsTest` / `BookingOptionalFieldsTest` updated to the `events` payload — 37 pass
- [x] New tests: multi-event create (one Event per entry, `end_time` default), reject event without `start_time` (422), reject empty `events` array (422)
- [x] Full backend suite: 1028 pass. The 1 unrelated failure (`AdvancePageMapsTest`, a `rehearsal_schedules.frequency` data-truncation issue) pre-exists on `staging` and is untouched by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)