### PR TITLE
fix(bookings): query event dates instead of dropped bookings.date column

### DIFF
--- a/app/Console/Commands/SendDepositReminders.php
+++ b/app/Console/Commands/SendDepositReminders.php
@@ -31,11 +31,13 @@ class SendDepositReminders extends Command
     {
         $this->info('Sending deposit payment reminders...');
 
-        $bookings = Bookings::with(['contract', 'contacts', 'band'])
+        $bookings = Bookings::with(['contract', 'contacts', 'band', 'events'])
             ->whereHas('contract', function ($query) {
                 $query->where('status', 'completed');
             })
-            ->where('date', '>', Carbon::now()) // Only future events
+            ->whereHas('events', function ($query) {
+                $query->where('date', '>', Carbon::now()); // Only future events
+            })
             ->get();
 
         $sentCount = 0;

--- a/app/Console/Commands/SendFinalPaymentReminders.php
+++ b/app/Console/Commands/SendFinalPaymentReminders.php
@@ -31,9 +31,11 @@ class SendFinalPaymentReminders extends Command
     {
         $this->info('Sending final payment reminders...');
 
-        $bookings = Bookings::with(['contacts', 'band'])
-            ->where('date', '>', Carbon::now())
-            ->where('date', '<=', Carbon::now()->addDays(8)) // Within next 8 days
+        $bookings = Bookings::with(['contacts', 'band', 'events'])
+            ->whereHas('events', function ($query) {
+                $query->where('date', '>', Carbon::now())
+                    ->where('date', '<=', Carbon::now()->addDays(8)); // Within next 8 days
+            })
             ->get();
 
         $sentCount = 0;

--- a/app/Http/Controllers/BandsController.php
+++ b/app/Http/Controllers/BandsController.php
@@ -317,8 +317,9 @@ class BandsController extends Controller
             },
             'contacts.bookingContacts.booking' => function ($query)
             {
-                $query->select('id', 'name', 'date');
-            }
+                $query->select('id', 'name');
+            },
+            'contacts.bookingContacts.booking.events',
         ]);
 
         // Transform to only include what we need

--- a/database/factories/RehearsalScheduleFactory.php
+++ b/database/factories/RehearsalScheduleFactory.php
@@ -12,14 +12,14 @@ class RehearsalScheduleFactory extends Factory
 
     public function definition()
     {
-        $frequency = $this->faker->randomElement(['weekly', 'biweekly', 'monthly', 'custom']);
+        $frequency = $this->faker->randomElement(['weekly', 'weekday', 'monthly', 'custom']);
 
         return [
             'band_id' => Bands::factory(),
             'name' => 'Weekly Rehearsal',
             'description' => $this->faker->optional()->sentence,
             'frequency' => $frequency,
-            'day_of_week' => in_array($frequency, ['weekly', 'biweekly'])
+            'day_of_week' => $frequency === 'weekly'
                 ? $this->faker->randomElement(['monday', 'tuesday', 'wednesday', 'thursday', 'friday', 'saturday', 'sunday'])
                 : null,
             'selected_days' => null,

--- a/tests/Feature/BandsControllerTest.php
+++ b/tests/Feature/BandsControllerTest.php
@@ -301,4 +301,29 @@ class BandsControllerTest extends TestCase
             'band_id' => $this->band->id,
         ]);
     }
+
+    public function test_contacts_endpoint_returns_booking_history_with_event_date(): void
+    {
+        $booking = \App\Models\Bookings::factory()->create([
+            'band_id' => $this->band->id,
+            'name' => 'History Booking',
+        ]);
+        Events::factory()->create([
+            'eventable_type' => \App\Models\Bookings::class,
+            'eventable_id' => $booking->id,
+            'date' => '2026-08-15',
+        ]);
+
+        $contact = \App\Models\Contacts::factory()->create(['band_id' => $this->band->id]);
+        $booking->contacts()->attach($contact->id, ['role' => 'primary']);
+
+        $response = $this->actingAs($this->owner)
+            ->getJson("/api/bands/{$this->band->id}/contacts");
+
+        $response->assertOk();
+        $response->assertJsonFragment([
+            'booking_name' => 'History Booking',
+            'date' => '2026-08-15',
+        ]);
+    }
 }

--- a/tests/Feature/PaymentReminderNotificationsTest.php
+++ b/tests/Feature/PaymentReminderNotificationsTest.php
@@ -297,4 +297,83 @@ class PaymentReminderNotificationsTest extends TestCase
 
         $this->assertSame('350.00', $array['deposit_due']);
     }
+
+    public function test_send_final_reminders_command_runs_and_notifies_for_upcoming_event(): void
+    {
+        Notification::fake();
+
+        $booking = Bookings::factory()->create([
+            'band_id' => $this->band->id,
+            'name' => 'Upcoming Gala',
+            'price' => 2000.00,
+        ]);
+        \App\Models\Events::factory()->create([
+            'eventable_type' => Bookings::class,
+            'eventable_id' => $booking->id,
+            'date' => now()->addDays(7)->format('Y-m-d'),
+        ]);
+        $booking->payments()->create([
+            'name' => 'Partial',
+            'band_id' => $this->band->id,
+            'amount' => 500,
+            'date' => now(),
+            'status' => 'paid',
+        ]);
+
+        $contact = Contacts::factory()->create(['band_id' => $this->band->id]);
+        $booking->contacts()->attach($contact->id, ['role' => 'primary']);
+
+        $this->artisan('payments:send-final-reminders')->assertExitCode(0);
+
+        Notification::assertSentTo($contact, FinalPaymentReminder::class);
+    }
+
+    public function test_send_final_reminders_command_ignores_bookings_with_distant_events(): void
+    {
+        Notification::fake();
+
+        $booking = Bookings::factory()->create([
+            'band_id' => $this->band->id,
+            'price' => 2000.00,
+        ]);
+        \App\Models\Events::factory()->create([
+            'eventable_type' => Bookings::class,
+            'eventable_id' => $booking->id,
+            'date' => now()->addMonths(2)->format('Y-m-d'),
+        ]);
+
+        $contact = Contacts::factory()->create(['band_id' => $this->band->id]);
+        $booking->contacts()->attach($contact->id, ['role' => 'primary']);
+
+        $this->artisan('payments:send-final-reminders')->assertExitCode(0);
+
+        Notification::assertNothingSent();
+    }
+
+    public function test_send_deposit_reminders_command_runs_and_notifies(): void
+    {
+        Notification::fake();
+
+        $booking = Bookings::factory()->create([
+            'band_id' => $this->band->id,
+            'price' => 1000.00,
+        ]);
+        \App\Models\Events::factory()->create([
+            'eventable_type' => Bookings::class,
+            'eventable_id' => $booking->id,
+            'date' => now()->addMonths(2)->format('Y-m-d'),
+        ]);
+        $contract = $booking->contract()->create([
+            'status' => 'completed',
+            'author_id' => $this->user->id,
+        ]);
+        $contract->forceFill(['updated_at' => now()->subWeeks(3)])->saveQuietly();
+
+        $contact = Contacts::factory()->create(['band_id' => $this->band->id]);
+        $booking->contacts()->attach($contact->id, ['role' => 'primary']);
+
+        $this->artisan('payments:send-deposit-reminders')->assertExitCode(0);
+
+        Notification::assertSentTo($contact, DepositPaymentReminder::class);
+    }
 }


### PR DESCRIPTION
## Summary

Three production Sentry issues share one root cause: the `bookings.date` column was dropped when event dates moved to the polymorphic `events` table, but three code paths still query `bookings.date` directly — causing `SQLSTATE[42S22]: Unknown column 'date'` errors.

- **`SendFinalPaymentReminders` / `SendDepositReminders`** — replaced `where('date', ...)` with `whereHas('events', ...)` so the date filter runs against the `events` table.
- **`BandsController::contacts`** — the eager-load `select('id','name','date')` referenced the missing column; now selects valid columns and eager-loads `booking.events` so the `start_date` accessor resolves.

Fixes TTS-BAND-111, TTS-BAND-112, TTS-BAND-114.

## Test plan

- [x] `payments:send-final-reminders` notifies for upcoming events, skips distant ones
- [x] `payments:send-deposit-reminders` notifies on completed contracts
- [x] `GET /api/bands/{band}/contacts` returns booking history with the event date
- [x] `PaymentReminderNotificationsTest` 13/13 pass
- [x] `BandsControllerTest` 11/11 pass

New tests run the actual commands and endpoint — prior tests only covered the notification classes in isolation, which let this regression ship.

🤖 Generated with [Claude Code](https://claude.com/claude-code)