### PR TITLE
Guard calendar queue jobs against missing data

### DIFF
--- a/app/Jobs/ProcessBookingCreated.php
+++ b/app/Jobs/ProcessBookingCreated.php
@@ -27,7 +27,7 @@ class ProcessBookingCreated implements ShouldQueue, ShouldBeUniqueUntilProcessin
         return 'booking-created-' . $this->booking->id;
     }
 
-    public function handle()
+    public function handle(): void
     {
         Log::info('ProcessBookingCreated job started for booking ID: ' . $this->booking->id);
 
@@ -50,6 +50,7 @@ class ProcessBookingCreated implements ShouldQueue, ShouldBeUniqueUntilProcessin
             if (!$event) {
                 Log::warning('Skipping calendar sync: writeToGoogleCalendar returned no event', [
                     'booking_id' => $this->booking->id,
+                    'band_id'    => $this->booking->band_id,
                 ]);
                 return;
             }

--- a/app/Jobs/ProcessBookingCreated.php
+++ b/app/Jobs/ProcessBookingCreated.php
@@ -35,9 +35,27 @@ class ProcessBookingCreated implements ShouldQueue, ShouldBeUniqueUntilProcessin
         Log::debug('Refreshed booking from database');
 
         try {
-            $event = $this->booking->writeToGoogleCalendar($this->booking->band->bookingCalendar);
+            $bookingCalendar = $this->booking->band->bookingCalendar;
+
+            if (!$bookingCalendar) {
+                Log::warning('Skipping calendar sync: band has no booking calendar', [
+                    'booking_id' => $this->booking->id,
+                    'band_id'    => $this->booking->band_id,
+                ]);
+                return;
+            }
+
+            $event = $this->booking->writeToGoogleCalendar($bookingCalendar);
+
+            if (!$event) {
+                Log::warning('Skipping calendar sync: writeToGoogleCalendar returned no event', [
+                    'booking_id' => $this->booking->id,
+                ]);
+                return;
+            }
+
             Log::info('Created Google Calendar event with ID: ' . $event->id);
-            $this->booking->storeGoogleEventId($this->booking->band->bookingCalendar, $event->id);
+            $this->booking->storeGoogleEventId($bookingCalendar, $event->id);
             Log::info('Created Google Events record for booking ID: ' . $this->booking->id);
         } catch (\Exception $e) {
             Log::error('Failed to update booking in calendar: ' . $e->getMessage());

--- a/app/Models/Events.php
+++ b/app/Models/Events.php
@@ -198,9 +198,8 @@ class Events extends Model implements GoogleCalenderable
                     return null;
                 }
 
-                $decoded = is_string($value) ? json_decode($value) : $value;
-
-                if (is_string($decoded)) {
+                $decoded = $value;
+                for ($i = 0; $i < 4 && is_string($decoded); $i++) {
                     $decoded = json_decode($decoded);
                 }
 

--- a/app/Models/Events.php
+++ b/app/Models/Events.php
@@ -5,6 +5,7 @@ namespace App\Models;
 use Carbon\Carbon;
 use App\Casts\Price;
 use App\Formatters\CalendarEventFormatter;
+use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Model;
 use App\Models\Interfaces\GoogleCalenderable;
 use App\Models\Traits\GoogleCalendarWritable;
@@ -70,7 +71,6 @@ class Events extends Model implements GoogleCalenderable
     ];
 
     protected $casts = [
-        'additional_data' => 'object',
         'date' => 'date:Y-m-d',
         'start_time' => 'datetime:H:i',
         'end_time' => 'datetime:H:i',
@@ -180,6 +180,44 @@ class Events extends Model implements GoogleCalenderable
     public function getResolvedVenueAddressAttribute(): ?string
     {
         return $this->venue_address ?? $this->eventable?->venue_address ?? null;
+    }
+
+    /**
+     * Normalize additional_data to an object on read.
+     *
+     * The column is JSON, but some rows are double-encoded (a JSON string
+     * whose content is itself JSON). Decode until we have an object so every
+     * reader (->public, ->times, ...) is safe regardless of how the row was
+     * stored.
+     */
+    protected function additionalData(): Attribute
+    {
+        return Attribute::make(
+            get: function ($value) {
+                if ($value === null) {
+                    return null;
+                }
+
+                $decoded = is_string($value) ? json_decode($value) : $value;
+
+                if (is_string($decoded)) {
+                    $decoded = json_decode($decoded);
+                }
+
+                return is_object($decoded) ? $decoded : null;
+            },
+            set: function ($value) {
+                // Preserve the prior `object` cast's write behavior: serialize
+                // arrays / objects to JSON. Strings are passed through as-is
+                // (write-side normalization of malformed strings is out of
+                // scope for this change).
+                if ($value === null || is_string($value)) {
+                    return $value;
+                }
+
+                return json_encode($value);
+            },
+        );
     }
 
     public function scopePublic($query)

--- a/docs/superpowers/plans/2026-05-19-calendar-job-crash-guards.md
+++ b/docs/superpowers/plans/2026-05-19-calendar-job-crash-guards.md
@@ -1,0 +1,360 @@
+# Calendar Job Crash Guards — Implementation Plan (PR A)
+
+> **For agentic workers:** Use superpowers:subagent-driven-development to implement this plan task-by-task.
+
+**Goal:** Stop two recurring production crashes in the calendar-sync queue jobs (Sentry TTS-BAND-2J and TTS-BAND-11E) without altering correct behavior.
+
+**Architecture:** Two independent, defensive fixes. (1) `ProcessBookingCreated` dereferences the result of `writeToGoogleCalendar()` without the null-guard its sibling `ProcessEventCreated` already has — add the guard. (2) `Events.additional_data` is cast `object`, but double-encoded rows decode to a *string*; `ProcessEventCreated` then does `additional_data->public` and fatals. Fix the read side once with a model accessor that normalizes any storage shape to an object.
+
+**Scope:** PR A only — crash guards. The separate data-corruption repair (factory fix + migration to un-double-encode existing rows) is a deliberate follow-up (PR B), NOT in this plan.
+
+**Tech Stack:** Laravel 12, PHPUnit 11.
+
+---
+
+## Task 1: Guard `ProcessBookingCreated` against a missing booking calendar
+
+**Files:**
+- Modify: `app/Jobs/ProcessBookingCreated.php`
+- Test: `tests/Feature/ProcessBookingCreatedTest.php` (create)
+
+**Background:** `ProcessBookingCreated::handle()` does:
+```php
+$event = $this->booking->writeToGoogleCalendar($this->booking->band->bookingCalendar);
+Log::info('Created Google Calendar event with ID: ' . $event->id);
+$this->booking->storeGoogleEventId($this->booking->band->bookingCalendar, $event->id);
+```
+`band->bookingCalendar` is a `hasOne` returning `null` when the band has no `type='booking'` calendar. `writeToGoogleCalendar(null)` returns `false` (see `GoogleCalendarWritable` trait). Then `$event->id` fatals: "Attempt to read property id on false". `ProcessEventCreated` already does this correctly with `if ($event) { ... }`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/Feature/ProcessBookingCreatedTest.php`:
+
+```php
+<?php
+
+namespace Tests\Feature;
+
+use App\Jobs\ProcessBookingCreated;
+use App\Models\Bands;
+use App\Models\Bookings;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class ProcessBookingCreatedTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_handle_does_not_throw_when_band_has_no_booking_calendar(): void
+    {
+        // A band with no booking calendar -> writeToGoogleCalendar() returns false.
+        $band = Bands::factory()->create();
+        $booking = Bookings::factory()->create(['band_id' => $band->id]);
+
+        $this->assertNull($band->bookingCalendar);
+
+        // Must not throw "Attempt to read property id on false".
+        (new ProcessBookingCreated($booking))->handle();
+
+        // Nothing was synced.
+        $this->assertDatabaseMissing('google_events', [
+            'google_eventable_id'   => $booking->id,
+            'google_eventable_type' => Bookings::class,
+        ]);
+    }
+}
+```
+
+- [ ] **Step 2: Run the test, confirm it fails**
+
+Run: `docker-compose exec -T app php artisan test --filter=test_handle_does_not_throw_when_band_has_no_booking_calendar`
+Expected: FAIL — `Attempt to read property "id" on false` (or `bool`).
+
+If it instead fails on the `assertNull` (band somehow has a calendar) or a factory error, fix the test setup first — the `Bands` factory must not auto-create a booking calendar. If it does, inspect `database/factories/BandsFactory.php` and create the booking with a band that genuinely has no `type='booking'` calendar row.
+
+- [ ] **Step 3: Add the guard**
+
+In `app/Jobs/ProcessBookingCreated.php`, replace the body of the `try` block. Current:
+
+```php
+        try {
+            $event = $this->booking->writeToGoogleCalendar($this->booking->band->bookingCalendar);
+            Log::info('Created Google Calendar event with ID: ' . $event->id);
+            $this->booking->storeGoogleEventId($this->booking->band->bookingCalendar, $event->id);
+            Log::info('Created Google Events record for booking ID: ' . $this->booking->id);
+        } catch (\Exception $e) {
+            Log::error('Failed to update booking in calendar: ' . $e->getMessage());
+        }
+```
+
+Replace with:
+
+```php
+        try {
+            $bookingCalendar = $this->booking->band->bookingCalendar;
+
+            if (!$bookingCalendar) {
+                Log::warning('Skipping calendar sync: band has no booking calendar', [
+                    'booking_id' => $this->booking->id,
+                    'band_id'    => $this->booking->band_id,
+                ]);
+                return;
+            }
+
+            $event = $this->booking->writeToGoogleCalendar($bookingCalendar);
+
+            if (!$event) {
+                Log::warning('Skipping calendar sync: writeToGoogleCalendar returned no event', [
+                    'booking_id' => $this->booking->id,
+                ]);
+                return;
+            }
+
+            Log::info('Created Google Calendar event with ID: ' . $event->id);
+            $this->booking->storeGoogleEventId($bookingCalendar, $event->id);
+            Log::info('Created Google Events record for booking ID: ' . $this->booking->id);
+        } catch (\Exception $e) {
+            Log::error('Failed to update booking in calendar: ' . $e->getMessage());
+        }
+```
+
+This also fixes a latent bug: the original called `band->bookingCalendar` twice (a second query); now it is fetched once.
+
+- [ ] **Step 4: Run the test, confirm it passes**
+
+Run: `docker-compose exec -T app php artisan test --filter=test_handle_does_not_throw_when_band_has_no_booking_calendar`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/Jobs/ProcessBookingCreated.php tests/Feature/ProcessBookingCreatedTest.php
+git commit -m "fix: guard ProcessBookingCreated against missing booking calendar
+
+writeToGoogleCalendar() returns false when a band has no booking
+calendar; the job then read ->id on false and fataled.
+
+Fixes TTS-BAND-2J"
+```
+
+---
+
+## Task 2: Normalize `Events.additional_data` so a string-typed value never crashes readers
+
+**Files:**
+- Modify: `app/Models/Events.php`
+- Test: `tests/Unit/Models/EventsAdditionalDataTest.php` (create)
+
+**Background:** `additional_data` is cast `'object'`. Some rows store double-encoded JSON (a JSON string whose content is itself JSON). The `object` cast decodes once → a PHP `string`, not `stdClass`. `ProcessEventCreated::handle()` then does `$this->event->additional_data->public` → fatal "Attempt to read property public on string". Confirmed in the DB: `JSON_TYPE(additional_data)` is `STRING` for affected rows, `OBJECT` for healthy ones. `Events.php` also reads `additional_data->times` elsewhere, so the fix must cover all readers.
+
+Fix: replace the `'object'` cast with an accessor that always returns an object (or null), decoding a second time if the cast produced a string. This is purely a read-side normalization — it does NOT rewrite stored data (that is PR B).
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/Unit/Models/EventsAdditionalDataTest.php`:
+
+```php
+<?php
+
+namespace Tests\Unit\Models;
+
+use App\Models\Bookings;
+use App\Models\Events;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Tests\TestCase;
+
+class EventsAdditionalDataTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_additional_data_returns_object_for_normal_json(): void
+    {
+        $event = Events::factory()->create();
+        // Write a clean JSON object directly.
+        DB::table('events')->where('id', $event->id)
+            ->update(['additional_data' => json_encode(['public' => true])]);
+
+        $fresh = Events::find($event->id);
+        $this->assertIsObject($fresh->additional_data);
+        $this->assertTrue($fresh->additional_data->public);
+    }
+
+    public function test_additional_data_returns_object_for_double_encoded_json(): void
+    {
+        $event = Events::factory()->create();
+        // Simulate a double-encoded row: the column holds a JSON *string*
+        // whose decoded content is itself JSON. json_encode twice.
+        DB::table('events')->where('id', $event->id)
+            ->update(['additional_data' => json_encode(json_encode(['public' => true]))]);
+
+        $fresh = Events::find($event->id);
+        $this->assertIsObject($fresh->additional_data);
+        $this->assertTrue($fresh->additional_data->public);
+    }
+
+    public function test_additional_data_is_null_when_absent(): void
+    {
+        $event = Events::factory()->create();
+        DB::table('events')->where('id', $event->id)
+            ->update(['additional_data' => null]);
+
+        $fresh = Events::find($event->id);
+        $this->assertNull($fresh->additional_data);
+    }
+}
+```
+
+- [ ] **Step 2: Run the tests, confirm the double-encoded one fails**
+
+Run: `docker-compose exec -T app php artisan test --filter=EventsAdditionalDataTest`
+Expected: `test_additional_data_returns_object_for_double_encoded_json` FAILS — the `object` cast returns a string, so `assertIsObject` fails / `->public` would error. The other two may pass already.
+
+- [ ] **Step 3: Replace the cast with a normalizing accessor**
+
+In `app/Models/Events.php`:
+
+(a) Remove `'additional_data' => 'object',` from the `$casts` array. Leave the other casts.
+
+(b) Add this accessor method to the class (place it near the other accessors, e.g. just after the `eventable()` relation or with the other `get*Attribute` methods). Add `use Illuminate\Database\Eloquent\Casts\Attribute;` to the imports if not already present:
+
+```php
+    /**
+     * Normalize additional_data to an object on read.
+     *
+     * The column is JSON, but historically some rows were double-encoded
+     * (a JSON string whose content is itself JSON). Decode until we have
+     * an object so every reader (->public, ->times, ...) is safe regardless
+     * of how the row was stored.
+     */
+    protected function additionalData(): Attribute
+    {
+        return Attribute::make(
+            get: function ($value) {
+                if ($value === null) {
+                    return null;
+                }
+
+                $decoded = is_string($value) ? json_decode($value) : $value;
+
+                // A double-encoded row decodes once to a JSON string; decode again.
+                if (is_string($decoded)) {
+                    $decoded = json_decode($decoded);
+                }
+
+                return is_object($decoded) ? $decoded : null;
+            },
+        );
+    }
+```
+
+Note on the raw `$value`: with the `object` cast removed, Eloquent passes the raw DB string to the accessor. `json_decode` of a normal row yields `stdClass`; of a double-encoded row yields a `string`, which the second `json_decode` resolves. A row that is a JSON array or scalar yields a non-object → returns `null` (additional_data is always expected to be an object map; null is the safe neutral value and existing readers already guard with `if ($this->additional_data && ...)`).
+
+- [ ] **Step 4: Run the tests, confirm all pass**
+
+Run: `docker-compose exec -T app php artisan test --filter=EventsAdditionalDataTest`
+Expected: all 3 PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/Models/Events.php tests/Unit/Models/EventsAdditionalDataTest.php
+git commit -m "fix: normalize Events.additional_data to an object on read
+
+Double-encoded JSON rows decoded to a string under the object cast,
+crashing readers like additional_data->public. Replace the cast with
+an accessor that decodes until it has an object.
+
+Fixes TTS-BAND-11E"
+```
+
+---
+
+## Task 3: Regression test — `ProcessEventCreated` survives a double-encoded row
+
+**Files:**
+- Test: `tests/Feature/ProcessEventCreatedTest.php` (create)
+
+**Background:** Task 2 fixes the root cause (the accessor). This task adds a job-level regression test proving `ProcessEventCreated::handle()` no longer crashes on a double-encoded `additional_data` row — the exact production scenario of TTS-BAND-11E.
+
+- [ ] **Step 1: Write the test**
+
+Create `tests/Feature/ProcessEventCreatedTest.php`:
+
+```php
+<?php
+
+namespace Tests\Feature;
+
+use App\Jobs\ProcessEventCreated;
+use App\Models\Bands;
+use App\Models\Bookings;
+use App\Models\Events;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Tests\TestCase;
+
+class ProcessEventCreatedTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_handle_does_not_crash_on_double_encoded_additional_data(): void
+    {
+        // A band with no calendars -> writeToGoogleCalendar returns false,
+        // so the job exercises the additional_data->public branch without
+        // needing real Google API calls.
+        $band = Bands::factory()->create();
+        $booking = Bookings::factory()->create(['band_id' => $band->id]);
+        $event = Events::factory()->create([
+            'eventable_type' => Bookings::class,
+            'eventable_id'   => $booking->id,
+        ]);
+
+        // Double-encode additional_data, the exact corruption from TTS-BAND-11E.
+        DB::table('events')->where('id', $event->id)
+            ->update(['additional_data' => json_encode(json_encode(['public' => true]))]);
+
+        // Must not throw "Attempt to read property public on string".
+        (new ProcessEventCreated($event))->handle();
+
+        // Job ran to completion; no Google event row created (no calendar).
+        $this->assertDatabaseMissing('google_events', [
+            'google_eventable_id'   => $event->id,
+            'google_eventable_type' => Events::class,
+        ]);
+    }
+}
+```
+
+- [ ] **Step 2: Run the test, confirm it passes**
+
+Run: `docker-compose exec -T app php artisan test --filter=test_handle_does_not_crash_on_double_encoded_additional_data`
+Expected: PASS (Task 2's accessor makes `additional_data->public` safe).
+
+If it FAILS with "Attempt to read property public on string", Task 2's accessor is not covering the job's read path — investigate `ProcessEventCreated.php:48` and the accessor before proceeding.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/Feature/ProcessEventCreatedTest.php
+git commit -m "test: ProcessEventCreated survives double-encoded additional_data"
+```
+
+---
+
+## Task 4: Verification
+
+- [ ] **Step 1: Run all four new/affected test files**
+
+Run: `docker-compose exec -T app php artisan test --filter='ProcessBookingCreatedTest|EventsAdditionalDataTest|ProcessEventCreatedTest'`
+Expected: all PASS.
+
+- [ ] **Step 2: Run the broader calendar/event suite for regressions**
+
+Run: `docker-compose exec -T app php artisan test --filter='Calendar|EventsToGoogle|BookingsToGoogle|EventObserver|BookingObserver'`
+Expected: all PASS. The `additional_data` accessor change is the one with regression risk — if any existing test that reads `additional_data` fails, investigate before proceeding.
+
+- [ ] **Step 3: Confirm clean state**
+
+Run: `git status --short`
+Expected: clean (only the unrelated untracked `.pki/` directory, if present).

--- a/tests/Feature/ProcessBookingCreatedTest.php
+++ b/tests/Feature/ProcessBookingCreatedTest.php
@@ -13,7 +13,7 @@ class ProcessBookingCreatedTest extends TestCase
 {
     use RefreshDatabase;
 
-    public function test_handle_does_not_throw_when_band_has_no_booking_calendar(): void
+    public function test_handle_skips_calendar_sync_when_band_has_no_booking_calendar(): void
     {
         $band = Bands::factory()->create();
         $booking = Bookings::factory()->create(['band_id' => $band->id]);

--- a/tests/Feature/ProcessBookingCreatedTest.php
+++ b/tests/Feature/ProcessBookingCreatedTest.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Jobs\ProcessBookingCreated;
+use App\Models\Bands;
+use App\Models\Bookings;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Log;
+use Tests\TestCase;
+
+class ProcessBookingCreatedTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_handle_does_not_throw_when_band_has_no_booking_calendar(): void
+    {
+        $band = Bands::factory()->create();
+        $booking = Bookings::factory()->create(['band_id' => $band->id]);
+
+        $this->assertNull($band->bookingCalendar);
+
+        Log::spy();
+
+        (new ProcessBookingCreated($booking))->handle();
+
+        Log::shouldHaveReceived('warning')
+            ->withArgs(fn (string $message): bool => str_contains($message, 'has no booking calendar'))
+            ->once();
+
+        Log::shouldNotHaveReceived('error');
+
+        $this->assertDatabaseMissing('google_events', [
+            'google_eventable_id'   => $booking->id,
+            'google_eventable_type' => Bookings::class,
+        ]);
+    }
+}

--- a/tests/Feature/ProcessEventCreatedTest.php
+++ b/tests/Feature/ProcessEventCreatedTest.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Jobs\ProcessEventCreated;
+use App\Models\Bands;
+use App\Models\Bookings;
+use App\Models\Events;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+use Tests\TestCase;
+
+class ProcessEventCreatedTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_handle_does_not_crash_on_double_encoded_additional_data(): void
+    {
+        // A band with no calendars -> writeToGoogleCalendar returns false, so
+        // the job exercises the additional_data->public branch (line 48 of
+        // ProcessEventCreated) without needing real Google API calls.
+        $band = Bands::factory()->create();
+        $booking = Bookings::factory()->create(['band_id' => $band->id]);
+        $event = Events::factory()->create([
+            'eventable_type' => Bookings::class,
+            'eventable_id'   => $booking->id,
+        ]);
+
+        // Double-encode additional_data, the exact corruption from TTS-BAND-11E.
+        DB::table('events')->where('id', $event->id)
+            ->update(['additional_data' => json_encode(json_encode(['public' => true]))]);
+
+        // Capture log calls so we can assert the production crash signature
+        // ("Attempt to read property public on string") never appears, even
+        // though ProcessEventCreated::handle() swallows exceptions via try/catch.
+        $loggedErrors = [];
+        Log::shouldReceive('info')->andReturnUsing(function () {});
+        Log::shouldReceive('debug')->andReturnUsing(function () {});
+        Log::shouldReceive('warning')->andReturnUsing(function () {});
+        Log::shouldReceive('error')->andReturnUsing(function ($message) use (&$loggedErrors) {
+            $loggedErrors[] = $message;
+        });
+
+        // Must not throw "Attempt to read property public on string".
+        (new ProcessEventCreated($event))->handle();
+
+        foreach ($loggedErrors as $message) {
+            $this->assertStringNotContainsString(
+                'Attempt to read property "public" on string',
+                $message,
+                'ProcessEventCreated swallowed the TTS-BAND-11E crash via try/catch — accessor regression.',
+            );
+        }
+
+        // Job ran to completion; no Google event row created (no calendar).
+        $this->assertDatabaseMissing('google_events', [
+            'google_eventable_id'   => $event->id,
+            'google_eventable_type' => Events::class,
+        ]);
+    }
+}

--- a/tests/Feature/ProcessEventCreatedTest.php
+++ b/tests/Feature/ProcessEventCreatedTest.php
@@ -9,6 +9,7 @@ use App\Models\Events;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
+use Mockery;
 use Tests\TestCase;
 
 class ProcessEventCreatedTest extends TestCase
@@ -31,27 +32,17 @@ class ProcessEventCreatedTest extends TestCase
         DB::table('events')->where('id', $event->id)
             ->update(['additional_data' => json_encode(json_encode(['public' => true]))]);
 
-        // Capture log calls so we can assert the production crash signature
-        // ("Attempt to read property public on string") never appears, even
-        // though ProcessEventCreated::handle() swallows exceptions via try/catch.
-        $loggedErrors = [];
-        Log::shouldReceive('info')->andReturnUsing(function () {});
-        Log::shouldReceive('debug')->andReturnUsing(function () {});
-        Log::shouldReceive('warning')->andReturnUsing(function () {});
-        Log::shouldReceive('error')->andReturnUsing(function ($message) use (&$loggedErrors) {
-            $loggedErrors[] = $message;
-        });
+        Log::spy();
 
-        // Must not throw "Attempt to read property public on string".
         (new ProcessEventCreated($event))->handle();
 
-        foreach ($loggedErrors as $message) {
-            $this->assertStringNotContainsString(
-                'Attempt to read property "public" on string',
-                $message,
-                'ProcessEventCreated swallowed the TTS-BAND-11E crash via try/catch — accessor regression.',
-            );
-        }
+        // The job swallows throws into Log::error, so a "no throw" assertion
+        // alone would pass even when the bug is present. Assert the exact
+        // production crash signature was never logged.
+        Log::shouldNotHaveReceived('error', [Mockery::on(
+            fn ($message) => is_string($message)
+                && str_contains($message, 'Attempt to read property "public" on string')
+        )]);
 
         // Job ran to completion; no Google event row created (no calendar).
         $this->assertDatabaseMissing('google_events', [

--- a/tests/Unit/Models/EventsAdditionalDataTest.php
+++ b/tests/Unit/Models/EventsAdditionalDataTest.php
@@ -44,4 +44,33 @@ class EventsAdditionalDataTest extends TestCase
         $fresh = Events::find($event->id);
         $this->assertNull($fresh->additional_data);
     }
+
+    public function test_additional_data_returns_null_for_json_array_payload(): void
+    {
+        // The column semantically holds an object map. A JSON array payload
+        // is malformed for our purposes and returns null rather than letting
+        // an array silently flow to ->public / ->times readers.
+        $event = Events::factory()->create();
+        DB::table('events')->where('id', $event->id)
+            ->update(['additional_data' => json_encode(['one', 'two', 'three'])]);
+
+        $fresh = Events::find($event->id);
+        $this->assertNull($fresh->additional_data);
+    }
+
+    public function test_assigning_array_to_additional_data_round_trips_through_set(): void
+    {
+        // The `set` closure preserves the prior `object` cast's write behavior
+        // by json_encoding arrays/objects. Without this, the 32 call sites that
+        // assign PHP arrays to additional_data would fail with "Array to string
+        // conversion" on save.
+        $event = Events::factory()->create();
+        $event->additional_data = ['public' => true, 'venue' => 'Studio A'];
+        $event->save();
+
+        $fresh = Events::find($event->id);
+        $this->assertIsObject($fresh->additional_data);
+        $this->assertTrue($fresh->additional_data->public);
+        $this->assertSame('Studio A', $fresh->additional_data->venue);
+    }
 }

--- a/tests/Unit/Models/EventsAdditionalDataTest.php
+++ b/tests/Unit/Models/EventsAdditionalDataTest.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Tests\Unit\Models;
+
+use App\Models\Events;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Tests\TestCase;
+
+class EventsAdditionalDataTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_additional_data_returns_object_for_normal_json(): void
+    {
+        $event = Events::factory()->create();
+        DB::table('events')->where('id', $event->id)
+            ->update(['additional_data' => json_encode(['public' => true])]);
+
+        $fresh = Events::find($event->id);
+        $this->assertIsObject($fresh->additional_data);
+        $this->assertTrue($fresh->additional_data->public);
+    }
+
+    public function test_additional_data_returns_object_for_double_encoded_json(): void
+    {
+        $event = Events::factory()->create();
+        // Simulate the production corruption: the column holds a JSON string
+        // whose decoded content is itself JSON.
+        DB::table('events')->where('id', $event->id)
+            ->update(['additional_data' => json_encode(json_encode(['public' => true]))]);
+
+        $fresh = Events::find($event->id);
+        $this->assertIsObject($fresh->additional_data);
+        $this->assertTrue($fresh->additional_data->public);
+    }
+
+    public function test_additional_data_is_null_when_absent(): void
+    {
+        $event = Events::factory()->create();
+        DB::table('events')->where('id', $event->id)
+            ->update(['additional_data' => null]);
+
+        $fresh = Events::find($event->id);
+        $this->assertNull($fresh->additional_data);
+    }
+}


### PR DESCRIPTION
## Summary

Fix two recurring production crashes in the calendar-sync queue jobs without touching the underlying data corruption (that's a deliberate follow-up — **PR B**).

- **TTS-BAND-2J** (181 occurrences) — `ProcessBookingCreated::handle()` crashed with *"Attempt to read property `id` on false"* when a band had no booking calendar. `writeToGoogleCalendar(null)` returns `false`, then `$event->id` fataled. Added falsy-guards mirroring the pattern `ProcessEventCreated` already uses, plus a single-fetch of `band->bookingCalendar`.
- **TTS-BAND-11E** (156 occurrences) — `ProcessEventCreated::handle()` crashed with *"Attempt to read property `public` on string"* when an `events.additional_data` row was double-encoded JSON (confirmed in DB: `JSON_TYPE` returns `STRING` for affected rows). Replaced the `'object'` cast with an `additionalData(): Attribute` accessor that decodes until it has an object (bounded loop, up to 4 hops). A minimal `set` mutator preserves the prior cast's write-side behavior (json_encode arrays/objects) so the 32 existing call sites that assign arrays continue to work — write-side **normalization** stays in PR B's scope.

Fixes TTS-BAND-2J, TTS-BAND-11E.

## Out of scope — PR B (data repair)

- `EventsFactory.php` does `'additional_data' => json_encode([...])` — passing an already-encoded string into the cast, which encodes it again. Source of the corruption.
- A migration/command to un-double-encode existing production rows (rows where `JSON_TYPE(additional_data) = 'STRING'`).
- **`app/Models/Rehearsal.php` still has the same `'object'` cast on `additional_data`** — if rehearsals have the same double-encoding bug, the same crash signature could fire from rehearsal readers. PR B's repair should cover this table too (or a matching accessor added).

PR A doesn't depend on PR B — once these guards land, the crashes stop firing.

## Test plan

- [x] `ProcessBookingCreatedTest` — 1 test using `Log::spy()` (the job's `try/catch` swallows throws, so a "does not throw" assertion is insufficient); verified to FAIL on buggy code and PASS on fixed
- [x] `EventsAdditionalDataTest` — 5 tests: normal JSON, double-encoded JSON, null, array-payload-returns-null, and set-path round-trip
- [x] `ProcessEventCreatedTest` — 1 test asserting the exact production error signature is never logged; verified via revert to FAIL on pre-accessor code and PASS on fixed
- [x] Broader regression suite — 58 tests across `Calendar|EventsToGoogle|BookingsToGoogle|EventObserver|BookingObserver|PublicCalendarSync` all PASS, plus 217 across `SubInvitation|Questionnaire|BookingService|Events` when the accessor was being validated

🤖 Generated with [Claude Code](https://claude.com/claude-code)