### PR TITLE
refactor: pass raw array to additional_data in EventsFactory

### DIFF
--- a/database/factories/EventsFactory.php
+++ b/database/factories/EventsFactory.php
@@ -17,11 +17,11 @@ class EventsFactory extends Factory
     public function definition()
     {
         return [
-            'additional_data' => json_encode([
+            'additional_data' => [
                 'key1' => $this->faker->word,
                 'key2' => $this->faker->numberBetween(1, 100),
                 'key3' => $this->faker->sentence,
-            ]),
+            ],
             'date' => $this->faker->date(),
             'event_type_id' => function ()
             {


### PR DESCRIPTION
## Summary

Small cleanup of `database/factories/EventsFactory.php`. The factory was calling `json_encode([...])` on the `additional_data` attribute. Under the old `'object'` cast this produced double-encoded rows (the source of the 10 corrupted rows that caused TTS-BAND-11E, since cleaned up). Under PR #396's accessor + `set` mutator the line happens to work by accident — strings pass through the mutator unchanged — but it bypasses the encoding path the rest of the codebase uses and obscures intent.

Hand the mutator a raw array, like every other call site.

## Not a bug fix

I started writing a regression test that asserted the factory produces `JSON_TYPE = 'OBJECT'` rows. Under the current `set` mutator, both the buggy and fixed factory produce `OBJECT` rows — so the test would have been false-positive theater. Deleted it. This PR is honest code hygiene, not a regression fix.

The production data corruption itself (the 10 double-encoded rows) is being repaired separately via an out-of-band SQL `UPDATE` rather than a migration, since it's a one-shot cleanup.

## Test plan

- [x] Existing `EventsAdditionalDataTest` (5 tests) continues to pass — confirms factory-produced rows still read correctly
- [x] Broader spot-check: `ProcessEventCreatedTest|EventGoogleCalendarUpdateTest|EventsToGoogleCalendarTest|EventObserver` (30 tests, 51 assertions) all PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)