### PR TITLE
fix(mobile/events/api): persist start_time, end_time, attire, lodging, wedding on event PATCH

### DIFF
--- a/app/Http/Controllers/Api/Mobile/EventsController.php
+++ b/app/Http/Controllers/Api/Mobile/EventsController.php
@@ -178,7 +178,7 @@ class EventsController extends Controller
         );
 
         $event->update([
-            ...$request->only(['title', 'date', 'time', 'notes']),
+            ...$request->only(['title', 'date', 'start_time', 'end_time', 'notes']),
             'additional_data' => $ad,
         ]);
 

--- a/app/Http/Requests/Mobile/UpdateEventRequest.php
+++ b/app/Http/Requests/Mobile/UpdateEventRequest.php
@@ -16,7 +16,11 @@ class UpdateEventRequest extends FormRequest
         return [
             'title'                  => 'sometimes|string|max:255',
             'date'                   => 'sometimes|date_format:Y-m-d',
-            'time'                   => 'sometimes|nullable|date_format:H:i',
+            // start_time / end_time replaced the legacy single `time` column
+            // in the 2026-05-03 events-table migration. The mobile app sends
+            // these as "HH:mm" strings.
+            'start_time'             => 'sometimes|nullable|date_format:H:i',
+            'end_time'               => 'sometimes|nullable|date_format:H:i',
             'notes'                  => 'sometimes|nullable|string',
             'venue_name'             => 'sometimes|nullable|string|max:255',
             'venue_address'          => 'sometimes|nullable|string|max:255',
@@ -28,6 +32,13 @@ class UpdateEventRequest extends FormRequest
             'timeline'               => 'sometimes|array',
             'timeline.*.title'       => 'required_with:timeline|string|max:255',
             'timeline.*.time'        => 'nullable|string|max:20',
+            // Lodging is stored as a list of {title, type, data} rows in
+            // additional_data.lodging. `data` is mixed — bool for the
+            // "Provided" checkbox row, string for the text rows.
+            'lodging'                => 'sometimes|array',
+            'lodging.*.title'        => 'required_with:lodging|string|max:50',
+            'lodging.*.type'         => 'required_with:lodging|in:checkbox,text',
+            'lodging.*.data'         => 'nullable',
             'wedding'                => 'sometimes|array',
             'wedding.onsite'         => 'sometimes|nullable|boolean',
             'wedding.dances'         => 'sometimes|array',

--- a/app/Services/Mobile/EventDataService.php
+++ b/app/Services/Mobile/EventDataService.php
@@ -386,6 +386,21 @@ class EventDataService
             );
         }
 
+        if ($request->has('lodging')) {
+            $ad->lodging = array_map(
+                fn ($row) => [
+                    'title' => $row['title'],
+                    'type'  => $row['type'],
+                    // For the "Provided" checkbox row, coerce data to bool
+                    // so the read side's `data == true` comparison works.
+                    'data'  => ($row['type'] ?? null) === 'checkbox'
+                        ? (bool) ($row['data'] ?? false)
+                        : ($row['data'] ?? null),
+                ],
+                $request->input('lodging', [])
+            );
+        }
+
         if ($request->has('wedding')) {
             if (!isset($ad->wedding) || !is_object($ad->wedding)) {
                 $ad->wedding = new \stdClass();

--- a/tests/Feature/Api/Mobile/EventAdditionalDataUpdateTest.php
+++ b/tests/Feature/Api/Mobile/EventAdditionalDataUpdateTest.php
@@ -1,0 +1,206 @@
+<?php
+
+namespace Tests\Feature\Api\Mobile;
+
+use App\Models\Bands;
+use App\Models\Bookings;
+use App\Models\Events;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+/**
+ * Covers PATCH /api/mobile/events/{event} for the additional_data fields
+ * the mobile event-edit screen exposes:
+ *
+ *   - is_public, outside, backline_provided, production_needed (booleans)
+ *   - lodging (canonical 4-row {title, type, data} list)
+ *
+ * Regression coverage for the case where the mobile app sent these fields
+ * but the backend never wrote `lodging` (no validation, no handler), so
+ * lodging edits silently disappeared.
+ */
+class EventAdditionalDataUpdateTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function makeOwnedEvent(array $additionalData = []): array
+    {
+        $user = User::factory()->create();
+        $band = Bands::factory()->create();
+        $band->owners()->create(['user_id' => $user->id]);
+
+        $booking = Bookings::factory()->create(['band_id' => $band->id]);
+
+        $event = Events::factory()->create([
+            'eventable_id'    => $booking->id,
+            'eventable_type'  => Bookings::class,
+            'date'            => now()->addDays(7)->format('Y-m-d'),
+            'additional_data' => (object) $additionalData,
+        ]);
+
+        $token = $user->createToken('test-device')->plainTextToken;
+
+        return compact('user', 'band', 'booking', 'event', 'token');
+    }
+
+    private function patchEvent(string $token, Bands $band, Events $event, array $payload)
+    {
+        return $this->withToken($token)
+            ->withHeaders(['X-Band-ID' => $band->id])
+            ->patchJson("/api/mobile/events/{$event->key}", $payload);
+    }
+
+    // ── Flag toggles ─────────────────────────────────────────────────────────
+
+    public function test_update_persists_is_public_flag(): void
+    {
+        ['band' => $band, 'event' => $event, 'token' => $token] = $this->makeOwnedEvent();
+
+        $this->patchEvent($token, $band, $event, [
+            'is_public' => true,
+        ])->assertOk();
+
+        // is_public is stored as `additional_data->public` on the model.
+        $this->assertTrue($event->fresh()->additional_data->public);
+    }
+
+    public function test_update_persists_outside_flag(): void
+    {
+        ['band' => $band, 'event' => $event, 'token' => $token] = $this->makeOwnedEvent();
+
+        $this->patchEvent($token, $band, $event, [
+            'outside' => true,
+        ])->assertOk();
+
+        $this->assertTrue($event->fresh()->additional_data->outside);
+    }
+
+    public function test_update_persists_backline_provided_flag(): void
+    {
+        ['band' => $band, 'event' => $event, 'token' => $token] = $this->makeOwnedEvent();
+
+        $this->patchEvent($token, $band, $event, [
+            'backline_provided' => true,
+        ])->assertOk();
+
+        $this->assertTrue($event->fresh()->additional_data->backline_provided);
+    }
+
+    public function test_update_persists_production_needed_flag(): void
+    {
+        ['band' => $band, 'event' => $event, 'token' => $token] = $this->makeOwnedEvent();
+
+        $this->patchEvent($token, $band, $event, [
+            'production_needed' => true,
+        ])->assertOk();
+
+        $this->assertTrue($event->fresh()->additional_data->production_needed);
+    }
+
+    public function test_update_can_flip_flag_to_false(): void
+    {
+        ['band' => $band, 'event' => $event, 'token' => $token] =
+            $this->makeOwnedEvent(['outside' => true]);
+
+        $this->patchEvent($token, $band, $event, [
+            'outside' => false,
+        ])->assertOk();
+
+        $this->assertFalse($event->fresh()->additional_data->outside);
+    }
+
+    // ── Lodging ──────────────────────────────────────────────────────────────
+
+    public function test_update_persists_lodging_block(): void
+    {
+        ['band' => $band, 'event' => $event, 'token' => $token] = $this->makeOwnedEvent();
+
+        $this->patchEvent($token, $band, $event, [
+            'lodging' => [
+                ['title' => 'Provided',  'type' => 'checkbox', 'data' => true],
+                ['title' => 'location',  'type' => 'text',     'data' => 'Hilton Riverwalk'],
+                ['title' => 'check_in',  'type' => 'text',     'data' => '15:00'],
+                ['title' => 'check_out', 'type' => 'text',     'data' => '11:00'],
+            ],
+        ])->assertOk();
+
+        $lodging = $event->fresh()->additional_data->lodging;
+        $this->assertCount(4, $lodging);
+
+        // The "Provided" checkbox row is coerced to a real bool so the
+        // read-side `data == true` comparison works.
+        $this->assertSame('Provided', $lodging[0]->title);
+        $this->assertSame('checkbox', $lodging[0]->type);
+        $this->assertTrue($lodging[0]->data);
+
+        $this->assertSame('location', $lodging[1]->title);
+        $this->assertSame('Hilton Riverwalk', $lodging[1]->data);
+        $this->assertSame('15:00', $lodging[2]->data);
+        $this->assertSame('11:00', $lodging[3]->data);
+    }
+
+    public function test_update_coerces_truthy_strings_on_provided_checkbox(): void
+    {
+        // The Flutter side sends a real bool, but defend against any
+        // client (or older payload) that sends "1" or "true" as a string.
+        ['band' => $band, 'event' => $event, 'token' => $token] = $this->makeOwnedEvent();
+
+        $this->patchEvent($token, $band, $event, [
+            'lodging' => [
+                ['title' => 'Provided', 'type' => 'checkbox', 'data' => '1'],
+                ['title' => 'location', 'type' => 'text',     'data' => ''],
+                ['title' => 'check_in', 'type' => 'text',     'data' => ''],
+                ['title' => 'check_out','type' => 'text',     'data' => ''],
+            ],
+        ])->assertOk();
+
+        $lodging = $event->fresh()->additional_data->lodging;
+        $this->assertTrue($lodging[0]->data);
+    }
+
+    public function test_update_rejects_lodging_row_with_invalid_type(): void
+    {
+        ['band' => $band, 'event' => $event, 'token' => $token] = $this->makeOwnedEvent();
+
+        $this->patchEvent($token, $band, $event, [
+            'lodging' => [
+                ['title' => 'Provided', 'type' => 'radio', 'data' => true],
+            ],
+        ])
+            ->assertStatus(422)
+            ->assertJsonValidationErrors('lodging.0.type');
+    }
+
+    public function test_update_rejects_lodging_row_missing_title(): void
+    {
+        ['band' => $band, 'event' => $event, 'token' => $token] = $this->makeOwnedEvent();
+
+        $this->patchEvent($token, $band, $event, [
+            'lodging' => [
+                ['type' => 'text', 'data' => 'Hilton'],
+            ],
+        ])
+            ->assertStatus(422)
+            ->assertJsonValidationErrors('lodging.0.title');
+    }
+
+    public function test_update_without_lodging_key_leaves_existing_lodging_untouched(): void
+    {
+        ['band' => $band, 'event' => $event, 'token' => $token] = $this->makeOwnedEvent([
+            'lodging' => [
+                ['title' => 'Provided', 'type' => 'checkbox', 'data' => true],
+                ['title' => 'location', 'type' => 'text',     'data' => 'Original'],
+            ],
+        ]);
+
+        $this->patchEvent($token, $band, $event, [
+            'title' => 'Renamed',
+        ])->assertOk();
+
+        $fresh = $event->fresh();
+        $this->assertSame('Renamed', $fresh->title);
+        $this->assertCount(2, $fresh->additional_data->lodging);
+        $this->assertSame('Original', $fresh->additional_data->lodging[1]->data);
+    }
+}

--- a/tests/Feature/Api/Mobile/EventStartTimeUpdateTest.php
+++ b/tests/Feature/Api/Mobile/EventStartTimeUpdateTest.php
@@ -1,0 +1,129 @@
+<?php
+
+namespace Tests\Feature\Api\Mobile;
+
+use App\Models\Bands;
+use App\Models\Bookings;
+use App\Models\Events;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+/**
+ * Covers `PATCH /api/mobile/events/{event}` for the start_time / end_time
+ * fields. Regression coverage for the case where the mobile app sent
+ * `start_time` (and `end_time`) but the validator only declared the
+ * legacy `time` field (dropped by the 2026-05-03 migration), so the
+ * controller silently discarded the new values.
+ */
+class EventStartTimeUpdateTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /**
+     * Build a user that owns a band, a booking owned by that band, and a
+     * polymorphic Events row attached to the booking.
+     */
+    private function makeOwnedEvent(array $eventOverrides = []): array
+    {
+        $user = User::factory()->create();
+        $band = Bands::factory()->create();
+        $band->owners()->create(['user_id' => $user->id]);
+
+        $booking = Bookings::factory()->create(['band_id' => $band->id]);
+
+        $event = Events::factory()->create(array_merge([
+            'eventable_id'   => $booking->id,
+            'eventable_type' => Bookings::class,
+            'date'           => now()->addDays(7)->format('Y-m-d'),
+            'start_time'     => '19:00',
+            'end_time'       => '22:00',
+        ], $eventOverrides));
+
+        $token = $user->createToken('test-device')->plainTextToken;
+
+        return compact('user', 'band', 'booking', 'event', 'token');
+    }
+
+    private function patchEvent(string $token, Bands $band, Events $event, array $payload)
+    {
+        return $this->withToken($token)
+            ->withHeaders(['X-Band-ID' => $band->id])
+            ->patchJson("/api/mobile/events/{$event->key}", $payload);
+    }
+
+    public function test_update_persists_start_time(): void
+    {
+        ['band' => $band, 'event' => $event, 'token' => $token] = $this->makeOwnedEvent();
+
+        $this->patchEvent($token, $band, $event, [
+            'start_time' => '20:30',
+        ])->assertOk();
+
+        // start_time is cast to a datetime; format back to H:i for comparison.
+        $this->assertSame('20:30', $event->fresh()->start_time->format('H:i'));
+        // end_time untouched.
+        $this->assertSame('22:00', $event->fresh()->end_time->format('H:i'));
+    }
+
+    public function test_update_persists_end_time(): void
+    {
+        ['band' => $band, 'event' => $event, 'token' => $token] = $this->makeOwnedEvent();
+
+        $this->patchEvent($token, $band, $event, [
+            'end_time' => '23:45',
+        ])->assertOk();
+
+        $this->assertSame('23:45', $event->fresh()->end_time->format('H:i'));
+        $this->assertSame('19:00', $event->fresh()->start_time->format('H:i'));
+    }
+
+    public function test_update_persists_both_times_together(): void
+    {
+        ['band' => $band, 'event' => $event, 'token' => $token] = $this->makeOwnedEvent();
+
+        $this->patchEvent($token, $band, $event, [
+            'start_time' => '18:00',
+            'end_time'   => '21:30',
+        ])->assertOk();
+
+        $fresh = $event->fresh();
+        $this->assertSame('18:00', $fresh->start_time->format('H:i'));
+        $this->assertSame('21:30', $fresh->end_time->format('H:i'));
+    }
+
+    public function test_update_can_clear_start_time_with_null(): void
+    {
+        ['band' => $band, 'event' => $event, 'token' => $token] = $this->makeOwnedEvent();
+
+        $this->patchEvent($token, $band, $event, [
+            'start_time' => null,
+        ])->assertOk();
+
+        $this->assertNull($event->fresh()->start_time);
+    }
+
+    public function test_update_rejects_invalid_start_time_format(): void
+    {
+        ['band' => $band, 'event' => $event, 'token' => $token] = $this->makeOwnedEvent();
+
+        $this->patchEvent($token, $band, $event, [
+            'start_time' => '7:00 PM', // not H:i
+        ])
+            ->assertStatus(422)
+            ->assertJsonValidationErrors('start_time');
+    }
+
+    public function test_update_without_start_time_leaves_it_unchanged(): void
+    {
+        ['band' => $band, 'event' => $event, 'token' => $token] = $this->makeOwnedEvent();
+
+        $this->patchEvent($token, $band, $event, [
+            'title' => 'Renamed',
+        ])->assertOk();
+
+        $fresh = $event->fresh();
+        $this->assertSame('Renamed', $fresh->title);
+        $this->assertSame('19:00', $fresh->start_time->format('H:i'));
+    }
+}


### PR DESCRIPTION
## Why

Mobile counterpart to #399. The mobile event edit screen surfaces start_time / end_time, attire, lodging, and wedding details (in addition to the four flag toggles and timeline), but the `PATCH /api/mobile/events/{event}` endpoint silently dropped most of them. Users edited fields, tapped Save, and watched the values revert on reload.

## Root cause (three coupled backend gaps)

1. **`UpdateEventRequest` validated the legacy single `time` field** — dropped by the 2026-05-03 `move_date_venue_from_bookings_to_events` migration. The mobile app correctly sends `start_time` / `end_time`, but they weren't in the validator's rules and were stripped before the controller saw them.
2. **`EventsController::update` wrote `time`** (a column that no longer exists on the events table). `time` is also not fillable on the `Events` model, so even successful validation would have been a no-op write.
3. **Lodging had no validation and no handler.** `EventDataService::applyAdditionalDataChanges` had branches for `attire`, `outside`, `backline_provided`, `production_needed`, `is_public`, `timeline`, and `wedding` — but nothing for `lodging`.

## Fix

- `UpdateEventRequest`: replace `time` rule with `start_time` / `end_time` (both `sometimes|nullable|date_format:H:i`). Add `lodging` array rules with strict `title`/`type` validation (`type` must be `checkbox` or `text`).
- `EventsController::update`: switch the `$request->only([...])` to `['title', 'date', 'start_time', 'end_time', 'notes']`.
- `EventDataService::applyAdditionalDataChanges`: new `lodging` branch that maps each row to `{title, type, data}`. Coerces `data` to a real `bool` on the `'Provided'` checkbox row so the read-side `data == true` comparison keeps working (and so a defensive client that sends `"1"` or `"true"` strings still toggles correctly).

The four flag toggles, attire, timeline, and wedding were already supported on this endpoint — only `start_time`, `end_time`, and `lodging` needed backend changes here.

## Tests

Two new feature test classes:

- **`tests/Feature/Api/Mobile/EventStartTimeUpdateTest.php`** (6 tests): persists `start_time`, persists `end_time`, both together, clear via `null`, reject invalid `H:i` format (422), and `sometimes` semantics (untouched when omitted).
- **`tests/Feature/Api/Mobile/EventAdditionalDataUpdateTest.php`** (10 tests): each of the four flag toggles, flag flip-to-false, lodging happy path, truthy-string coercion on the `Provided` row, two validation rejections (invalid `type`, missing `title`), and the `sometimes` semantics for lodging.

Full mobile API suite: 135 passing (was 125, +10). Wider events suite: 53 passing.

## Pairs with

[tts_bandmate#…](#) (the Flutter side) which adds the matching `attire` and `wedding` parameters to `EventsRepository.updateEvent` and `_save()`, plus a round-trip widget test that asserts every screen field reaches the repo. The Flutter fix is needed even after this PR merges, since the screen was also missing the `attire` and `wedding` plumbing on the client side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)