### PR TITLE
fix: bind Show Time input to event start_time in booking editor

### DIFF
--- a/resources/js/Pages/Bookings/Components/EventEditor/BasicInfo.vue
+++ b/resources/js/Pages/Bookings/Components/EventEditor/BasicInfo.vue
@@ -21,9 +21,10 @@
     <div>
       <Input
         id="time"
-        v-model="modelValue.time"
+        v-model="modelValue.start_time"
         label="Show Time"
         type="time"
+        dusk="event-show-time"
         class="w-full p-2 border dark:bg-slate-700 dark:text-gray-50 rounded"
       />
     </div>

--- a/tests/Browser/EventTest.php
+++ b/tests/Browser/EventTest.php
@@ -129,6 +129,36 @@ class EventTest extends DuskTestCase
         });
     }
 
+    public function test_booking_event_editor_populates_show_time(): void
+    {
+        $booking = Bookings::factory()->create([
+            'band_id' => $this->band->id,
+            'name' => 'Jones Wedding',
+        ]);
+
+        $contact = Contacts::factory()->create([
+            'band_id' => $this->band->id,
+            'name' => 'Jane Jones',
+            'email' => 'show-time-contact@test.local',
+        ]);
+        $booking->contacts()->attach($contact, ['is_primary' => true]);
+
+        $event = Events::factory()->create([
+            'eventable_type' => Bookings::class,
+            'eventable_id' => $booking->id,
+            'title' => 'Jones Wedding',
+            'start_time' => '19:30',
+        ]);
+
+        $this->browse(function (Browser $browser) use ($event) {
+            $browser->loginAs($this->owner)
+                ->visit("/events/{$event->key}/edit")
+                ->waitForText('Jones Wedding', 10)
+                ->waitFor('@event-show-time', 10)
+                ->assertInputValue('@event-show-time', '19:30');
+        });
+    }
+
     public function test_user_can_delete_a_legacy_band_event(): void
     {
         $event = BandEvents::factory()->create([


### PR DESCRIPTION
## Summary
- The Show Time field on the booking event editor's Basic Information card was bound to a non-existent `time` property, so it always rendered `--:--` even when the event had a `start_time` set (visible in the timeline directly below it).
- Rebound the input to `modelValue.start_time` so it reflects the persisted value and edits round-trip.
- Added a Dusk regression test that seeds a booking event with a known `start_time` and asserts the Show Time input renders it.

## Test plan
- [ ] `php artisan dusk --filter=test_booking_event_editor_populates_show_time` passes
- [ ] Open an existing booking event in the editor — Show Time displays the event's start time (not `--:--`)
- [ ] Change the Show Time, save, reopen — new value persists

🤖 Generated with [Claude Code](https://claude.com/claude-code)