### PR TITLE
Leave-by push notification backend

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -66,3 +66,6 @@ GOOGLE_DRIVE_CLIENT_SECRET=
 
 # Anthropic Claude API
 ANTHROPIC_API_KEY=
+
+# Firebase
+FIREBASE_CREDENTIALS=storage/app/firebase/service-account.json

--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,6 @@ tasks/
 CLAUDE.md
 .claude/
 .superpowers/
+
+# Firebase credentials
+/storage/app/firebase/

--- a/app/Console/Commands/SendLeaveByNotifications.php
+++ b/app/Console/Commands/SendLeaveByNotifications.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Services\Push\LeaveByPushService;
+use Illuminate\Console\Command;
+use Illuminate\Support\Carbon;
+
+class SendLeaveByNotifications extends Command
+{
+    protected $signature = 'notifications:tick';
+    protected $description = 'Send due leave-by push notifications for today\'s rostered events';
+
+    public function handle(LeaveByPushService $service): int
+    {
+        $service->run(Carbon::now());
+        $this->info('Leave-by notification tick complete.');
+
+        return self::SUCCESS;
+    }
+}

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -27,6 +27,10 @@ class Kernel extends ConsoleKernel
         // Horizon metrics snapshot (every 5 minutes)
         $schedule->command('horizon:snapshot')->everyFiveMinutes();
 
+        $schedule->command('notifications:tick')
+            ->everyFiveMinutes()
+            ->onOneServer();
+
         // Check for signed PandaDoc contracts every day in case the webhook failed
         $schedule->command('contracts:check-signed')
             ->dailyAt('11:00');

--- a/app/Http/Controllers/Api/Mobile/DevicesController.php
+++ b/app/Http/Controllers/Api/Mobile/DevicesController.php
@@ -23,10 +23,14 @@ class DevicesController extends Controller
         return response()->json(['status' => 'ok']);
     }
 
-    public function destroy(Request $request, string $token): JsonResponse
+    public function destroy(Request $request): JsonResponse
     {
+        // Token comes in the request body, not the URL path: FCM/APNs tokens can
+        // contain '/' and ':' which would break a path-segment route binding.
+        $request->validate(['token' => ['required', 'string', 'max:512']]);
+
         DeviceToken::where('user_id', $request->user()->id)
-            ->where('token', $token)
+            ->where('token', $request->string('token')->toString())
             ->delete();
 
         return response()->json(['status' => 'ok']);

--- a/app/Http/Controllers/Api/Mobile/DevicesController.php
+++ b/app/Http/Controllers/Api/Mobile/DevicesController.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Http\Controllers\Api\Mobile;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Mobile\StoreDeviceTokenRequest;
+use App\Models\DeviceToken;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+class DevicesController extends Controller
+{
+    public function store(StoreDeviceTokenRequest $request): JsonResponse
+    {
+        DeviceToken::updateOrCreate(
+            ['token' => $request->string('token')->toString()],
+            [
+                'user_id'  => $request->user()->id,
+                'platform' => $request->string('platform')->toString(),
+            ],
+        );
+
+        return response()->json(['status' => 'ok']);
+    }
+
+    public function destroy(Request $request, string $token): JsonResponse
+    {
+        DeviceToken::where('user_id', $request->user()->id)
+            ->where('token', $token)
+            ->delete();
+
+        return response()->json(['status' => 'ok']);
+    }
+}

--- a/app/Http/Requests/Mobile/StoreDeviceTokenRequest.php
+++ b/app/Http/Requests/Mobile/StoreDeviceTokenRequest.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Http\Requests\Mobile;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class StoreDeviceTokenRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'token'    => ['required', 'string', 'max:512'],
+            'platform' => ['required', 'in:ios,android'],
+        ];
+    }
+}

--- a/app/Jobs/SendEventPush.php
+++ b/app/Jobs/SendEventPush.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace App\Jobs;
+
+use App\Models\DeviceToken;
+use App\Models\PushNotificationLog;
+use App\Services\Push\FcmSender;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+
+class SendEventPush implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    /**
+     * @param array<string,string> $payload
+     */
+    public function __construct(
+        public int $eventId,
+        public int $userId,
+        public string $type,
+        public array $payload,
+    ) {}
+
+    public function handle(FcmSender $fcm): void
+    {
+        $tokens = DeviceToken::where('user_id', $this->userId)->get();
+        $anyDelivered = false;
+
+        foreach ($tokens as $deviceToken) {
+            $result = $fcm->sendData($deviceToken->token, $this->payload);
+            if ($result === FcmSender::PRUNE) {
+                $deviceToken->delete();
+            } elseif ($result === FcmSender::DELIVERED) {
+                $anyDelivered = true;
+            }
+        }
+
+        if ($anyDelivered) {
+            PushNotificationLog::firstOrCreate(
+                ['event_id' => $this->eventId, 'user_id' => $this->userId, 'type' => $this->type],
+                ['sent_at' => now()],
+            );
+        }
+    }
+}

--- a/app/Models/DeviceToken.php
+++ b/app/Models/DeviceToken.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class DeviceToken extends Model
+{
+    use HasFactory;
+
+    protected $fillable = ['user_id', 'token', 'platform'];
+
+    public function user()
+    {
+        return $this->belongsTo(User::class);
+    }
+}

--- a/app/Models/Events.php
+++ b/app/Models/Events.php
@@ -65,6 +65,7 @@ class Events extends Model implements GoogleCalenderable
         'roster_id',
         'value',
         'venue_address',
+        'venue_timezone',
         'venue_name',
         'media_folder_path',
         'enable_portal_media_access',

--- a/app/Models/PushNotificationLog.php
+++ b/app/Models/PushNotificationLog.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class PushNotificationLog extends Model
+{
+    protected $table = 'push_notification_log';
+
+    protected $fillable = ['event_id', 'user_id', 'type', 'sent_at'];
+
+    protected $casts = ['sent_at' => 'datetime'];
+
+    public function event()
+    {
+        return $this->belongsTo(Events::class, 'event_id');
+    }
+
+    public function user()
+    {
+        return $this->belongsTo(User::class);
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -463,4 +463,9 @@ class User extends Authenticatable
     {
         return $this->hasMany(CalendarAccess::class);
     }
+
+    public function deviceTokens()
+    {
+        return $this->hasMany(\App\Models\DeviceToken::class);
+    }
 }

--- a/app/Services/Push/FcmSender.php
+++ b/app/Services/Push/FcmSender.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Services\Push;
+
+use Illuminate\Support\Facades\Log;
+use Kreait\Firebase\Contract\Messaging;
+use Kreait\Firebase\Exception\Messaging\NotFound;
+use Kreait\Firebase\Exception\MessagingException;
+use Kreait\Firebase\Messaging\CloudMessage;
+
+class FcmSender
+{
+    public const DELIVERED = 'delivered';
+    public const PRUNE = 'prune';      // token is dead; caller should delete it
+    public const TRANSIENT = 'transient';
+
+    public function __construct(private Messaging $messaging) {}
+
+    /**
+     * Send a data-only message to one token.
+     * @param array<string,string> $data
+     */
+    public function sendData(string $token, array $data): string
+    {
+        try {
+            $message = CloudMessage::new()->toToken($token)->withData($data);
+            $this->messaging->send($message);
+            return self::DELIVERED;
+        } catch (NotFound $e) {
+            return self::PRUNE;
+        } catch (MessagingException $e) {
+            Log::warning('FcmSender transient error', ['error' => $e->getMessage()]);
+            return self::TRANSIENT;
+        }
+    }
+}

--- a/app/Services/Push/FcmSender.php
+++ b/app/Services/Push/FcmSender.php
@@ -23,7 +23,7 @@ class FcmSender
     public function sendData(string $token, array $data): string
     {
         try {
-            $message = CloudMessage::new()->toToken($token)->withData($data);
+            $message = CloudMessage::new()->withToken($token)->withData($data);
             $this->messaging->send($message);
             return self::DELIVERED;
         } catch (NotFound $e) {

--- a/app/Services/Push/LeaveByPushService.php
+++ b/app/Services/Push/LeaveByPushService.php
@@ -1,0 +1,162 @@
+<?php
+
+namespace App\Services\Push;
+
+use App\Jobs\SendEventPush;
+use App\Models\EventMember;
+use App\Models\Events;
+use App\Models\PushNotificationLog;
+use Carbon\CarbonInterface;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Log;
+
+class LeaveByPushService
+{
+    public const DEPARTURE_LEAD_MINUTES = 90;
+    public const GRACE_WINDOW_MINUTES = 30;
+
+    public function __construct(private VenueTimezoneResolver $tzResolver) {}
+
+    public function run(CarbonInterface $now): void
+    {
+        foreach ($this->todaysEventsWithRoster($now) as $event) {
+            try {
+                $this->processEvent($event, $now);
+            } catch (\Throwable $e) {
+                Log::error('LeaveByPush: event failed', ['event_id' => $event->id, 'error' => $e->getMessage()]);
+            }
+        }
+    }
+
+    /** @return iterable<Events> */
+    private function todaysEventsWithRoster(CarbonInterface $now): iterable
+    {
+        $from = $now->copy()->subDay()->toDateString();
+        $to = $now->copy()->addDay()->toDateString();
+
+        return Events::query()
+            ->whereBetween('date', [$from, $to])
+            ->whereHas('eventMembers', fn ($q) =>
+                $q->whereNotIn('attendance_status', ['absent', 'excused'])->whereNull('deleted_at'))
+            ->get();
+    }
+
+    private function processEvent(Events $event, CarbonInterface $now): void
+    {
+        $tz = $this->tzResolver->forEvent($event);
+        $firstItem = $this->firstTimelineItem($event);
+
+        $firstTime = $firstItem['time'] ?? $event->start_time;
+        $firstItemDt = $this->combine($event->date, $firstTime, $tz);
+        if ($firstItemDt === null) {
+            return;
+        }
+
+        $sends = [
+            'event_reminder_8h' => $firstItemDt->copy()->subHours(8),
+            'event_departure'   => $firstItemDt->copy()->subMinutes(self::DEPARTURE_LEAD_MINUTES),
+        ];
+
+        foreach ($sends as $type => $sendAt) {
+            if (!$this->isDue($sendAt, $now)) {
+                continue;
+            }
+            $this->dispatchForRecipients($event, $type, $firstItem, $tz, $firstItemDt);
+        }
+    }
+
+    private function isDue(CarbonInterface $sendAt, CarbonInterface $now): bool
+    {
+        return $now->greaterThanOrEqualTo($sendAt)
+            && $now->lessThan($sendAt->copy()->addMinutes(self::GRACE_WINDOW_MINUTES));
+    }
+
+    private function dispatchForRecipients(Events $event, string $type, ?array $firstItem, string $tz, CarbonInterface $firstItemDt): void
+    {
+        $members = EventMember::where('event_id', $event->id)
+            ->whereNotIn('attendance_status', ['absent', 'excused'])
+            ->whereNull('deleted_at')
+            ->whereHas('user.deviceTokens')
+            ->with('user')
+            ->get();
+
+        foreach ($members as $member) {
+            $already = PushNotificationLog::where('event_id', $event->id)
+                ->where('user_id', $member->user_id)
+                ->where('type', $type)
+                ->exists();
+            if ($already) {
+                continue;
+            }
+
+            SendEventPush::dispatch(
+                $event->id,
+                $member->user_id,
+                $type,
+                $this->payload($event, $type, $firstItem, $tz, $firstItemDt),
+            );
+        }
+    }
+
+    /** @return array<string,string> */
+    private function payload(Events $event, string $type, ?array $firstItem, string $tz, CarbonInterface $firstItemDt): array
+    {
+        $data = [
+            'type'     => $type,
+            'eventKey' => (string) $event->key,
+            'title'    => (string) $event->title,
+        ];
+        if (!empty($event->resolved_venue_address)) {
+            $data['venueAddress'] = (string) $event->resolved_venue_address;
+        }
+        if ($firstItem) {
+            $data['firstItemTitle'] = (string) ($firstItem['title'] ?? '');
+            $data['firstItemTime'] = $firstItemDt->toIso8601String();
+        }
+        $showDt = $this->combine($event->date, $event->start_time, $tz);
+        if ($showDt !== null) {
+            $data['showTime'] = $showDt->toIso8601String();
+        }
+
+        return $data;
+    }
+
+    /** Earliest timeline entry from additional_data->times, or null. */
+    private function firstTimelineItem(Events $event): ?array
+    {
+        $ad = $event->additional_data;
+        $times = is_object($ad) ? ($ad->times ?? null) : (is_array($ad) ? ($ad['times'] ?? null) : null);
+        if (!is_array($times) || $times === []) {
+            return null;
+        }
+        $items = [];
+        foreach ($times as $t) {
+            $t = (array) $t;
+            if (!empty($t['time'])) {
+                $items[] = ['title' => $t['title'] ?? '', 'time' => $t['time']];
+            }
+        }
+        if ($items === []) {
+            return null;
+        }
+        usort($items, fn ($a, $b) => strtotime($a['time']) <=> strtotime($b['time']));
+
+        return $items[0];
+    }
+
+    /** Combine a date + time string into a Carbon in the given tz, or null. */
+    private function combine($date, $time, string $tz): ?CarbonInterface
+    {
+        if (empty($time)) {
+            return null;
+        }
+        try {
+            $dateStr = $date instanceof CarbonInterface ? $date->toDateString() : (string) $date;
+            $timeStr = preg_match('/(\d{1,2}:\d{2})/', (string) $time, $m) ? $m[1] : (string) $time;
+
+            return Carbon::parse("{$dateStr} {$timeStr}", $tz);
+        } catch (\Throwable $e) {
+            return null;
+        }
+    }
+}

--- a/app/Services/Push/LeaveByPushService.php
+++ b/app/Services/Push/LeaveByPushService.php
@@ -81,6 +81,12 @@ class LeaveByPushService
             ->get();
 
         foreach ($members as $member) {
+            // Idempotency pre-check. NOTE: the log row is written by SendEventPush
+            // only after delivery, so two ticks within the grace window could both
+            // pass this check and dispatch before either logs — a user could get a
+            // duplicate push. The (event_id,user_id,type) unique index guarantees a
+            // single log row regardless. Acceptable for a reminder; if at-most-once
+            // delivery is ever required, claim the log row here before dispatching.
             $already = PushNotificationLog::where('event_id', $event->id)
                 ->where('user_id', $member->user_id)
                 ->where('type', $type)
@@ -155,7 +161,7 @@ class LeaveByPushService
             $timeStr = preg_match('/(\d{1,2}:\d{2})/', (string) $time, $m) ? $m[1] : (string) $time;
 
             return Carbon::parse("{$dateStr} {$timeStr}", $tz);
-        } catch (\Throwable $e) {
+        } catch (\Throwable) {
             return null;
         }
     }

--- a/app/Services/Push/VenueTimezoneResolver.php
+++ b/app/Services/Push/VenueTimezoneResolver.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace App\Services\Push;
+
+use App\Models\Events;
+use Closure;
+use GoogleMaps\GoogleMaps;
+use Illuminate\Support\Facades\Log;
+
+class VenueTimezoneResolver
+{
+    /** @var Closure(string): ?string  Address → IANA tz (null on failure). */
+    private Closure $lookup;
+
+    public function __construct(?Closure $lookup = null)
+    {
+        $this->lookup = $lookup ?? fn (string $address) => $this->lookupViaGoogle($address);
+    }
+
+    public function forEvent(Events $event): string
+    {
+        if (!empty($event->venue_timezone)) {
+            return $event->venue_timezone;
+        }
+
+        $address = $event->resolved_venue_address;
+        if (empty($address)) {
+            return config('app.timezone');
+        }
+
+        $tz = ($this->lookup)($address);
+        if ($tz === null) {
+            Log::warning('VenueTimezoneResolver: lookup failed, using app tz', [
+                'event_id' => $event->id,
+            ]);
+            return config('app.timezone'); // do not cache the fallback
+        }
+
+        $event->venue_timezone = $tz;
+        $event->save();
+
+        return $tz;
+    }
+
+    private function lookupViaGoogle(string $address): ?string
+    {
+        try {
+            $maps = app(GoogleMaps::class);
+
+            $geo = json_decode(
+                $maps->load('geocoding')->setParamByKey('address', $address)->get(),
+                true,
+            );
+            $loc = $geo['results'][0]['geometry']['location'] ?? null;
+            if (!$loc) {
+                return null;
+            }
+
+            $tzResp = json_decode(
+                $maps->load('timezone')->setParam([
+                    'location'  => "{$loc['lat']},{$loc['lng']}",
+                    'timestamp' => now()->timestamp,
+                ])->get(),
+                true,
+            );
+
+            return $tzResp['timeZoneId'] ?? null;
+        } catch (\Throwable $e) {
+            Log::warning('VenueTimezoneResolver: google lookup threw', ['error' => $e->getMessage()]);
+            return null;
+        }
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,7 @@
         "google/apiclient": "^2.15",
         "guzzlehttp/guzzle": "^7.9",
         "inertiajs/inertia-laravel": "^1.3",
+        "kreait/laravel-firebase": "^7.2",
         "laravel/ai": "^0.5.1",
         "laravel/framework": "^12.0",
         "laravel/horizon": "^5.43",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "611d3c6a8919780d438136590f979a7d",
+    "content-hash": "d6616655190a6757bb015f8209d35f9f",
     "packages": [
         {
             "name": "alexpechkarev/geometry-library",
@@ -523,6 +523,201 @@
             "time": "2026-02-21T08:57:45+00:00"
         },
         {
+            "name": "beste/clock",
+            "version": "3.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/beste/clock.git",
+                "reference": "7004b55fcd54737b539886244b3a3b2188181974"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/beste/clock/zipball/7004b55fcd54737b539886244b3a3b2188181974",
+                "reference": "7004b55fcd54737b539886244b3a3b2188181974",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^8.0",
+                "psr/clock": "^1.0"
+            },
+            "provide": {
+                "psr/clock-implementation": "1.0"
+            },
+            "require-dev": {
+                "phpstan/extension-installer": "^1.2",
+                "phpstan/phpstan": "^1.9.1",
+                "phpstan/phpstan-phpunit": "^1.2.2",
+                "phpstan/phpstan-strict-rules": "^1.4.4",
+                "phpunit/phpunit": "^9.5.26",
+                "psalm/plugin-phpunit": "^0.16.1",
+                "vimeo/psalm": "^4.29"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/Clock.php"
+                ],
+                "psr-4": {
+                    "Beste\\Clock\\": "src/Clock"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jérôme Gamez",
+                    "email": "jerome@gamez.name"
+                }
+            ],
+            "description": "A collection of Clock implementations",
+            "keywords": [
+                "clock",
+                "clock-interface",
+                "psr-20",
+                "psr20"
+            ],
+            "support": {
+                "issues": "https://github.com/beste/clock/issues",
+                "source": "https://github.com/beste/clock/tree/3.0.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/jeromegamez",
+                    "type": "github"
+                }
+            ],
+            "time": "2022-11-26T18:03:05+00:00"
+        },
+        {
+            "name": "beste/in-memory-cache",
+            "version": "1.5.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/beste/in-memory-cache-php.git",
+                "reference": "d6991967b05e820cb1bcd2d31ca11ea8b1ca3f77"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/beste/in-memory-cache-php/zipball/d6991967b05e820cb1bcd2d31ca11ea8b1ca3f77",
+                "reference": "d6991967b05e820cb1bcd2d31ca11ea8b1ca3f77",
+                "shasum": ""
+            },
+            "require": {
+                "php": "~8.3.0 || ~8.4.0 || ~8.5.0",
+                "psr/cache": "^2.0 || ^3.0",
+                "psr/clock": "^1.0"
+            },
+            "provide": {
+                "psr/cache-implementation": "2.0 || 3.0"
+            },
+            "require-dev": {
+                "beste/clock": "^3.0",
+                "friendsofphp/php-cs-fixer": "^3.95.1",
+                "phpstan/extension-installer": "^1.4.3",
+                "phpstan/phpstan": "^2.1.51",
+                "phpstan/phpstan-deprecation-rules": "^2.0.4",
+                "phpstan/phpstan-phpunit": "^2.0.16",
+                "phpstan/phpstan-strict-rules": "^2.0.10",
+                "phpunit/phpunit": "^12.5.23",
+                "symfony/var-dumper": "^7.4.8 || ^v8.0.8"
+            },
+            "suggest": {
+                "psr/clock-implementation": "Allows injecting a Clock, for example a frozen clock for testing"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Beste\\Cache\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jérôme Gamez",
+                    "email": "jerome@gamez.name"
+                }
+            ],
+            "description": "A PSR-6 In-Memory cache that can be used as a fallback implementation and/or in tests.",
+            "keywords": [
+                "beste",
+                "cache",
+                "psr-6"
+            ],
+            "support": {
+                "issues": "https://github.com/beste/in-memory-cache-php/issues",
+                "source": "https://github.com/beste/in-memory-cache-php/tree/1.5.0"
+            },
+            "time": "2026-04-27T12:29:41+00:00"
+        },
+        {
+            "name": "beste/json",
+            "version": "1.7.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/beste/json.git",
+                "reference": "976525f1ce2323a4e044364269d60b402603e216"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/beste/json/zipball/976525f1ce2323a4e044364269d60b402603e216",
+                "reference": "976525f1ce2323a4e044364269d60b402603e216",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "php": "~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0 || ~8.5.0"
+            },
+            "require-dev": {
+                "phpstan/extension-installer": "^1.3",
+                "phpstan/phpstan": "^2.0.4",
+                "phpstan/phpstan-phpunit": "^2.0.2",
+                "phpstan/phpstan-strict-rules": "^2.0.1",
+                "phpunit/phpunit": "^10.4.2",
+                "rector/rector": "^2.0.3"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/Json.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jérôme Gamez",
+                    "email": "jerome@gamez.name"
+                }
+            ],
+            "description": "A simple JSON helper to decode and encode JSON",
+            "keywords": [
+                "helper",
+                "json"
+            ],
+            "support": {
+                "issues": "https://github.com/beste/json/issues",
+                "source": "https://github.com/beste/json/tree/1.7.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/jeromegamez",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/beste/json",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-09-11T23:36:19+00:00"
+        },
+        {
             "name": "brick/math",
             "version": "0.14.8",
             "source": {
@@ -650,6 +845,83 @@
                 }
             ],
             "time": "2024-02-09T16:56:22+00:00"
+        },
+        {
+            "name": "cuyz/valinor",
+            "version": "2.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/CuyZ/Valinor.git",
+                "reference": "3b0afa3a287ed7f3a69aab223726cf1139454c34"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/CuyZ/Valinor/zipball/3b0afa3a287ed7f3a69aab223726cf1139454c34",
+                "reference": "3b0afa3a287ed7f3a69aab223726cf1139454c34",
+                "shasum": ""
+            },
+            "require": {
+                "php": "~8.2.0 || ~8.3.0 || ~8.4.0 || ~8.5.0"
+            },
+            "conflict": {
+                "phpstan/phpstan": "<1.0 || >= 3.0",
+                "vimeo/psalm": "<5.0 || >=7.0"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "^3.91",
+                "infection/infection": "^0.32",
+                "marcocesarato/php-conventional-changelog": "^1.12",
+                "mikey179/vfsstream": "^1.6.10",
+                "phpbench/phpbench": "^1.3",
+                "phpstan/phpstan": "^2.0",
+                "phpstan/phpstan-phpunit": "^2.0",
+                "phpstan/phpstan-strict-rules": "^2.0",
+                "phpunit/phpunit": "^11.5",
+                "psr/http-message": "^2.0",
+                "rector/rector": "^2.0",
+                "vimeo/psalm": "^6.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "CuyZ\\Valinor\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Romain Canon",
+                    "email": "romain.hydrocanon@gmail.com",
+                    "homepage": "https://github.com/romm"
+                }
+            ],
+            "description": "Dependency free PHP library that helps to map any input into a strongly-typed structure.",
+            "homepage": "https://github.com/CuyZ/Valinor",
+            "keywords": [
+                "array",
+                "conversion",
+                "hydrator",
+                "json",
+                "mapper",
+                "mapping",
+                "object",
+                "tree",
+                "yaml"
+            ],
+            "support": {
+                "issues": "https://github.com/CuyZ/Valinor/issues",
+                "source": "https://github.com/CuyZ/Valinor/tree/2.4.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/romm",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-03-23T17:38:05+00:00"
         },
         {
             "name": "dflydev/dot-access-data",
@@ -1227,6 +1499,62 @@
             "time": "2023-08-08T05:53:35+00:00"
         },
         {
+            "name": "fig/http-message-util",
+            "version": "1.1.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/http-message-util.git",
+                "reference": "9d94dc0154230ac39e5bf89398b324a86f63f765"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/http-message-util/zipball/9d94dc0154230ac39e5bf89398b324a86f63f765",
+                "reference": "9d94dc0154230ac39e5bf89398b324a86f63f765",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.3 || ^7.0 || ^8.0"
+            },
+            "suggest": {
+                "psr/http-message": "The package containing the PSR-7 interfaces"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Fig\\Http\\Message\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Utility classes and constants for use with PSR-7 (psr/http-message)",
+            "keywords": [
+                "http",
+                "http-message",
+                "psr",
+                "psr-7",
+                "request",
+                "response"
+            ],
+            "support": {
+                "issues": "https://github.com/php-fig/http-message-util/issues",
+                "source": "https://github.com/php-fig/http-message-util/tree/1.1.5"
+            },
+            "time": "2020-11-24T22:02:12+00:00"
+        },
+        {
             "name": "firebase/php-jwt",
             "version": "v7.0.5",
             "source": {
@@ -1540,6 +1868,380 @@
             "time": "2026-03-18T20:03:29+00:00"
         },
         {
+            "name": "google/cloud-core",
+            "version": "v1.72.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/googleapis/google-cloud-php-core.git",
+                "reference": "f1f2f8465106f4b52568b05a6548d3d055f76767"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/googleapis/google-cloud-php-core/zipball/f1f2f8465106f4b52568b05a6548d3d055f76767",
+                "reference": "f1f2f8465106f4b52568b05a6548d3d055f76767",
+                "shasum": ""
+            },
+            "require": {
+                "google/auth": "^1.34",
+                "google/gax": "^1.38.0",
+                "guzzlehttp/guzzle": "^6.5.8||^7.4.4",
+                "guzzlehttp/promises": "^1.4||^2.0",
+                "guzzlehttp/psr7": "^2.6",
+                "monolog/monolog": "^2.9||^3.0",
+                "php": "^8.1",
+                "psr/http-message": "^1.0||^2.0",
+                "rize/uri-template": "~0.3||~0.4"
+            },
+            "require-dev": {
+                "erusev/parsedown": "^1.6",
+                "google/cloud-common-protos": "~0.5||^1.0",
+                "nikic/php-parser": "^5.6",
+                "opis/closure": "^3.7|^4.0",
+                "phpdocumentor/reflection": "^6.0",
+                "phpdocumentor/reflection-docblock": "^5.3.3||^6.0",
+                "phpspec/prophecy-phpunit": "^2.0",
+                "phpunit/phpunit": "^9.0",
+                "squizlabs/php_codesniffer": "2.*"
+            },
+            "suggest": {
+                "opis/closure": "May be used to serialize closures to process jobs in the batch daemon. Please require version ^3.",
+                "symfony/lock": "Required for the Spanner cached based session pool. Please require the following commit: 3.3.x-dev#1ba6ac9"
+            },
+            "bin": [
+                "bin/google-cloud-batch"
+            ],
+            "type": "library",
+            "extra": {
+                "component": {
+                    "id": "cloud-core",
+                    "path": "Core",
+                    "entry": "src/ServiceBuilder.php",
+                    "target": "googleapis/google-cloud-php-core.git"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Google\\Cloud\\Core\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "description": "Google Cloud PHP shared dependency, providing functionality useful to all components.",
+            "support": {
+                "source": "https://github.com/googleapis/google-cloud-php-core/tree/v1.72.2"
+            },
+            "time": "2026-06-02T19:05:53+00:00"
+        },
+        {
+            "name": "google/cloud-storage",
+            "version": "v1.51.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/googleapis/google-cloud-php-storage.git",
+                "reference": "9ba3d5e8cbd53bf67fab644b5be310e719533def"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/googleapis/google-cloud-php-storage/zipball/9ba3d5e8cbd53bf67fab644b5be310e719533def",
+                "reference": "9ba3d5e8cbd53bf67fab644b5be310e719533def",
+                "shasum": ""
+            },
+            "require": {
+                "google/cloud-core": "^1.72.0",
+                "php": "^8.1",
+                "ramsey/uuid": "^4.2.3"
+            },
+            "require-dev": {
+                "erusev/parsedown": "^1.6",
+                "google/cloud-pubsub": "^2.0",
+                "nikic/php-parser": "^5",
+                "phpdocumentor/reflection": "^6.0",
+                "phpdocumentor/reflection-docblock": "^5.3.3",
+                "phpseclib/phpseclib": "^2.0||^3.0",
+                "phpspec/prophecy-phpunit": "^2.0",
+                "phpunit/phpunit": "^9.0",
+                "squizlabs/php_codesniffer": "2.*"
+            },
+            "suggest": {
+                "google/cloud-pubsub": "May be used to register a topic to receive bucket notifications.",
+                "phpseclib/phpseclib": "May be used in place of OpenSSL for creating signed Cloud Storage URLs. Please require version ^2."
+            },
+            "type": "library",
+            "extra": {
+                "component": {
+                    "id": "cloud-storage",
+                    "path": "Storage",
+                    "entry": "src/StorageClient.php",
+                    "target": "googleapis/google-cloud-php-storage.git"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Google\\Cloud\\Storage\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "description": "Cloud Storage Client for PHP",
+            "support": {
+                "source": "https://github.com/googleapis/google-cloud-php-storage/tree/v1.51.0"
+            },
+            "time": "2026-04-09T21:01:46+00:00"
+        },
+        {
+            "name": "google/common-protos",
+            "version": "4.14.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/googleapis/common-protos-php.git",
+                "reference": "f8e72f7b581702e7c3ee0776144f4974da172428"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/googleapis/common-protos-php/zipball/f8e72f7b581702e7c3ee0776144f4974da172428",
+                "reference": "f8e72f7b581702e7c3ee0776144f4974da172428",
+                "shasum": ""
+            },
+            "require": {
+                "google/protobuf": "^4.31||^5.0",
+                "php": "^8.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.6"
+            },
+            "type": "library",
+            "extra": {
+                "component": {
+                    "id": "common-protos",
+                    "path": "CommonProtos",
+                    "entry": "README.md",
+                    "target": "googleapis/common-protos-php.git"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Google\\Api\\": "src/Api",
+                    "Google\\Iam\\": "src/Iam",
+                    "Google\\Rpc\\": "src/Rpc",
+                    "Google\\Type\\": "src/Type",
+                    "Google\\Cloud\\": "src/Cloud",
+                    "GPBMetadata\\Google\\Api\\": "metadata/Api",
+                    "GPBMetadata\\Google\\Iam\\": "metadata/Iam",
+                    "GPBMetadata\\Google\\Rpc\\": "metadata/Rpc",
+                    "GPBMetadata\\Google\\Type\\": "metadata/Type",
+                    "GPBMetadata\\Google\\Cloud\\": "metadata/Cloud",
+                    "GPBMetadata\\Google\\Logging\\": "metadata/Logging"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "description": "Google API Common Protos for PHP",
+            "homepage": "https://github.com/googleapis/common-protos-php",
+            "keywords": [
+                "google"
+            ],
+            "support": {
+                "source": "https://github.com/googleapis/common-protos-php/tree/v4.14.0"
+            },
+            "time": "2026-04-09T21:01:46+00:00"
+        },
+        {
+            "name": "google/gax",
+            "version": "v1.43.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/googleapis/gax-php.git",
+                "reference": "9ee87e3b9fa9f71b13d64544a05b483d4460fa9c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/googleapis/gax-php/zipball/9ee87e3b9fa9f71b13d64544a05b483d4460fa9c",
+                "reference": "9ee87e3b9fa9f71b13d64544a05b483d4460fa9c",
+                "shasum": ""
+            },
+            "require": {
+                "google/auth": "^1.49",
+                "google/common-protos": "^4.4",
+                "google/grpc-gcp": "^0.4",
+                "google/longrunning": "~0.4",
+                "google/protobuf": "^4.31||^5.34",
+                "grpc/grpc": "^1.13",
+                "guzzlehttp/promises": "^2.0",
+                "guzzlehttp/psr7": "^2.0",
+                "php": "^8.1",
+                "ramsey/uuid": "^4.0"
+            },
+            "conflict": {
+                "ext-protobuf": "<4.31.0"
+            },
+            "require-dev": {
+                "google/cloud-tools": "^0.16.1",
+                "phpspec/prophecy-phpunit": "^2.1",
+                "phpstan/phpstan": "^2.0",
+                "phpunit/phpunit": "^9.6"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Google\\ApiCore\\": "src",
+                    "GPBMetadata\\ApiCore\\": "metadata/ApiCore"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "Google API Core for PHP",
+            "homepage": "https://github.com/googleapis/gax-php",
+            "keywords": [
+                "google"
+            ],
+            "support": {
+                "issues": "https://github.com/googleapis/gax-php/issues",
+                "source": "https://github.com/googleapis/gax-php/tree/v1.43.1"
+            },
+            "time": "2026-06-09T18:21:06+00:00"
+        },
+        {
+            "name": "google/grpc-gcp",
+            "version": "0.4.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/GoogleCloudPlatform/grpc-gcp-php.git",
+                "reference": "1049c0c15b6a1789fdeb52af688a94d540932469"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/GoogleCloudPlatform/grpc-gcp-php/zipball/1049c0c15b6a1789fdeb52af688a94d540932469",
+                "reference": "1049c0c15b6a1789fdeb52af688a94d540932469",
+                "shasum": ""
+            },
+            "require": {
+                "google/auth": "^1.3",
+                "google/protobuf": "^v3.25.3||^4.26.1||^5.0",
+                "grpc/grpc": "^v1.13.0",
+                "php": "^8.0",
+                "psr/cache": "^1.0.1||^2.0.0||^3.0.0"
+            },
+            "require-dev": {
+                "google/cloud-spanner": "^1.7",
+                "phpunit/phpunit": "^9.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Grpc\\Gcp\\": "src/"
+                },
+                "classmap": [
+                    "src/generated/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "description": "gRPC GCP library for channel management",
+            "support": {
+                "issues": "https://github.com/GoogleCloudPlatform/grpc-gcp-php/issues",
+                "source": "https://github.com/GoogleCloudPlatform/grpc-gcp-php/tree/v0.4.2"
+            },
+            "time": "2026-03-12T22:56:09+00:00"
+        },
+        {
+            "name": "google/longrunning",
+            "version": "0.7.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/googleapis/php-longrunning.git",
+                "reference": "cac9bedf199239ae2b1acd4a8e4ea2276bd9f55a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/googleapis/php-longrunning/zipball/cac9bedf199239ae2b1acd4a8e4ea2276bd9f55a",
+                "reference": "cac9bedf199239ae2b1acd4a8e4ea2276bd9f55a",
+                "shasum": ""
+            },
+            "require-dev": {
+                "google/gax": "^1.38.0",
+                "phpunit/phpunit": "^9.0"
+            },
+            "type": "library",
+            "extra": {
+                "component": {
+                    "id": "longrunning",
+                    "path": "LongRunning",
+                    "entry": null,
+                    "target": "googleapis/php-longrunning"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Google\\LongRunning\\": "src/LongRunning",
+                    "Google\\ApiCore\\LongRunning\\": "src/ApiCore/LongRunning",
+                    "GPBMetadata\\Google\\Longrunning\\": "metadata/Longrunning"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "description": "Google LongRunning Client for PHP",
+            "support": {
+                "source": "https://github.com/googleapis/php-longrunning/tree/v0.7.1"
+            },
+            "time": "2026-03-31T19:52:22+00:00"
+        },
+        {
+            "name": "google/protobuf",
+            "version": "v5.35.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/protocolbuffers/protobuf-php.git",
+                "reference": "55bb4a7d6739b5af0927b96213c1371a3afb7cfb"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/protocolbuffers/protobuf-php/zipball/55bb4a7d6739b5af0927b96213c1371a3afb7cfb",
+                "reference": "55bb4a7d6739b5af0927b96213c1371a3afb7cfb",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": ">=11.5.0 <12.0.0"
+            },
+            "suggest": {
+                "ext-bcmath": "Need to support JSON deserialization"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Google\\Protobuf\\": "src/Google/Protobuf",
+                    "GPBMetadata\\Google\\Protobuf\\": "src/GPBMetadata/Google/Protobuf"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "proto library for PHP",
+            "homepage": "https://developers.google.com/protocol-buffers/",
+            "keywords": [
+                "proto"
+            ],
+            "support": {
+                "source": "https://github.com/protocolbuffers/protobuf-php/tree/v5.35.1"
+            },
+            "time": "2026-06-11T21:19:23+00:00"
+        },
+        {
             "name": "graham-campbell/result-type",
             "version": "v1.1.4",
             "source": {
@@ -1600,6 +2302,50 @@
                 }
             ],
             "time": "2025-12-27T19:43:20+00:00"
+        },
+        {
+            "name": "grpc/grpc",
+            "version": "1.81.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/grpc/grpc-php.git",
+                "reference": "47046d6b2a6cc7e68806a287d6a1fee57e0c40da"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/grpc/grpc-php/zipball/47046d6b2a6cc7e68806a287d6a1fee57e0c40da",
+                "reference": "47046d6b2a6cc7e68806a287d6a1fee57e0c40da",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1.0"
+            },
+            "require-dev": {
+                "google/auth": "^v1.3.0"
+            },
+            "suggest": {
+                "ext-protobuf": "For better performance, install the protobuf C extension.",
+                "google/protobuf": "To get started using grpc quickly, install the native protobuf library."
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Grpc\\": "src/lib/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "description": "gRPC library for PHP",
+            "homepage": "https://grpc.io",
+            "keywords": [
+                "rpc"
+            ],
+            "support": {
+                "source": "https://github.com/grpc/grpc-php/tree/v1.81.0"
+            },
+            "time": "2026-05-20T09:30:50+00:00"
         },
         {
             "name": "guzzlehttp/guzzle",
@@ -2279,6 +3025,248 @@
                 "source": "https://github.com/KnpLabs/snappy/tree/v1.6.0"
             },
             "time": "2026-02-13T12:50:40+00:00"
+        },
+        {
+            "name": "kreait/firebase-php",
+            "version": "8.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/beste/firebase-php.git",
+                "reference": "7a1007c8151e1bf7be9f6b0f9a1e37b1f734f59e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/beste/firebase-php/zipball/7a1007c8151e1bf7be9f6b0f9a1e37b1f734f59e",
+                "reference": "7a1007c8151e1bf7be9f6b0f9a1e37b1f734f59e",
+                "shasum": ""
+            },
+            "require": {
+                "beste/clock": "^3.0",
+                "beste/in-memory-cache": "^1.3.1",
+                "beste/json": "^1.5.1",
+                "cuyz/valinor": "^2.2.1",
+                "ext-ctype": "*",
+                "ext-filter": "*",
+                "ext-json": "*",
+                "ext-mbstring": "*",
+                "fig/http-message-util": "^1.1.5",
+                "firebase/php-jwt": "^6.10.2 || ^7.0.2",
+                "google/auth": "^1.45",
+                "google/cloud-storage": "^1.48.7",
+                "guzzlehttp/guzzle": "^7.9.2",
+                "guzzlehttp/promises": "^2.0.4",
+                "guzzlehttp/psr7": "^2.7",
+                "kreait/firebase-tokens": "^5.2",
+                "lcobucci/jwt": "^5.3",
+                "mtdowling/jmespath.php": "^2.8.0",
+                "php": "~8.3.0 || ~8.4.0 || ~8.5.0",
+                "psr/cache": "^2.0 || ^3.0",
+                "psr/clock": "^1.0",
+                "psr/http-client": "^1.0.3",
+                "psr/http-factory": "^1.1",
+                "psr/http-message": "^1.1 || ^2.0"
+            },
+            "require-dev": {
+                "google/cloud-firestore": "^1.55.0",
+                "psr/log": "^3.0.2",
+                "symfony/var-dumper": "^7.4.4 || ^8.0.4",
+                "vlucas/phpdotenv": "^5.6.3"
+            },
+            "suggest": {
+                "google/cloud-firestore": "^1.0 to use the Firestore component"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-7.x": "7.x-dev",
+                    "dev-8.x": "8.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Kreait\\Firebase\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jérôme Gamez",
+                    "homepage": "https://github.com/jeromegamez"
+                }
+            ],
+            "description": "Firebase Admin SDK",
+            "homepage": "https://github.com/beste/firebase-php",
+            "keywords": [
+                "api",
+                "database",
+                "firebase",
+                "google",
+                "sdk"
+            ],
+            "support": {
+                "docs": "https://firebase-php.readthedocs.io",
+                "issues": "https://github.com/beste/firebase-php/issues",
+                "source": "https://github.com/beste/firebase-php"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sponsors/jeromegamez",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-03-04T12:06:19+00:00"
+        },
+        {
+            "name": "kreait/firebase-tokens",
+            "version": "5.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/beste/firebase-tokens-php.git",
+                "reference": "5dc119c8c29fcab1fb3a35ed5164dee0d33e4430"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/beste/firebase-tokens-php/zipball/5dc119c8c29fcab1fb3a35ed5164dee0d33e4430",
+                "reference": "5dc119c8c29fcab1fb3a35ed5164dee0d33e4430",
+                "shasum": ""
+            },
+            "require": {
+                "beste/clock": "^3.0",
+                "ext-json": "*",
+                "ext-openssl": "*",
+                "fig/http-message-util": "^1.1.5",
+                "guzzlehttp/guzzle": "^7.8",
+                "lcobucci/jwt": "^5.2",
+                "php": "~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0 || ~8.5.0",
+                "psr/cache": "^1.0|^2.0|^3.0"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "^3.62.0",
+                "phpstan/extension-installer": "^1.4.1",
+                "phpstan/phpstan": "^2.1",
+                "phpstan/phpstan-phpunit": "^2.0",
+                "phpunit/phpunit": "^10.5.30",
+                "rector/rector": "^2.1",
+                "symfony/cache": "^6.4.3 || ^7.1.3",
+                "symfony/var-dumper": "^6.4.3 || ^7.1.3"
+            },
+            "suggest": {
+                "psr/cache-implementation": "to cache fetched remote public keys"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Kreait\\Firebase\\JWT\\": "src/JWT"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jérôme Gamez",
+                    "homepage": "https://github.com/jeromegamez"
+                }
+            ],
+            "description": "A library to work with Firebase tokens",
+            "homepage": "https://github.com/kreait/firebase-token-php",
+            "keywords": [
+                "Authentication",
+                "auth",
+                "firebase",
+                "google",
+                "token"
+            ],
+            "support": {
+                "issues": "https://github.com/beste/firebase-tokens-php/issues",
+                "source": "https://github.com/beste/firebase-tokens-php/tree/5.3.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sponsors/jeromegamez",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-09-11T23:24:49+00:00"
+        },
+        {
+            "name": "kreait/laravel-firebase",
+            "version": "7.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/beste/laravel-firebase.git",
+                "reference": "a9f63c54089c9a5aa7bce5cabd9a57b2dcbeed64"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/beste/laravel-firebase/zipball/a9f63c54089c9a5aa7bce5cabd9a57b2dcbeed64",
+                "reference": "a9f63c54089c9a5aa7bce5cabd9a57b2dcbeed64",
+                "shasum": ""
+            },
+            "require": {
+                "illuminate/contracts": "^11.0 || ^12.0 || ^13.0",
+                "illuminate/notifications": "^11.0 || ^12.0 || ^13.0",
+                "illuminate/support": "^11.0 || ^12.0 || ^13.0",
+                "kreait/firebase-php": "^8.0",
+                "php": "~8.3.0 || ~8.4.0 || ~8.5.0",
+                "symfony/cache": "^6.1.2 || ^7.0.3 || ^8.0.8"
+            },
+            "require-dev": {
+                "laravel/pint": "^1.22.1",
+                "orchestra/testbench": "^9.0 || ^10.4 || ^11.0",
+                "phpunit/phpunit": "^12.5.17 || ^13.1.1"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "aliases": {
+                        "Firebase": "Kreait\\Laravel\\Firebase\\Facades\\Firebase"
+                    },
+                    "providers": [
+                        "Kreait\\Laravel\\Firebase\\ServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Kreait\\Laravel\\Firebase\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jérôme Gamez",
+                    "email": "jerome@gamez.name"
+                }
+            ],
+            "description": "A Laravel package for the Firebase PHP Admin SDK",
+            "keywords": [
+                "FCM",
+                "api",
+                "database",
+                "firebase",
+                "gcm",
+                "laravel",
+                "sdk"
+            ],
+            "support": {
+                "issues": "https://github.com/beste/laravel-firebase/issues",
+                "source": "https://github.com/beste/laravel-firebase/tree/7.2.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sponsors/jeromegamez",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-05-07T13:39:14+00:00"
         },
         {
             "name": "laravel/ai",
@@ -3034,6 +4022,79 @@
                 "source": "https://github.com/laravel/tinker/tree/v2.11.1"
             },
             "time": "2026-02-06T14:12:35+00:00"
+        },
+        {
+            "name": "lcobucci/jwt",
+            "version": "5.6.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/lcobucci/jwt.git",
+                "reference": "bb3e9f21e4196e8afc41def81ef649c164bca25e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/lcobucci/jwt/zipball/bb3e9f21e4196e8afc41def81ef649c164bca25e",
+                "reference": "bb3e9f21e4196e8afc41def81ef649c164bca25e",
+                "shasum": ""
+            },
+            "require": {
+                "ext-openssl": "*",
+                "ext-sodium": "*",
+                "php": "~8.2.0 || ~8.3.0 || ~8.4.0 || ~8.5.0",
+                "psr/clock": "^1.0"
+            },
+            "require-dev": {
+                "infection/infection": "^0.29",
+                "lcobucci/clock": "^3.2",
+                "lcobucci/coding-standard": "^11.0",
+                "phpbench/phpbench": "^1.2",
+                "phpstan/extension-installer": "^1.2",
+                "phpstan/phpstan": "^1.10.7",
+                "phpstan/phpstan-deprecation-rules": "^1.1.3",
+                "phpstan/phpstan-phpunit": "^1.3.10",
+                "phpstan/phpstan-strict-rules": "^1.5.0",
+                "phpunit/phpunit": "^11.1"
+            },
+            "suggest": {
+                "lcobucci/clock": ">= 3.2"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Lcobucci\\JWT\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Luís Cobucci",
+                    "email": "lcobucci@gmail.com",
+                    "role": "Developer"
+                }
+            ],
+            "description": "A simple library to work with JSON Web Token and JSON Web Signature",
+            "keywords": [
+                "JWS",
+                "jwt"
+            ],
+            "support": {
+                "issues": "https://github.com/lcobucci/jwt/issues",
+                "source": "https://github.com/lcobucci/jwt/tree/5.6.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/lcobucci",
+                    "type": "github"
+                },
+                {
+                    "url": "https://www.patreon.com/lcobucci",
+                    "type": "patreon"
+                }
+            ],
+            "time": "2025-10-17T11:30:53+00:00"
         },
         {
             "name": "league/commonmark",
@@ -5970,6 +7031,70 @@
                 "source": "https://github.com/ramsey/uuid/tree/4.9.2"
             },
             "time": "2025-12-14T04:43:48+00:00"
+        },
+        {
+            "name": "rize/uri-template",
+            "version": "0.4.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/rize/UriTemplate.git",
+                "reference": "7ad22944daede547b4542e1c977ec4a81aa20832"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/rize/UriTemplate/zipball/7ad22944daede547b4542e1c977ec4a81aa20832",
+                "reference": "7ad22944daede547b4542e1c977ec4a81aa20832",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "^3.63",
+                "phpstan/phpstan": "^1.12",
+                "phpunit/phpunit": "~10.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Rize\\": "src/Rize"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Marut K",
+                    "homepage": "http://twitter.com/rezigned"
+                }
+            ],
+            "description": "PHP URI Template (RFC 6570) supports both expansion & extraction",
+            "keywords": [
+                "RFC 6570",
+                "template",
+                "uri"
+            ],
+            "support": {
+                "issues": "https://github.com/rize/UriTemplate/issues",
+                "source": "https://github.com/rize/UriTemplate/tree/0.4.2"
+            },
+            "funding": [
+                {
+                    "url": "https://www.paypal.me/rezigned",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/rezigned",
+                    "type": "github"
+                },
+                {
+                    "url": "https://opencollective.com/rize-uri-template",
+                    "type": "open_collective"
+                }
+            ],
+            "time": "2026-05-07T15:30:40+00:00"
         },
         {
             "name": "sabberworm/php-css-parser",

--- a/config/firebase.php
+++ b/config/firebase.php
@@ -1,0 +1,207 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+    /*
+     * ------------------------------------------------------------------------
+     * Default Firebase project
+     * ------------------------------------------------------------------------
+     */
+
+    'default' => env('FIREBASE_PROJECT', 'app'),
+
+    /*
+     * ------------------------------------------------------------------------
+     * Firebase project configurations
+     * ------------------------------------------------------------------------
+     */
+
+    'projects' => [
+        'app' => [
+
+            /*
+             * ------------------------------------------------------------------------
+             * Credentials / Service Account
+             * ------------------------------------------------------------------------
+             *
+             * In order to access a Firebase project and its related services using a
+             * server SDK, requests must be authenticated. For server-to-server
+             * communication this is done with a Service Account.
+             *
+             * If you don't already have generated a Service Account, you can do so by
+             * following the instructions from the official documentation pages at
+             *
+             * https://firebase.google.com/docs/admin/setup#initialize_the_sdk
+             *
+             * Once you have downloaded the Service Account JSON file, you can use it
+             * to configure the package.
+             *
+             * If you don't provide credentials, the Firebase Admin SDK will try to
+             * auto-discover them
+             *
+             * - by checking the environment variable FIREBASE_CREDENTIALS
+             * - by checking the environment variable GOOGLE_APPLICATION_CREDENTIALS
+             * - by trying to find Google's well known file
+             * - by checking if the application is running on GCE/GCP
+             *
+             * If no credentials file can be found, an exception will be thrown the
+             * first time you try to access a component of the Firebase Admin SDK.
+             *
+             */
+
+            'credentials' => env('FIREBASE_CREDENTIALS', env('GOOGLE_APPLICATION_CREDENTIALS')),
+
+            /*
+             * ------------------------------------------------------------------------
+             * Firebase Auth Component
+             * ------------------------------------------------------------------------
+             */
+
+            'auth' => [
+                'tenant_id' => env('FIREBASE_AUTH_TENANT_ID'),
+            ],
+
+            /*
+             * ------------------------------------------------------------------------
+             * Firestore Component
+             * ------------------------------------------------------------------------
+             */
+
+            'firestore' => [
+
+                /*
+                 * If you want to access a Firestore database other than the default database,
+                 * enter its name here.
+                 *
+                 * By default, the Firestore client will connect to the `(default)` database.
+                 *
+                 * https://firebase.google.com/docs/firestore/manage-databases
+                 */
+
+                // 'database' => env('FIREBASE_FIRESTORE_DATABASE'),
+            ],
+
+            /*
+             * ------------------------------------------------------------------------
+             * Firebase Realtime Database
+             * ------------------------------------------------------------------------
+             */
+
+            'database' => [
+
+                /*
+                 * In most of the cases the project ID defined in the credentials file
+                 * determines the URL of your project's Realtime Database. If the
+                 * connection to the Realtime Database fails, you can override
+                 * its URL with the value you see at
+                 *
+                 * https://console.firebase.google.com/u/1/project/_/database
+                 *
+                 * Please make sure that you use a full URL like, for example,
+                 * https://my-project-id.firebaseio.com
+                 */
+
+                'url' => env('FIREBASE_DATABASE_URL'),
+
+                /*
+                 * As a best practice, a service should have access to only the resources it needs.
+                 * To get more fine-grained control over the resources a Firebase app instance can access,
+                 * use a unique identifier in your Security Rules to represent your service.
+                 *
+                 * https://firebase.google.com/docs/database/admin/start#authenticate-with-limited-privileges
+                 */
+
+                // 'auth_variable_override' => [
+                //     'uid' => 'my-service-worker'
+                // ],
+
+            ],
+
+            /*
+             * ------------------------------------------------------------------------
+             * Firebase Cloud Storage
+             * ------------------------------------------------------------------------
+             */
+
+            'storage' => [
+
+                /*
+                 * Your project's default storage bucket usually uses the project ID
+                 * as its name. If you have multiple storage buckets and want to
+                 * use another one as the default for your application, you can
+                 * override it here.
+                 */
+
+                'default_bucket' => env('FIREBASE_STORAGE_DEFAULT_BUCKET'),
+
+            ],
+
+            /*
+             * ------------------------------------------------------------------------
+             * Caching
+             * ------------------------------------------------------------------------
+             *
+             * The Firebase Admin SDK can cache some data returned from the Firebase
+             * API, for example Google's public keys used to verify ID tokens.
+             *
+             */
+
+            'cache_store' => env('FIREBASE_CACHE_STORE', 'file'),
+
+            /*
+             * ------------------------------------------------------------------------
+             * Logging
+             * ------------------------------------------------------------------------
+             *
+             * Enable logging of HTTP interaction for insights and/or debugging.
+             *
+             * Log channels are defined in config/logging.php
+             *
+             * Successful HTTP messages are logged with the log level 'info'.
+             * Failed HTTP messages are logged with the log level 'notice'.
+             *
+             * Note: Using the same channel for simple and debug logs will result in
+             * two entries per request and response.
+             */
+
+            'logging' => [
+                'http_log_channel' => env('FIREBASE_HTTP_LOG_CHANNEL'),
+                'http_debug_log_channel' => env('FIREBASE_HTTP_DEBUG_LOG_CHANNEL'),
+            ],
+
+            /*
+             * ------------------------------------------------------------------------
+             * HTTP Client Options
+             * ------------------------------------------------------------------------
+             *
+             * Behavior of the HTTP Client performing the API requests
+             */
+
+            'http_client_options' => [
+
+                /*
+                 * Use a proxy that all API requests should be passed through.
+                 * (default: none)
+                 */
+
+                'proxy' => env('FIREBASE_HTTP_CLIENT_PROXY'),
+
+                /*
+                 * Set the maximum amount of seconds (float) that can pass before
+                 * a request is considered timed out
+                 *
+                 * The default time out can be reviewed at
+                 * https://github.com/beste/firebase-php/blob/6.x/src/Firebase/Http/HttpClientOptions.php
+                 */
+
+                'timeout' => env('FIREBASE_HTTP_CLIENT_TIMEOUT'),
+
+                'guzzle_middlewares' => [
+                    // MyInvokableMiddleware::class,
+                    // [MyMiddleware::class, 'static_method'],
+                ],
+            ],
+        ],
+    ],
+];

--- a/database/factories/DeviceTokenFactory.php
+++ b/database/factories/DeviceTokenFactory.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\DeviceToken;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class DeviceTokenFactory extends Factory
+{
+    protected $model = DeviceToken::class;
+
+    public function definition(): array
+    {
+        return [
+            'user_id'  => User::factory(),
+            'token'    => $this->faker->unique()->sha256(),
+            'platform' => $this->faker->randomElement(['ios', 'android']),
+        ];
+    }
+}

--- a/database/migrations/2026_06_14_142116_create_device_tokens_table.php
+++ b/database/migrations/2026_06_14_142116_create_device_tokens_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('device_tokens', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedBigInteger('user_id');
+            $table->string('token', 512)->unique();
+            $table->enum('platform', ['ios', 'android']);
+            $table->timestamps();
+
+            $table->foreign('user_id')
+                ->references('id')->on('users')
+                ->cascadeOnDelete();
+            $table->index('user_id');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('device_tokens');
+    }
+};

--- a/database/migrations/2026_06_14_142215_create_push_notification_log_table.php
+++ b/database/migrations/2026_06_14_142215_create_push_notification_log_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('push_notification_log', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedBigInteger('event_id');
+            $table->unsignedBigInteger('user_id');
+            $table->string('type', 32);
+            $table->timestamp('sent_at')->nullable();
+            $table->timestamps();
+
+            $table->index('event_id');
+            $table->unique(['event_id', 'user_id', 'type']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('push_notification_log');
+    }
+};

--- a/database/migrations/2026_06_14_142256_add_venue_timezone_to_events_table.php
+++ b/database/migrations/2026_06_14_142256_add_venue_timezone_to_events_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('events', function (Blueprint $table) {
+            $table->string('venue_timezone', 64)->nullable()->after('venue_address');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('events', function (Blueprint $table) {
+            $table->dropColumn('venue_timezone');
+        });
+    }
+};

--- a/docs/superpowers/plans/2026-06-14-leave-by-push-backend.md
+++ b/docs/superpowers/plans/2026-06-14-leave-by-push-backend.md
@@ -1,0 +1,1517 @@
+# Leave-By Push Notification Backend — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Register mobile device tokens and, on a 5-minute scheduler tick, send two data-only FCM push notifications per rostered event per day (an 8h-before reminder and a departure trigger), at times computed in the venue's timezone, idempotently.
+
+**Architecture:** A Laravel 12 subsystem: `device_tokens` + `push_notification_log` tables, a `DevicesController` for the two mobile endpoints, `kreait/laravel-firebase` behind an `FcmSender`, a `VenueTimezoneResolver` (reusing the configured googlemaps package), and a `LeaveByPushService` orchestrator invoked by a `notifications:tick` command. First-item/show-time are derived in the service using the SAME `additional_data->times` shape and `strtotime` sort that `EventDataService::parseAdditionalData` uses (deliberately kept in lockstep — see Self-Review).
+
+**Tech Stack:** Laravel 12, PHP 8.3, Sanctum, Horizon/queues, `kreait/laravel-firebase`, `alexpechkarev/google-maps` (already configured), PHPUnit.
+
+**Spec:** `docs/superpowers/specs/2026-06-14-leave-by-push-backend-design.md`
+
+**Conventions:** All artisan/composer/phpunit run via `docker compose exec app …`. Branch is off `staging`; PR targets `staging`. `Events` model is plural (`App\Models\Events`).
+
+---
+
+## Prerequisites (manual, external — not code steps)
+
+- [ ] **P1: Firebase service account JSON** — Firebase console → Project Settings → Service accounts → Generate new private key (same Firebase project as the mobile Phase 1 setup). Place the JSON where the server can read it; set `FIREBASE_CREDENTIALS` in `.env` to its path. Keep it out of git.
+- [ ] **P2: Enable the Google Time Zone API** on the project owning `GOOGLE_MAPS_API_KEY` (the timezone endpoint is already declared in `config/googlemaps.php`).
+- [ ] **P3: Confirm Horizon / queue workers** run in the target environment so dispatched send jobs are processed.
+
+---
+
+## File Structure
+
+New:
+- `database/migrations/<ts>_create_device_tokens_table.php`
+- `database/migrations/<ts>_create_push_notification_log_table.php`
+- `database/migrations/<ts>_add_venue_timezone_to_events_table.php`
+- `app/Models/DeviceToken.php`
+- `app/Models/PushNotificationLog.php`
+- `app/Http/Controllers/Api/Mobile/DevicesController.php`
+- `app/Http/Requests/Mobile/StoreDeviceTokenRequest.php`
+- `app/Services/Push/VenueTimezoneResolver.php`
+- `app/Services/Push/FcmSender.php`
+- `app/Services/Push/LeaveByPushService.php`
+- `app/Jobs/SendEventPush.php`
+- `app/Console/Commands/SendLeaveByNotifications.php`
+- `database/factories/DeviceTokenFactory.php`
+- Tests under `tests/Feature/Push/` and `tests/Unit/Push/`
+
+Modified:
+- `routes/api.php` — two device routes in the `auth:sanctum` mobile group
+- `app/Console/Kernel.php` — schedule `notifications:tick` every 5 min, `onOneServer()`
+- `composer.json` — `kreait/laravel-firebase`
+- `config/firebase.php` — published by the package
+
+Reused (NOT modified): `app/Services/EventDataService.php` (timeline/first-item via existing `formatForShow`/`parseAdditionalData`), `app/Models/EventMember.php`, `app/Models/Events.php`.
+
+---
+
+## Task 1: Install kreait/laravel-firebase
+
+**Files:** `composer.json`, `config/firebase.php`
+
+- [ ] **Step 1: Require the package**
+
+Run: `docker compose exec app composer require kreait/laravel-firebase`
+Expected: installs, `composer.json` shows `kreait/laravel-firebase`.
+
+- [ ] **Step 2: Publish config**
+
+Run: `docker compose exec app php artisan vendor:publish --provider="Kreait\Laravel\Firebase\ServiceProvider" --tag=config`
+Expected: `config/firebase.php` created.
+
+- [ ] **Step 3: Add the credentials env key**
+
+Add to `.env` and `.env.example`:
+```
+FIREBASE_CREDENTIALS=storage/app/firebase/service-account.json
+```
+(The actual file is provided manually per prerequisite P1; gitignore `storage/app/firebase/`.)
+
+Add to `.gitignore`:
+```
+/storage/app/firebase/
+```
+
+- [ ] **Step 4: Verify it boots**
+
+Run: `docker compose exec app php artisan config:clear && docker compose exec app php artisan about`
+Expected: no errors (the Firebase provider registers).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add composer.json composer.lock config/firebase.php .env.example .gitignore
+git commit -m "build: add kreait/laravel-firebase for FCM"
+```
+
+---
+
+## Task 2: device_tokens migration + model + factory
+
+**Files:**
+- Create: `database/migrations/<ts>_create_device_tokens_table.php`
+- Create: `app/Models/DeviceToken.php`
+- Create: `database/factories/DeviceTokenFactory.php`
+- Test: `tests/Unit/Push/DeviceTokenTest.php`
+
+- [ ] **Step 1: Create the migration**
+
+Run: `docker compose exec app php artisan make:migration create_device_tokens_table`
+Then set its contents:
+```php
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('device_tokens', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedBigInteger('user_id');
+            $table->string('token', 512)->unique();
+            $table->enum('platform', ['ios', 'android']);
+            $table->timestamps();
+
+            $table->foreign('user_id')
+                ->references('id')->on('users')
+                ->cascadeOnDelete();
+            $table->index('user_id');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('device_tokens');
+    }
+};
+```
+
+- [ ] **Step 2: Create the model**
+
+`app/Models/DeviceToken.php`:
+```php
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class DeviceToken extends Model
+{
+    use HasFactory;
+
+    protected $fillable = ['user_id', 'token', 'platform'];
+
+    public function user()
+    {
+        return $this->belongsTo(User::class);
+    }
+}
+```
+
+- [ ] **Step 3: Create the factory**
+
+`database/factories/DeviceTokenFactory.php`:
+```php
+<?php
+
+namespace Database\Factories;
+
+use App\Models\DeviceToken;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class DeviceTokenFactory extends Factory
+{
+    protected $model = DeviceToken::class;
+
+    public function definition(): array
+    {
+        return [
+            'user_id'  => User::factory(),
+            'token'    => $this->faker->unique()->sha256(),
+            'platform' => $this->faker->randomElement(['ios', 'android']),
+        ];
+    }
+}
+```
+
+- [ ] **Step 4: Write the test**
+
+`tests/Unit/Push/DeviceTokenTest.php`:
+```php
+<?php
+
+namespace Tests\Unit\Push;
+
+use App\Models\DeviceToken;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class DeviceTokenTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_belongs_to_a_user(): void
+    {
+        $user = User::factory()->create();
+        $token = DeviceToken::factory()->create(['user_id' => $user->id]);
+
+        $this->assertTrue($token->user->is($user));
+    }
+
+    public function test_token_is_unique(): void
+    {
+        DeviceToken::factory()->create(['token' => 'abc']);
+        $this->expectException(\Illuminate\Database\QueryException::class);
+        DeviceToken::factory()->create(['token' => 'abc']);
+    }
+}
+```
+
+- [ ] **Step 5: Run migration + test**
+
+Run: `docker compose exec app php artisan migrate`
+Run: `docker compose exec app php artisan test tests/Unit/Push/DeviceTokenTest.php`
+Expected: 2 passing.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add database/migrations/*device_tokens* app/Models/DeviceToken.php database/factories/DeviceTokenFactory.php tests/Unit/Push/DeviceTokenTest.php
+git commit -m "feat(push): device_tokens table, model, factory"
+```
+
+---
+
+## Task 3: push_notification_log migration + model
+
+**Files:**
+- Create: `database/migrations/<ts>_create_push_notification_log_table.php`
+- Create: `app/Models/PushNotificationLog.php`
+- Test: `tests/Unit/Push/PushNotificationLogTest.php`
+
+- [ ] **Step 1: Migration**
+
+Run: `docker compose exec app php artisan make:migration create_push_notification_log_table`
+Contents:
+```php
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('push_notification_log', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedBigInteger('event_id');
+            $table->unsignedBigInteger('user_id');
+            $table->string('type', 32); // event_reminder_8h | event_departure
+            $table->timestamp('sent_at')->nullable();
+            $table->timestamps();
+
+            $table->index('event_id');
+            $table->unique(['event_id', 'user_id', 'type']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('push_notification_log');
+    }
+};
+```
+
+- [ ] **Step 2: Model**
+
+`app/Models/PushNotificationLog.php`:
+```php
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class PushNotificationLog extends Model
+{
+    protected $table = 'push_notification_log';
+
+    protected $fillable = ['event_id', 'user_id', 'type', 'sent_at'];
+
+    protected $casts = ['sent_at' => 'datetime'];
+
+    public function event()
+    {
+        return $this->belongsTo(Events::class, 'event_id');
+    }
+
+    public function user()
+    {
+        return $this->belongsTo(User::class);
+    }
+}
+```
+
+- [ ] **Step 3: Test the unique constraint**
+
+`tests/Unit/Push/PushNotificationLogTest.php`:
+```php
+<?php
+
+namespace Tests\Unit\Push;
+
+use App\Models\PushNotificationLog;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class PushNotificationLogTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_event_user_type_is_unique(): void
+    {
+        PushNotificationLog::create(['event_id' => 1, 'user_id' => 1, 'type' => 'event_reminder_8h']);
+        $this->expectException(\Illuminate\Database\QueryException::class);
+        PushNotificationLog::create(['event_id' => 1, 'user_id' => 1, 'type' => 'event_reminder_8h']);
+    }
+
+    public function test_same_event_user_different_type_allowed(): void
+    {
+        PushNotificationLog::create(['event_id' => 1, 'user_id' => 1, 'type' => 'event_reminder_8h']);
+        PushNotificationLog::create(['event_id' => 1, 'user_id' => 1, 'type' => 'event_departure']);
+        $this->assertSame(2, PushNotificationLog::count());
+    }
+}
+```
+
+- [ ] **Step 4: Run**
+
+Run: `docker compose exec app php artisan migrate`
+Run: `docker compose exec app php artisan test tests/Unit/Push/PushNotificationLogTest.php`
+Expected: 2 passing.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add database/migrations/*push_notification_log* app/Models/PushNotificationLog.php tests/Unit/Push/PushNotificationLogTest.php
+git commit -m "feat(push): push_notification_log table + model (idempotency ledger)"
+```
+
+---
+
+## Task 4: add venue_timezone column to events
+
+**Files:**
+- Create: `database/migrations/<ts>_add_venue_timezone_to_events_table.php`
+
+- [ ] **Step 1: Migration**
+
+Run: `docker compose exec app php artisan make:migration add_venue_timezone_to_events_table`
+Contents:
+```php
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('events', function (Blueprint $table) {
+            $table->string('venue_timezone', 64)->nullable()->after('venue_address');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('events', function (Blueprint $table) {
+            $table->dropColumn('venue_timezone');
+        });
+    }
+};
+```
+
+- [ ] **Step 2: Add to Events fillable**
+
+In `app/Models/Events.php`, add `'venue_timezone'` to the `$fillable` array (next to `venue_address`).
+
+- [ ] **Step 3: Run migration**
+
+Run: `docker compose exec app php artisan migrate`
+Expected: column added.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add database/migrations/*venue_timezone* app/Models/Events.php
+git commit -m "feat(push): cache venue_timezone on events"
+```
+
+---
+
+## Task 5: Device registration endpoints
+
+**Files:**
+- Create: `app/Http/Requests/Mobile/StoreDeviceTokenRequest.php`
+- Create: `app/Http/Controllers/Api/Mobile/DevicesController.php`
+- Modify: `routes/api.php`
+- Test: `tests/Feature/Push/DeviceRegistrationTest.php`
+
+- [ ] **Step 1: Write the failing feature test**
+
+`tests/Feature/Push/DeviceRegistrationTest.php`:
+```php
+<?php
+
+namespace Tests\Feature\Push;
+
+use App\Models\DeviceToken;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Sanctum\Sanctum;
+use Tests\TestCase;
+
+class DeviceRegistrationTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_register_requires_auth(): void
+    {
+        $this->postJson('/api/mobile/devices', ['token' => 't', 'platform' => 'ios'])
+            ->assertUnauthorized();
+    }
+
+    public function test_register_creates_token_for_user(): void
+    {
+        $user = User::factory()->create();
+        Sanctum::actingAs($user);
+
+        $this->postJson('/api/mobile/devices', ['token' => 'tok-abc', 'platform' => 'ios'])
+            ->assertOk();
+
+        $this->assertDatabaseHas('device_tokens', [
+            'user_id' => $user->id, 'token' => 'tok-abc', 'platform' => 'ios',
+        ]);
+    }
+
+    public function test_register_is_idempotent_by_token(): void
+    {
+        $user = User::factory()->create();
+        Sanctum::actingAs($user);
+
+        $this->postJson('/api/mobile/devices', ['token' => 'tok-abc', 'platform' => 'ios'])->assertOk();
+        $this->postJson('/api/mobile/devices', ['token' => 'tok-abc', 'platform' => 'android'])->assertOk();
+
+        $this->assertSame(1, DeviceToken::where('token', 'tok-abc')->count());
+        $this->assertDatabaseHas('device_tokens', ['token' => 'tok-abc', 'platform' => 'android']);
+    }
+
+    public function test_validation_rejects_bad_platform(): void
+    {
+        Sanctum::actingAs(User::factory()->create());
+        $this->postJson('/api/mobile/devices', ['token' => 't', 'platform' => 'windows'])
+            ->assertStatus(422);
+    }
+
+    public function test_destroy_removes_only_callers_token(): void
+    {
+        $me = User::factory()->create();
+        $other = User::factory()->create();
+        DeviceToken::factory()->create(['user_id' => $other->id, 'token' => 'theirs', 'platform' => 'ios']);
+        DeviceToken::factory()->create(['user_id' => $me->id, 'token' => 'mine', 'platform' => 'ios']);
+
+        Sanctum::actingAs($me);
+        $this->deleteJson('/api/mobile/devices/mine')->assertOk();
+
+        $this->assertDatabaseMissing('device_tokens', ['token' => 'mine']);
+        $this->assertDatabaseHas('device_tokens', ['token' => 'theirs']);
+    }
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `docker compose exec app php artisan test tests/Feature/Push/DeviceRegistrationTest.php`
+Expected: FAIL (route/controller missing).
+
+- [ ] **Step 3: FormRequest**
+
+`app/Http/Requests/Mobile/StoreDeviceTokenRequest.php`:
+```php
+<?php
+
+namespace App\Http\Requests\Mobile;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class StoreDeviceTokenRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true; // route is behind auth:sanctum
+    }
+
+    public function rules(): array
+    {
+        return [
+            'token'    => ['required', 'string', 'max:512'],
+            'platform' => ['required', 'in:ios,android'],
+        ];
+    }
+}
+```
+
+- [ ] **Step 4: Controller**
+
+`app/Http/Controllers/Api/Mobile/DevicesController.php`:
+```php
+<?php
+
+namespace App\Http\Controllers\Api\Mobile;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Mobile\StoreDeviceTokenRequest;
+use App\Models\DeviceToken;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+class DevicesController extends Controller
+{
+    public function store(StoreDeviceTokenRequest $request): JsonResponse
+    {
+        DeviceToken::updateOrCreate(
+            ['token' => $request->string('token')->toString()],
+            [
+                'user_id'  => $request->user()->id,
+                'platform' => $request->string('platform')->toString(),
+            ],
+        );
+
+        return response()->json(['status' => 'ok']);
+    }
+
+    public function destroy(Request $request, string $token): JsonResponse
+    {
+        DeviceToken::where('user_id', $request->user()->id)
+            ->where('token', $token)
+            ->delete();
+
+        return response()->json(['status' => 'ok']);
+    }
+}
+```
+
+- [ ] **Step 5: Routes**
+
+In `routes/api.php`, inside the `auth:sanctum` mobile group (where `mobile.events.show` is declared), add:
+```php
+    Route::post('/devices', [App\Http\Controllers\Api\Mobile\DevicesController::class, 'store'])->name('mobile.devices.store');
+    Route::delete('/devices/{token}', [App\Http\Controllers\Api\Mobile\DevicesController::class, 'destroy'])->name('mobile.devices.destroy');
+```
+NOTE: match the existing group's path style. The mobile group is prefixed so routes resolve to `/api/mobile/...`. Verify the resulting paths are exactly `/api/mobile/devices` and `/api/mobile/devices/{token}` (the test asserts these). If the group prefix differs, adjust the route path accordingly so the final URL matches.
+
+- [ ] **Step 6: Run to verify it passes**
+
+Run: `docker compose exec app php artisan test tests/Feature/Push/DeviceRegistrationTest.php`
+Expected: 5 passing.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add app/Http/Requests/Mobile/StoreDeviceTokenRequest.php app/Http/Controllers/Api/Mobile/DevicesController.php routes/api.php tests/Feature/Push/DeviceRegistrationTest.php
+git commit -m "feat(push): device registration endpoints"
+```
+
+---
+
+## Task 6: VenueTimezoneResolver
+
+Resolves an event's IANA timezone from its venue address, caching on `events.venue_timezone`. Uses the configured `alexpechkarev/google-maps` package (geocode → timezone), wrapped so tests fake it.
+
+**Files:**
+- Create: `app/Services/Push/VenueTimezoneResolver.php`
+- Test: `tests/Unit/Push/VenueTimezoneResolverTest.php`
+
+- [ ] **Step 1: Write the failing test (geocoder faked via a closure seam)**
+
+`tests/Unit/Push/VenueTimezoneResolverTest.php`:
+```php
+<?php
+
+namespace Tests\Unit\Push;
+
+use App\Models\Bands;
+use App\Models\Bookings;
+use App\Models\Events;
+use App\Services\Push\VenueTimezoneResolver;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class VenueTimezoneResolverTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function eventWithAddress(?string $address): Events
+    {
+        $band = Bands::factory()->create();
+        $booking = Bookings::factory()->create(['band_id' => $band->id]);
+        return Events::factory()->create([
+            'eventable_id'   => $booking->id,
+            'eventable_type' => Bookings::class,
+            'venue_address'  => $address,
+        ]);
+    }
+
+    public function test_returns_cached_timezone_without_calling_lookup(): void
+    {
+        $event = $this->eventWithAddress('100 Main St');
+        $event->venue_timezone = 'America/Chicago';
+        $event->save();
+
+        $resolver = new VenueTimezoneResolver(fn () => $this->fail('should not look up'));
+
+        $this->assertSame('America/Chicago', $resolver->forEvent($event));
+    }
+
+    public function test_looks_up_caches_and_returns(): void
+    {
+        $event = $this->eventWithAddress('100 Main St, Austin TX');
+        $resolver = new VenueTimezoneResolver(fn (string $addr) => 'America/Chicago');
+
+        $this->assertSame('America/Chicago', $resolver->forEvent($event));
+        $this->assertSame('America/Chicago', $event->fresh()->venue_timezone);
+    }
+
+    public function test_falls_back_to_app_tz_without_caching_on_failure(): void
+    {
+        config(['app.timezone' => 'America/New_York']);
+        $event = $this->eventWithAddress('nowhere');
+        $resolver = new VenueTimezoneResolver(fn (string $addr) => null);
+
+        $this->assertSame('America/New_York', $resolver->forEvent($event));
+        $this->assertNull($event->fresh()->venue_timezone);
+    }
+
+    public function test_no_address_uses_app_tz(): void
+    {
+        config(['app.timezone' => 'America/New_York']);
+        $event = $this->eventWithAddress(null);
+        $resolver = new VenueTimezoneResolver(fn (string $addr) => $this->fail('no lookup for empty address'));
+
+        $this->assertSame('America/New_York', $resolver->forEvent($event));
+    }
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `docker compose exec app php artisan test tests/Unit/Push/VenueTimezoneResolverTest.php`
+Expected: FAIL (class missing).
+
+- [ ] **Step 3: Implement**
+
+`app/Services/Push/VenueTimezoneResolver.php`:
+```php
+<?php
+
+namespace App\Services\Push;
+
+use App\Models\Events;
+use Closure;
+use Illuminate\Support\Facades\Log;
+
+class VenueTimezoneResolver
+{
+    /** @var Closure(string): ?string  Address → IANA tz (null on failure). */
+    private Closure $lookup;
+
+    public function __construct(?Closure $lookup = null)
+    {
+        $this->lookup = $lookup ?? fn (string $address) => $this->lookupViaGoogle($address);
+    }
+
+    public function forEvent(Events $event): string
+    {
+        if (!empty($event->venue_timezone)) {
+            return $event->venue_timezone;
+        }
+
+        $address = $event->resolved_venue_address;
+        if (empty($address)) {
+            return config('app.timezone');
+        }
+
+        $tz = ($this->lookup)($address);
+        if ($tz === null) {
+            Log::warning('VenueTimezoneResolver: lookup failed, using app tz', [
+                'event_id' => $event->id,
+            ]);
+            return config('app.timezone'); // do not cache the fallback
+        }
+
+        $event->venue_timezone = $tz;
+        $event->save();
+        return $tz;
+    }
+
+    private function lookupViaGoogle(string $address): ?string
+    {
+        try {
+            $maps = app('GoogleMaps'); // alexpechkarev/google-maps facade/binding
+            $geo = $maps->load('geocoding')
+                ->setParam(['address' => $address])
+                ->get();
+            $geo = json_decode($geo, true);
+            $loc = $geo['results'][0]['geometry']['location'] ?? null;
+            if (!$loc) {
+                return null;
+            }
+
+            $tzResp = $maps->load('timezone')
+                ->setParam([
+                    'location'  => "{$loc['lat']},{$loc['lng']}",
+                    'timestamp' => now()->timestamp,
+                ])
+                ->get();
+            $tzResp = json_decode($tzResp, true);
+
+            return $tzResp['timeZoneId'] ?? null;
+        } catch (\Throwable $e) {
+            Log::warning('VenueTimezoneResolver: google lookup threw', ['error' => $e->getMessage()]);
+            return null;
+        }
+    }
+}
+```
+NOTE: the `lookupViaGoogle` body uses the `alexpechkarev/google-maps` API as configured in `config/googlemaps.php`. If the package's facade name or call style differs in this repo, adjust ONLY `lookupViaGoogle` to match — the constructor seam and `forEvent` (which the tests cover) must not change. Verify against the package's existing usage in `LocationController::geocodeAddress`.
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `docker compose exec app php artisan test tests/Unit/Push/VenueTimezoneResolverTest.php`
+Expected: 4 passing. (The Google path is not unit-tested; it's exercised only via the injected closure.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/Services/Push/VenueTimezoneResolver.php tests/Unit/Push/VenueTimezoneResolverTest.php
+git commit -m "feat(push): venue timezone resolver (cached, app-tz fallback)"
+```
+
+---
+
+## Task 7: FcmSender
+
+Wraps `kreait` to send one data-only message; returns a result enum-like string. Not unit-tested against live FCM; the orchestrator test fakes it.
+
+**Files:**
+- Create: `app/Services/Push/FcmSender.php`
+
+- [ ] **Step 1: Implement**
+
+`app/Services/Push/FcmSender.php`:
+```php
+<?php
+
+namespace App\Services\Push;
+
+use Illuminate\Support\Facades\Log;
+use Kreait\Firebase\Contract\Messaging;
+use Kreait\Firebase\Exception\Messaging\NotFound;
+use Kreait\Firebase\Exception\MessagingException;
+use Kreait\Firebase\Messaging\CloudMessage;
+
+class FcmSender
+{
+    public const DELIVERED = 'delivered';
+    public const PRUNE = 'prune';      // token is dead; caller should delete it
+    public const TRANSIENT = 'transient';
+
+    public function __construct(private Messaging $messaging) {}
+
+    /**
+     * Send a data-only message to one token.
+     * @param array<string,string> $data
+     */
+    public function sendData(string $token, array $data): string
+    {
+        try {
+            $message = CloudMessage::withTarget('token', $token)->withData($data);
+            $this->messaging->send($message);
+            return self::DELIVERED;
+        } catch (NotFound $e) {
+            // Unregistered / invalid token.
+            return self::PRUNE;
+        } catch (MessagingException $e) {
+            Log::warning('FcmSender transient error', ['error' => $e->getMessage()]);
+            return self::TRANSIENT;
+        }
+    }
+}
+```
+NOTE: `Messaging` is resolved from the container by `kreait/laravel-firebase`. Confirm the exact exception class for an unregistered token in the installed kreait version — it is `Kreait\Firebase\Exception\Messaging\NotFound` for HTTP 404 (token not found). If the version differs, adjust the catch to the equivalent "token invalid/unregistered" exception; keep the three return constants.
+
+- [ ] **Step 2: Verify it loads (no test — thin glue)**
+
+Run: `docker compose exec app php artisan tinker --execute="echo class_exists(App\Services\Push\FcmSender::class) ? 'ok' : 'missing';"`
+Expected: `ok`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add app/Services/Push/FcmSender.php
+git commit -m "feat(push): FcmSender data-only wrapper over kreait"
+```
+
+---
+
+## Task 8: SendEventPush job
+
+A queued job that builds the data-only payload for one (event, user, type) and sends to all that user's tokens, logging on success and pruning dead tokens.
+
+**Files:**
+- Create: `app/Jobs/SendEventPush.php`
+- Test: `tests/Feature/Push/SendEventPushTest.php`
+
+- [ ] **Step 1: Write the failing test (FcmSender faked via container bind)**
+
+`tests/Feature/Push/SendEventPushTest.php`:
+```php
+<?php
+
+namespace Tests\Feature\Push;
+
+use App\Jobs\SendEventPush;
+use App\Models\Bands;
+use App\Models\Bookings;
+use App\Models\DeviceToken;
+use App\Models\Events;
+use App\Models\PushNotificationLog;
+use App\Models\User;
+use App\Services\Push\FcmSender;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class _FakeFcm extends FcmSender
+{
+    public array $sent = [];
+    public string $result = FcmSender::DELIVERED;
+    public function __construct() {}
+    public function sendData(string $token, array $data): string
+    {
+        $this->sent[] = ['token' => $token, 'data' => $data];
+        return $this->result;
+    }
+}
+
+class SendEventPushTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function event(): Events
+    {
+        $band = Bands::factory()->create();
+        $booking = Bookings::factory()->create(['band_id' => $band->id]);
+        return Events::factory()->create([
+            'eventable_id'   => $booking->id,
+            'eventable_type' => Bookings::class,
+            'title'          => 'Gig',
+            'venue_address'  => '100 Main St',
+        ]);
+    }
+
+    public function test_sends_data_only_payload_to_each_token_and_logs(): void
+    {
+        $fake = new _FakeFcm();
+        $this->app->instance(FcmSender::class, $fake);
+
+        $user = User::factory()->create();
+        DeviceToken::factory()->create(['user_id' => $user->id, 'token' => 'a', 'platform' => 'ios']);
+        DeviceToken::factory()->create(['user_id' => $user->id, 'token' => 'b', 'platform' => 'android']);
+        $event = $this->event();
+
+        (new SendEventPush(
+            eventId: $event->id,
+            userId: $user->id,
+            type: 'event_reminder_8h',
+            payload: [
+                'type' => 'event_reminder_8h',
+                'eventKey' => $event->key,
+                'title' => 'Gig',
+                'venueAddress' => '100 Main St',
+                'firstItemTitle' => 'Load In',
+                'firstItemTime' => '2026-06-14T14:00:00-05:00',
+                'showTime' => '2026-06-14T19:00:00-05:00',
+            ],
+        ))->handle($fake);
+
+        $this->assertCount(2, $fake->sent);
+        $this->assertSame('event_reminder_8h', $fake->sent[0]['data']['type']);
+        $this->assertSame($event->key, $fake->sent[0]['data']['eventKey']);
+        $this->assertDatabaseHas('push_notification_log', [
+            'event_id' => $event->id, 'user_id' => $user->id, 'type' => 'event_reminder_8h',
+        ]);
+    }
+
+    public function test_prunes_dead_tokens(): void
+    {
+        $fake = new _FakeFcm();
+        $fake->result = FcmSender::PRUNE;
+        $this->app->instance(FcmSender::class, $fake);
+
+        $user = User::factory()->create();
+        DeviceToken::factory()->create(['user_id' => $user->id, 'token' => 'dead', 'platform' => 'ios']);
+        $event = $this->event();
+
+        (new SendEventPush($event->id, $user->id, 'event_departure', [
+            'type' => 'event_departure', 'eventKey' => $event->key, 'title' => 'Gig',
+        ]))->handle($fake);
+
+        $this->assertDatabaseMissing('device_tokens', ['token' => 'dead']);
+        // Dead-token send is not a success: no log row.
+        $this->assertDatabaseMissing('push_notification_log', [
+            'event_id' => $event->id, 'user_id' => $user->id, 'type' => 'event_departure',
+        ]);
+    }
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `docker compose exec app php artisan test tests/Feature/Push/SendEventPushTest.php`
+Expected: FAIL (job missing).
+
+- [ ] **Step 3: Implement**
+
+`app/Jobs/SendEventPush.php`:
+```php
+<?php
+
+namespace App\Jobs;
+
+use App\Models\DeviceToken;
+use App\Models\PushNotificationLog;
+use App\Services\Push\FcmSender;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+
+class SendEventPush implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    /**
+     * @param array<string,string> $payload
+     */
+    public function __construct(
+        public int $eventId,
+        public int $userId,
+        public string $type,
+        public array $payload,
+    ) {}
+
+    public function handle(FcmSender $fcm): void
+    {
+        $tokens = DeviceToken::where('user_id', $this->userId)->get();
+        $anyDelivered = false;
+
+        foreach ($tokens as $deviceToken) {
+            $result = $fcm->sendData($deviceToken->token, $this->payload);
+            if ($result === FcmSender::PRUNE) {
+                $deviceToken->delete();
+            } elseif ($result === FcmSender::DELIVERED) {
+                $anyDelivered = true;
+            }
+        }
+
+        if ($anyDelivered) {
+            PushNotificationLog::firstOrCreate(
+                ['event_id' => $this->eventId, 'user_id' => $this->userId, 'type' => $this->type],
+                ['sent_at' => now()],
+            );
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `docker compose exec app php artisan test tests/Feature/Push/SendEventPushTest.php`
+Expected: 2 passing.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/Jobs/SendEventPush.php tests/Feature/Push/SendEventPushTest.php
+git commit -m "feat(push): SendEventPush job (per-user send, log, prune)"
+```
+
+---
+
+## Task 9: LeaveByPushService (orchestrator)
+
+Selects today's rostered events, computes the two send-times per event in venue tz, and dispatches `SendEventPush` for due, not-yet-logged (event,user,type) tuples.
+
+**Files:**
+- Create: `app/Services/Push/LeaveByPushService.php`
+- Test: `tests/Feature/Push/LeaveByPushServiceTest.php`
+
+- [ ] **Step 1: Write the failing test (time frozen, jobs faked)**
+
+`tests/Feature/Push/LeaveByPushServiceTest.php`:
+```php
+<?php
+
+namespace Tests\Feature\Push;
+
+use App\Jobs\SendEventPush;
+use App\Models\Bands;
+use App\Models\Bookings;
+use App\Models\DeviceToken;
+use App\Models\EventMember;
+use App\Models\Events;
+use App\Models\PushNotificationLog;
+use App\Models\User;
+use App\Services\Push\LeaveByPushService;
+use App\Services\Push\VenueTimezoneResolver;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Queue;
+use Tests\TestCase;
+
+class LeaveByPushServiceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function tearDown(): void
+    {
+        Carbon::setTestNow();
+        parent::tearDown();
+    }
+
+    private function makeRosteredEvent(string $date, string $startTime, string $firstItemTime): array
+    {
+        $band = Bands::factory()->create();
+        $booking = Bookings::factory()->create(['band_id' => $band->id]);
+        $event = Events::factory()->create([
+            'eventable_id'   => $booking->id,
+            'eventable_type' => Bookings::class,
+            'date'           => $date,
+            'start_time'     => $startTime,
+            'title'          => 'Gig',
+            'venue_address'  => '100 Main St',
+            'venue_timezone' => 'America/Chicago',
+            'additional_data'=> ['times' => [['title' => 'Load In', 'time' => $firstItemTime]]],
+        ]);
+        $user = User::factory()->create();
+        DeviceToken::factory()->create(['user_id' => $user->id, 'platform' => 'ios']);
+        EventMember::create([
+            'event_id' => $event->id, 'band_id' => $band->id, 'user_id' => $user->id,
+            'attendance_status' => 'confirmed',
+        ]);
+        return [$event, $user];
+    }
+
+    private function service(): LeaveByPushService
+    {
+        // Resolver returns the cached tz; no Google calls.
+        return $this->app->make(LeaveByPushService::class);
+    }
+
+    public function test_dispatches_8h_reminder_in_its_window(): void
+    {
+        Queue::fake();
+        // Chicago first item 14:00 → 8h-before = 06:00 Chicago = 11:00 UTC.
+        [$event, $user] = $this->makeRosteredEvent('2026-06-14', '19:00', '2026-06-14 14:00:00');
+        Carbon::setTestNow(Carbon::parse('2026-06-14 11:00:00', 'UTC'));
+
+        $this->service()->run(Carbon::now());
+
+        Queue::assertPushed(SendEventPush::class, function ($job) use ($event, $user) {
+            return $job->type === 'event_reminder_8h'
+                && $job->eventId === $event->id
+                && $job->userId === $user->id
+                && $job->payload['type'] === 'event_reminder_8h'
+                && $job->payload['firstItemTitle'] === 'Load In';
+        });
+    }
+
+    public function test_does_not_dispatch_when_already_logged(): void
+    {
+        Queue::fake();
+        [$event, $user] = $this->makeRosteredEvent('2026-06-14', '19:00', '2026-06-14 14:00:00');
+        PushNotificationLog::create([
+            'event_id' => $event->id, 'user_id' => $user->id, 'type' => 'event_reminder_8h',
+        ]);
+        Carbon::setTestNow(Carbon::parse('2026-06-14 11:00:00', 'UTC'));
+
+        $this->service()->run(Carbon::now());
+
+        Queue::assertNotPushed(SendEventPush::class, fn ($j) => $j->type === 'event_reminder_8h');
+    }
+
+    public function test_excludes_absent_members(): void
+    {
+        Queue::fake();
+        [$event, $user] = $this->makeRosteredEvent('2026-06-14', '19:00', '2026-06-14 14:00:00');
+        EventMember::where('event_id', $event->id)->update(['attendance_status' => 'absent']);
+        Carbon::setTestNow(Carbon::parse('2026-06-14 11:00:00', 'UTC'));
+
+        $this->service()->run(Carbon::now());
+
+        Queue::assertNotPushed(SendEventPush::class);
+    }
+
+    public function test_nothing_dispatched_outside_windows(): void
+    {
+        Queue::fake();
+        $this->makeRosteredEvent('2026-06-14', '19:00', '2026-06-14 14:00:00');
+        // Middle of the night, far from any send window.
+        Carbon::setTestNow(Carbon::parse('2026-06-14 02:00:00', 'UTC'));
+
+        $this->service()->run(Carbon::now());
+
+        Queue::assertNotPushed(SendEventPush::class);
+    }
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `docker compose exec app php artisan test tests/Feature/Push/LeaveByPushServiceTest.php`
+Expected: FAIL (service missing).
+
+- [ ] **Step 3: Implement**
+
+`app/Services/Push/LeaveByPushService.php`:
+```php
+<?php
+
+namespace App\Services\Push;
+
+use App\Jobs\SendEventPush;
+use App\Models\EventMember;
+use App\Models\Events;
+use App\Models\PushNotificationLog;
+use Carbon\CarbonInterface;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Log;
+
+class LeaveByPushService
+{
+    public const DEPARTURE_LEAD_MINUTES = 90;
+    public const GRACE_WINDOW_MINUTES = 30;
+
+    public function __construct(private VenueTimezoneResolver $tzResolver) {}
+
+    public function run(CarbonInterface $now): void
+    {
+        foreach ($this->todaysEventsWithRoster($now) as $event) {
+            try {
+                $this->processEvent($event, $now);
+            } catch (\Throwable $e) {
+                Log::error('LeaveByPush: event failed', ['event_id' => $event->id, 'error' => $e->getMessage()]);
+            }
+        }
+    }
+
+    /** @return iterable<Events> */
+    private function todaysEventsWithRoster(CarbonInterface $now): iterable
+    {
+        // Generous window so venue-tz dates near midnight aren't missed.
+        $from = $now->copy()->subDay()->toDateString();
+        $to = $now->copy()->addDay()->toDateString();
+
+        return Events::query()
+            ->whereBetween('date', [$from, $to])
+            ->whereHas('eventMembers', fn ($q) =>
+                $q->whereNotIn('attendance_status', ['absent', 'excused'])->whereNull('deleted_at'))
+            ->get();
+    }
+
+    private function processEvent(Events $event, CarbonInterface $now): void
+    {
+        $tz = $this->tzResolver->forEvent($event);
+        $firstItem = $this->firstTimelineItem($event);
+
+        // firstItemDateTime in venue tz
+        $firstTime = $firstItem['time'] ?? $event->start_time; // 'HH:MM' or full
+        $firstItemDt = $this->combine($event->date, $firstTime, $tz);
+        if ($firstItemDt === null) {
+            return;
+        }
+
+        $sends = [
+            'event_reminder_8h' => $firstItemDt->copy()->subHours(8),
+            'event_departure'   => $firstItemDt->copy()->subMinutes(self::DEPARTURE_LEAD_MINUTES),
+        ];
+
+        foreach ($sends as $type => $sendAt) {
+            if (!$this->isDue($sendAt, $now)) {
+                continue;
+            }
+            $this->dispatchForRecipients($event, $type, $firstItem, $tz, $firstItemDt);
+        }
+    }
+
+    private function isDue(CarbonInterface $sendAt, CarbonInterface $now): bool
+    {
+        return $now->greaterThanOrEqualTo($sendAt)
+            && $now->lessThan($sendAt->copy()->addMinutes(self::GRACE_WINDOW_MINUTES));
+    }
+
+    private function dispatchForRecipients(Events $event, string $type, ?array $firstItem, string $tz, CarbonInterface $firstItemDt): void
+    {
+        $members = EventMember::where('event_id', $event->id)
+            ->whereNotIn('attendance_status', ['absent', 'excused'])
+            ->whereNull('deleted_at')
+            ->whereHas('user.deviceTokens')
+            ->with('user')
+            ->get();
+
+        foreach ($members as $member) {
+            $already = PushNotificationLog::where('event_id', $event->id)
+                ->where('user_id', $member->user_id)
+                ->where('type', $type)
+                ->exists();
+            if ($already) {
+                continue;
+            }
+
+            SendEventPush::dispatch(
+                $event->id,
+                $member->user_id,
+                $type,
+                $this->payload($event, $type, $firstItem, $tz, $firstItemDt),
+            );
+        }
+    }
+
+    /** @return array<string,string> */
+    private function payload(Events $event, string $type, ?array $firstItem, string $tz, CarbonInterface $firstItemDt): array
+    {
+        $data = [
+            'type'     => $type,
+            'eventKey' => (string) $event->key,
+            'title'    => (string) $event->title,
+        ];
+        if (!empty($event->resolved_venue_address)) {
+            $data['venueAddress'] = (string) $event->resolved_venue_address;
+        }
+        if ($firstItem) {
+            $data['firstItemTitle'] = (string) ($firstItem['title'] ?? '');
+            $data['firstItemTime'] = $firstItemDt->toIso8601String();
+        }
+        $showDt = $this->combine($event->date, $event->start_time, $tz);
+        if ($showDt !== null) {
+            $data['showTime'] = $showDt->toIso8601String();
+        }
+        return $data;
+    }
+
+    /** Earliest timeline entry from additional_data->times, or null. */
+    private function firstTimelineItem(Events $event): ?array
+    {
+        $ad = $event->additional_data;
+        $times = is_object($ad) ? ($ad->times ?? null) : (is_array($ad) ? ($ad['times'] ?? null) : null);
+        if (!is_array($times) || $times === []) {
+            return null;
+        }
+        $items = [];
+        foreach ($times as $t) {
+            $t = (array) $t;
+            if (!empty($t['time'])) {
+                $items[] = ['title' => $t['title'] ?? '', 'time' => $t['time']];
+            }
+        }
+        if ($items === []) {
+            return null;
+        }
+        usort($items, fn ($a, $b) => strtotime($a['time']) <=> strtotime($b['time']));
+        return $items[0];
+    }
+
+    /** Combine a date + time string into a Carbon in the given tz, or null. */
+    private function combine($date, $time, string $tz): ?CarbonInterface
+    {
+        if (empty($time)) {
+            return null;
+        }
+        try {
+            $dateStr = $date instanceof CarbonInterface ? $date->toDateString() : (string) $date;
+            // $time may be 'HH:MM' or a full datetime; extract HH:MM if full.
+            $timeStr = preg_match('/(\d{1,2}:\d{2})/', (string) $time, $m) ? $m[1] : (string) $time;
+            return Carbon::parse("{$dateStr} {$timeStr}", $tz);
+        } catch (\Throwable $e) {
+            return null;
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Add the `deviceTokens` relation to User**
+
+In `app/Models/User.php`, add:
+```php
+    public function deviceTokens()
+    {
+        return $this->hasMany(\App\Models\DeviceToken::class);
+    }
+```
+
+- [ ] **Step 5: Run to verify it passes**
+
+Run: `docker compose exec app php artisan test tests/Feature/Push/LeaveByPushServiceTest.php`
+Expected: 4 passing.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/Services/Push/LeaveByPushService.php app/Models/User.php tests/Feature/Push/LeaveByPushServiceTest.php
+git commit -m "feat(push): LeaveByPushService orchestrator (due windows, idempotency, recipients)"
+```
+
+---
+
+## Task 10: Console command + scheduler
+
+**Files:**
+- Create: `app/Console/Commands/SendLeaveByNotifications.php`
+- Modify: `app/Console/Kernel.php`
+- Test: `tests/Feature/Push/SendLeaveByNotificationsCommandTest.php`
+
+- [ ] **Step 1: Command**
+
+`app/Console/Commands/SendLeaveByNotifications.php`:
+```php
+<?php
+
+namespace App\Console\Commands;
+
+use App\Services\Push\LeaveByPushService;
+use Illuminate\Console\Command;
+use Illuminate\Support\Carbon;
+
+class SendLeaveByNotifications extends Command
+{
+    protected $signature = 'notifications:tick';
+    protected $description = 'Send due leave-by push notifications for today\'s rostered events';
+
+    public function handle(LeaveByPushService $service): int
+    {
+        $service->run(Carbon::now());
+        $this->info('Leave-by notification tick complete.');
+        return self::SUCCESS;
+    }
+}
+```
+
+- [ ] **Step 2: Test the command delegates to the service**
+
+`tests/Feature/Push/SendLeaveByNotificationsCommandTest.php`:
+```php
+<?php
+
+namespace Tests\Feature\Push;
+
+use App\Services\Push\LeaveByPushService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Mockery;
+use Tests\TestCase;
+
+class SendLeaveByNotificationsCommandTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_tick_invokes_service_run(): void
+    {
+        $mock = Mockery::mock(LeaveByPushService::class);
+        $mock->shouldReceive('run')->once();
+        $this->app->instance(LeaveByPushService::class, $mock);
+
+        $this->artisan('notifications:tick')->assertExitCode(0);
+    }
+}
+```
+
+- [ ] **Step 3: Run**
+
+Run: `docker compose exec app php artisan test tests/Feature/Push/SendLeaveByNotificationsCommandTest.php`
+Expected: 1 passing.
+
+- [ ] **Step 4: Register in scheduler**
+
+In `app/Console/Kernel.php` `schedule()`, add (near `horizon:snapshot`):
+```php
+        $schedule->command('notifications:tick')
+            ->everyFiveMinutes()
+            ->onOneServer();
+```
+
+- [ ] **Step 5: Verify the schedule lists it**
+
+Run: `docker compose exec app php artisan schedule:list`
+Expected: `notifications:tick` appears, every five minutes.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/Console/Commands/SendLeaveByNotifications.php app/Console/Kernel.php tests/Feature/Push/SendLeaveByNotificationsCommandTest.php
+git commit -m "feat(push): notifications:tick command scheduled every 5 minutes"
+```
+
+---
+
+## Task 11: Full suite + payload contract test
+
+**Files:**
+- Create: `tests/Feature/Push/PayloadContractTest.php`
+
+- [ ] **Step 1: Explicit cross-repo contract test**
+
+The mobile app's `PushPayload.fromData` reads exactly these keys; assert the service produces them. `tests/Feature/Push/PayloadContractTest.php`:
+```php
+<?php
+
+namespace Tests\Feature\Push;
+
+use App\Jobs\SendEventPush;
+use App\Models\Bands;
+use App\Models\Bookings;
+use App\Models\DeviceToken;
+use App\Models\EventMember;
+use App\Models\Events;
+use App\Models\User;
+use App\Services\Push\LeaveByPushService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Queue;
+use Tests\TestCase;
+
+class PayloadContractTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function tearDown(): void
+    {
+        Carbon::setTestNow();
+        parent::tearDown();
+    }
+
+    public function test_payload_keys_match_mobile_contract(): void
+    {
+        Queue::fake();
+        $band = Bands::factory()->create();
+        $booking = Bookings::factory()->create(['band_id' => $band->id]);
+        $event = Events::factory()->create([
+            'eventable_id' => $booking->id, 'eventable_type' => Bookings::class,
+            'date' => '2026-06-14', 'start_time' => '19:00', 'title' => 'Gig',
+            'venue_address' => '100 Main St', 'venue_timezone' => 'America/Chicago',
+            'additional_data' => ['times' => [['title' => 'Load In', 'time' => '2026-06-14 14:00:00']]],
+        ]);
+        $user = User::factory()->create();
+        DeviceToken::factory()->create(['user_id' => $user->id, 'platform' => 'ios']);
+        EventMember::create(['event_id' => $event->id, 'band_id' => $band->id, 'user_id' => $user->id, 'attendance_status' => 'confirmed']);
+
+        Carbon::setTestNow(Carbon::parse('2026-06-14 11:00:00', 'UTC')); // 8h-before window
+        $this->app->make(LeaveByPushService::class)->run(Carbon::now());
+
+        Queue::assertPushed(SendEventPush::class, function ($job) {
+            $allowed = ['type', 'eventKey', 'title', 'venueAddress', 'firstItemTitle', 'firstItemTime', 'showTime'];
+            foreach (array_keys($job->payload) as $k) {
+                if (!in_array($k, $allowed, true)) {
+                    return false; // no unexpected keys
+                }
+            }
+            return $job->payload['type'] === 'event_reminder_8h'
+                && $job->payload['eventKey'] !== ''
+                && array_key_exists('firstItemTitle', $job->payload)
+                && array_key_exists('showTime', $job->payload);
+        });
+    }
+}
+```
+
+- [ ] **Step 2: Run the whole push suite**
+
+Run: `docker compose exec app php artisan test tests/Feature/Push tests/Unit/Push`
+Expected: all passing.
+
+- [ ] **Step 3: Run the full suite for regressions**
+
+Run: `docker compose exec app php artisan test`
+Expected: no NEW failures (note any pre-existing failures unrelated to this work).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tests/Feature/Push/PayloadContractTest.php
+git commit -m "test(push): assert payload matches mobile PushPayload contract"
+```
+
+---
+
+## Self-Review Notes
+
+- **Spec coverage:** device endpoints (Task 5), kreait/FCM data-only send (Tasks 1,7,8), 5-min tick + due-window + idempotency log (Tasks 3,9,10), venue-tz derivation cached on events (Tasks 4,6), recipients = non-absent EventMembers with a device (Task 9), dead-token pruning (Task 8), per-event isolation on error (Task 9), payload contract (Task 11). Timeline/first-item reuse: the service reads `additional_data->times` with the SAME sort as `EventDataService::parseAdditionalData` (verified shape) rather than extracting the service — simpler and no risk to the existing API. Show time = `event.start_time` per spec.
+- **Placeholder scan:** none — full code in every step. The two NOTE blocks (googlemaps call style in Task 6, kreait exception class in Task 7) point at the single line to verify against the installed package; they are not deferred work.
+- **Type consistency:** `SendEventPush(eventId, userId, type, payload)` constructor matches its dispatch in `LeaveByPushService` and both tests. `FcmSender` constants (DELIVERED/PRUNE/TRANSIENT) used identically in the job and its test. `VenueTimezoneResolver(?Closure)` seam matches its tests. `deviceTokens()` relation on User used by `whereHas('user.deviceTokens')` and added in Task 9 Step 4. Payload keys identical across Tasks 9 and 11 and the mobile contract.
+- **Idempotency nuance:** `SendEventPush` logs only when at least one token was delivered; `LeaveByPushService` also pre-checks the log before dispatching. Double-protection; the unique index is the backstop.

--- a/docs/superpowers/specs/2026-06-14-leave-by-push-backend-design.md
+++ b/docs/superpowers/specs/2026-06-14-leave-by-push-backend-design.md
@@ -1,0 +1,151 @@
+# Leave-By Push Notification Backend — Design
+
+**Date:** 2026-06-14
+**Status:** Approved for planning
+**Repo:** TTS (Laravel 12 backend). PRs target **staging**. All artisan/composer/phpunit run via `docker compose exec app …`.
+**Companion:** the Flutter mobile app's leave-by notifications (Phase 1 push plumbing + Phase 2 location enrichment) is already built and merged. This backend is the piece that actually *sends* the pushes the app is built to receive.
+
+## Summary
+
+Build the backend service that registers mobile device tokens, then on a schedule selects the events each band member is rostered for today and sends two data-only push notifications per event (an 8-hours-before "you have a gig today" reminder and a departure trigger that wakes the device to compute live travel time). FCM delivers to both Android and iOS. The backend owns delivery and timing; the device owns location enrichment.
+
+## Goals
+
+- Implement the two device endpoints the mobile app already calls: `POST /api/mobile/devices`, `DELETE /api/mobile/devices/{token}`.
+- Send data-only FCM messages matching the app's Phase 1 payload contract (flat camelCase, no `notification` block).
+- Fire two notifications per event per day, at per-event times computed in the **venue's** timezone.
+- Be idempotent (never double-send) and self-recovering after a missed tick.
+- Notify only active roster members who have a registered device.
+
+## Non-Goals
+
+- Server-side travel-time / location (the device computes that — Phase 2, already built).
+- Subs/dep musicians (roster members only for v1; subs are a possible fast-follow).
+- A general notification-preferences UI (out of scope for v1).
+- Per-band timezone *configuration* UI (timezone is derived from the venue address, not entered).
+
+## Architecture
+
+A Laravel 12 subsystem with four cooperating parts:
+
+1. **Device registration** — `device_tokens` table + `DeviceTokenController` exposing `POST /api/mobile/devices` (upsert token+platform for the authed Sanctum user) and `DELETE /api/mobile/devices/{token}`.
+
+2. **FCM sending** — `kreait/laravel-firebase` configured with a backend Firebase service account. A thin `FcmSender` sends **data-only** messages. FCM proxies to APNs for iOS using the APNs key already uploaded in the mobile Phase 1 setup — one code path for both platforms. Invalid/unregistered tokens are pruned from `device_tokens`; transient errors log and let the queue retry.
+
+3. **Scheduling tick** — a console command `notifications:tick` registered in the scheduler every **5 minutes** (mirroring the existing `horizon:snapshot` cadence). Each tick finds today's rostered events, computes each event's two send-times in the venue timezone, and sends any whose time falls in the current window and isn't already logged.
+
+4. **Payload building** — reuses the existing mobile `EventsController` timeline mapping (extracted to a shared `EventTimelineMapper`) so the push's `firstItemTitle`/`firstItemTime`/`showTime` match exactly what the app's detail screen shows.
+
+**Recipients:** users in `event_members` (attendance_status not in `absent`/`excused`, not soft-deleted) who have at least one row in `device_tokens`.
+
+**Boundary:** backend owns delivery + timing (time-based text); the device owns location enrichment (upgrades/suppresses locally).
+
+## Data Model
+
+### New table: `device_tokens`
+- `id`, `user_id` (FK → users, indexed), `token` (string, unique), `platform` (enum `ios`/`android`), `timestamps`.
+- One row per device; upserted by `token`. Deleted when FCM reports the token dead.
+
+### New table: `push_notification_log` (idempotency ledger)
+- `id`, `event_id` (indexed), `user_id`, `type` (`event_reminder_8h` | `event_departure`), `sent_at`, `timestamps`.
+- **Unique index on `(event_id, user_id, type)`.** A row's existence means "already sent." The hard cap of 2 notifications/event/user/day falls out of this. Per-user (not per-device) so a user with two devices isn't re-notified.
+
+### New column: `events.venue_timezone` (nullable string)
+- Caches the resolved IANA timezone for the event's venue, populated lazily on first send-time computation.
+
+### New models
+- `DeviceToken` (`belongsTo User`), `PushNotificationLog` (`belongsTo User`, `belongsTo Events`).
+
+## Components
+
+New classes in `app/Services/`:
+
+- **`EventTimelineMapper`** — extracted from the inline logic in `app/Http/Controllers/Api/Mobile/EventsController.php` so the API and the push share one definition of "timeline → first item / show time." Targeted refactor: pull the mapping out of the controller, have the controller call it, and reuse it here. `firstItem(event)` returns the timeline entry with the earliest parseable time; `showTime(event)` returns `event.start_time`.
+
+- **`VenueTimezoneResolver`** — `forEvent(event): string` (IANA zone). If `event.venue_timezone` is set, return it. Else geocode `event.venue_address` (reuse the app's existing Google key) → lat/lng → Google Time Zone API → IANA zone; cache it on `events.venue_timezone`. On any failure, return `config('app.timezone')` **without** caching (so it retries later).
+
+- **`LeaveByPushService`** — orchestrator. `run(Carbon $now)`: select today's rostered events; per event compute send-times via `VenueTimezoneResolver` + `EventTimelineMapper`; check `push_notification_log`; dispatch sends to recipients.
+
+- **`FcmSender`** — wraps `kreait` to send one data-only message to one token; returns `delivered` / `prune` (dead token) / `transient` (retryable).
+
+New controller: **`DeviceTokenController`** (`store`, `destroy`).
+New console command: **`notifications:tick`** → `LeaveByPushService::run(now())`.
+
+## Data Flow
+
+The tick (every 5 minutes):
+
+```
+notifications:tick → LeaveByPushService.run(now = Carbon::now())
+  1. Select today's events (across all bands) that have rostered members.
+     "Today" evaluated with a margin (now ± a few hours) so venue-tz events near
+     midnight aren't missed.
+  2. For each event (wrapped in try/catch — one bad event never aborts the run):
+     a. tz    = VenueTimezoneResolver.forEvent(event)        // cached on event
+     b. first = EventTimelineMapper.firstItem(event)         // earliest timeline time
+        show  = event.start_time
+     c. In tz:
+          firstItemDateTime = event.date + first.time (or start_time if no timeline)
+          send8h        = firstItemDateTime - 8h
+          sendDeparture = firstItemDateTime - DEPARTURE_LEAD_MINUTES (default 90)
+     d. For each send-type whose window contains now
+        (send-time ≤ now < send-time + GRACE_WINDOW, grace ≈ 30min > tick width):
+          recipients = rostered EventMembers (not absent/excused) with a device,
+                       excluding (event,user,type) already in push_notification_log
+          for each recipient:
+            build data-only payload → dispatch queued send job → FcmSender per token
+            on success: insert push_notification_log (event_id, user_id, type)
+            on dead token: delete device_tokens row
+```
+
+### Send-time definitions
+- **`event_reminder_8h`**: 8 hours before the first timeline item (or `start_time` if no timeline). The safety-net "you have a gig today."
+- **`event_departure`**: `DEPARTURE_LEAD_MINUTES` (default **90**) before the first item. Fires early enough that the device's computed "leave in 15 min" almost always still lies in the future. Tunable constant.
+
+### Data-only payload (matches the mobile Phase 1 contract exactly — flat camelCase, no `notification` block)
+```
+data: {
+  type: "event_reminder_8h" | "event_departure",
+  eventKey: <event.key>,
+  title: <event.title>,
+  venueAddress: <event.venue_address>,
+  firstItemTitle: <first.title>,
+  firstItemTime: <ISO8601 in venue tz>,
+  showTime: <event.start_time as ISO8601 in venue tz>
+}
+```
+Optional fields (`venueAddress`, `firstItemTitle`, `firstItemTime`, `showTime`) are omitted when absent. `type`, `eventKey`, `title` always present.
+
+### Idempotency & catch-up
+- The `(event_id, user_id, type)` unique index makes a duplicate send a no-op insert (caught and ignored).
+- The "due" check uses `send-time ≤ now < send-time + GRACE_WINDOW` with a grace window (~30 min) wider than the 5-min tick, so a single missed tick (deploy/downtime) still fires (slightly late) rather than being skipped.
+
+## Error Handling
+
+- **Geocode / Time Zone API failure** → `VenueTimezoneResolver` falls back to `config('app.timezone')`, logs a warning, does **not** cache the fallback (retries next time).
+- **FCM per-token result:** `unregistered`/`invalid-argument` → delete that `device_tokens` row. Transient (5xx/timeout) → log; queue retry handles it. Per-token try/catch so one bad token never blocks others.
+- **No devices / no timeline / no venue:** skip that send-type silently.
+- **The tick** wraps each event in try/catch (log + continue) so one bad event can't abort the run.
+- **Queue:** sends dispatched as queued jobs (Horizon) so a slow FCM call doesn't stall the tick. `onOneServer()` on the schedule entry prevents double-runs across servers.
+
+## Testing (PHPUnit + factories, `tests/Feature` + `tests/Unit`)
+
+- **Device endpoints (Feature):** register upserts by token; register requires `auth:sanctum`; delete removes only the caller's token.
+- **`EventTimelineMapper` (Unit):** first-item-is-earliest, show-is-`start_time`, empty/garbage timeline. Also assert the refactor leaves the existing `EventsController` output unchanged.
+- **`VenueTimezoneResolver` (Unit):** Google client faked (no live API) — returns zone, caches on event, falls back to app tz on failure (and does not cache the fallback).
+- **`LeaveByPushService` (Feature):** `FcmSender` faked, time frozen with `Carbon::setTestNow` (pinned — no live `now()` in assertions): due-window selection, idempotency (second run sends nothing), recipient filtering (absent/excused excluded, no-device excluded), dead-token pruning, per-event isolation on error, the 8h vs departure timing.
+- **Payload shape (Feature/Unit):** assert the exact data-only camelCase keys the app's `PushPayload.fromData` expects — this is the cross-repo contract.
+
+All commands run via `docker compose exec app …`.
+
+## Prerequisites (manual, external)
+
+- **Firebase service account JSON** for the backend (Firebase console → Project Settings → Service accounts → Generate new private key). Store as a secret; reference from `kreait` config. This is the same Firebase project the mobile app's Phase 1 used.
+- **Enable the Google Time Zone API** on the existing Google key used for geocoding.
+- Confirm the queue worker / Horizon is running in the target environment so dispatched send jobs are processed.
+
+## Open Items / Tuning (implementation-time)
+
+- `DEPARTURE_LEAD_MINUTES` (default 90) and `GRACE_WINDOW` (~30 min) — finalize during implementation.
+- "Today" selection margin for venue-tz edge cases near midnight.
+- Whether to batch FCM sends (kreait supports multicast) vs. one job per recipient — start simple (per recipient), optimize if volume warrants.

--- a/routes/api.php
+++ b/routes/api.php
@@ -94,7 +94,7 @@ Route::prefix('mobile')->group(function () {
 
         // Device registration (push notifications)
         Route::post('/devices', [App\Http\Controllers\Api\Mobile\DevicesController::class, 'store'])->name('mobile.devices.store');
-        Route::delete('/devices/{token}', [App\Http\Controllers\Api\Mobile\DevicesController::class, 'destroy'])->name('mobile.devices.destroy');
+        Route::delete('/devices', [App\Http\Controllers\Api\Mobile\DevicesController::class, 'destroy'])->name('mobile.devices.destroy');
 
         // Events
         Route::get('/events/{event}', [App\Http\Controllers\Api\Mobile\EventsController::class, 'show'])->name('mobile.events.show');

--- a/routes/api.php
+++ b/routes/api.php
@@ -92,6 +92,10 @@ Route::prefix('mobile')->group(function () {
         // Contract audit trail (band-agnostic — keyed by PandaDoc envelope id).
         Route::get('/contracts/{contract:envelope_id}/history', [App\Http\Controllers\Api\Mobile\BookingsController::class, 'contractHistory'])->name('mobile.contracts.history');
 
+        // Device registration (push notifications)
+        Route::post('/devices', [App\Http\Controllers\Api\Mobile\DevicesController::class, 'store'])->name('mobile.devices.store');
+        Route::delete('/devices/{token}', [App\Http\Controllers\Api\Mobile\DevicesController::class, 'destroy'])->name('mobile.devices.destroy');
+
         // Events
         Route::get('/events/{event}', [App\Http\Controllers\Api\Mobile\EventsController::class, 'show'])->name('mobile.events.show');
         Route::patch('/events/{event}', [App\Http\Controllers\Api\Mobile\EventsController::class, 'update'])->name('mobile.events.update');

--- a/tests/Feature/Push/DeviceRegistrationTest.php
+++ b/tests/Feature/Push/DeviceRegistrationTest.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Tests\Feature\Push;
+
+use App\Models\DeviceToken;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Sanctum\Sanctum;
+use Tests\TestCase;
+
+class DeviceRegistrationTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_register_requires_auth(): void
+    {
+        $this->postJson('/api/mobile/devices', ['token' => 't', 'platform' => 'ios'])
+            ->assertUnauthorized();
+    }
+
+    public function test_register_creates_token_for_user(): void
+    {
+        $user = User::factory()->create();
+        Sanctum::actingAs($user);
+
+        $this->postJson('/api/mobile/devices', ['token' => 'tok-abc', 'platform' => 'ios'])
+            ->assertOk();
+
+        $this->assertDatabaseHas('device_tokens', [
+            'user_id' => $user->id, 'token' => 'tok-abc', 'platform' => 'ios',
+        ]);
+    }
+
+    public function test_register_is_idempotent_by_token(): void
+    {
+        $user = User::factory()->create();
+        Sanctum::actingAs($user);
+
+        $this->postJson('/api/mobile/devices', ['token' => 'tok-abc', 'platform' => 'ios'])->assertOk();
+        $this->postJson('/api/mobile/devices', ['token' => 'tok-abc', 'platform' => 'android'])->assertOk();
+
+        $this->assertSame(1, DeviceToken::where('token', 'tok-abc')->count());
+        $this->assertDatabaseHas('device_tokens', ['token' => 'tok-abc', 'platform' => 'android']);
+    }
+
+    public function test_validation_rejects_bad_platform(): void
+    {
+        Sanctum::actingAs(User::factory()->create());
+        $this->postJson('/api/mobile/devices', ['token' => 't', 'platform' => 'windows'])
+            ->assertStatus(422);
+    }
+
+    public function test_destroy_removes_only_callers_token(): void
+    {
+        $me = User::factory()->create();
+        $other = User::factory()->create();
+        DeviceToken::factory()->create(['user_id' => $other->id, 'token' => 'theirs', 'platform' => 'ios']);
+        DeviceToken::factory()->create(['user_id' => $me->id, 'token' => 'mine', 'platform' => 'ios']);
+
+        Sanctum::actingAs($me);
+        $this->deleteJson('/api/mobile/devices/mine')->assertOk();
+
+        $this->assertDatabaseMissing('device_tokens', ['token' => 'mine']);
+        $this->assertDatabaseHas('device_tokens', ['token' => 'theirs']);
+    }
+}

--- a/tests/Feature/Push/DeviceRegistrationTest.php
+++ b/tests/Feature/Push/DeviceRegistrationTest.php
@@ -58,9 +58,21 @@ class DeviceRegistrationTest extends TestCase
         DeviceToken::factory()->create(['user_id' => $me->id, 'token' => 'mine', 'platform' => 'ios']);
 
         Sanctum::actingAs($me);
-        $this->deleteJson('/api/mobile/devices/mine')->assertOk();
+        $this->deleteJson('/api/mobile/devices', ['token' => 'mine'])->assertOk();
 
         $this->assertDatabaseMissing('device_tokens', ['token' => 'mine']);
         $this->assertDatabaseHas('device_tokens', ['token' => 'theirs']);
+    }
+
+    public function test_destroy_handles_tokens_with_slashes_and_colons(): void
+    {
+        $me = User::factory()->create();
+        $weird = 'fcm:abc/def-ghi:jkl';
+        DeviceToken::factory()->create(['user_id' => $me->id, 'token' => $weird, 'platform' => 'android']);
+
+        Sanctum::actingAs($me);
+        $this->deleteJson('/api/mobile/devices', ['token' => $weird])->assertOk();
+
+        $this->assertDatabaseMissing('device_tokens', ['token' => $weird]);
     }
 }

--- a/tests/Feature/Push/LeaveByPushServiceTest.php
+++ b/tests/Feature/Push/LeaveByPushServiceTest.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace Tests\Feature\Push;
+
+use App\Jobs\SendEventPush;
+use App\Models\Bands;
+use App\Models\Bookings;
+use App\Models\DeviceToken;
+use App\Models\EventMember;
+use App\Models\Events;
+use App\Models\PushNotificationLog;
+use App\Models\User;
+use App\Services\Push\LeaveByPushService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Queue;
+use Tests\TestCase;
+
+class LeaveByPushServiceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function tearDown(): void
+    {
+        Carbon::setTestNow();
+        parent::tearDown();
+    }
+
+    private function makeRosteredEvent(string $date, string $startTime, string $firstItemTime): array
+    {
+        $band = Bands::factory()->create();
+        $booking = Bookings::factory()->create(['band_id' => $band->id]);
+        $event = Events::factory()->create([
+            'eventable_id'   => $booking->id,
+            'eventable_type' => Bookings::class,
+            'date'           => $date,
+            'start_time'     => $startTime,
+            'title'          => 'Gig',
+            'venue_address'  => '100 Main St',
+            'venue_timezone' => 'America/Chicago',
+            'additional_data'=> ['times' => [['title' => 'Load In', 'time' => $firstItemTime]]],
+        ]);
+        $user = User::factory()->create();
+        DeviceToken::factory()->create(['user_id' => $user->id, 'platform' => 'ios']);
+        EventMember::create([
+            'event_id' => $event->id, 'band_id' => $band->id, 'user_id' => $user->id,
+            'attendance_status' => 'confirmed',
+        ]);
+        return [$event, $user];
+    }
+
+    public function test_dispatches_8h_reminder_in_its_window(): void
+    {
+        Queue::fake();
+        [$event, $user] = $this->makeRosteredEvent('2026-06-14', '19:00', '2026-06-14 14:00:00');
+        Carbon::setTestNow(Carbon::parse('2026-06-14 11:00:00', 'UTC')); // 14:00 Chicago - 8h = 06:00 CT = 11:00 UTC
+
+        $this->app->make(LeaveByPushService::class)->run(Carbon::now());
+
+        Queue::assertPushed(SendEventPush::class, function ($job) use ($event, $user) {
+            return $job->type === 'event_reminder_8h'
+                && $job->eventId === $event->id
+                && $job->userId === $user->id
+                && $job->payload['type'] === 'event_reminder_8h'
+                && $job->payload['firstItemTitle'] === 'Load In';
+        });
+    }
+
+    public function test_does_not_dispatch_when_already_logged(): void
+    {
+        Queue::fake();
+        [$event, $user] = $this->makeRosteredEvent('2026-06-14', '19:00', '2026-06-14 14:00:00');
+        PushNotificationLog::create(['event_id' => $event->id, 'user_id' => $user->id, 'type' => 'event_reminder_8h']);
+        Carbon::setTestNow(Carbon::parse('2026-06-14 11:00:00', 'UTC'));
+
+        $this->app->make(LeaveByPushService::class)->run(Carbon::now());
+
+        Queue::assertNotPushed(SendEventPush::class, fn ($j) => $j->type === 'event_reminder_8h');
+    }
+
+    public function test_excludes_absent_members(): void
+    {
+        Queue::fake();
+        [$event] = $this->makeRosteredEvent('2026-06-14', '19:00', '2026-06-14 14:00:00');
+        EventMember::where('event_id', $event->id)->update(['attendance_status' => 'absent']);
+        Carbon::setTestNow(Carbon::parse('2026-06-14 11:00:00', 'UTC'));
+
+        $this->app->make(LeaveByPushService::class)->run(Carbon::now());
+
+        Queue::assertNotPushed(SendEventPush::class);
+    }
+
+    public function test_nothing_dispatched_outside_windows(): void
+    {
+        Queue::fake();
+        $this->makeRosteredEvent('2026-06-14', '19:00', '2026-06-14 14:00:00');
+        Carbon::setTestNow(Carbon::parse('2026-06-14 02:00:00', 'UTC'));
+
+        $this->app->make(LeaveByPushService::class)->run(Carbon::now());
+
+        Queue::assertNotPushed(SendEventPush::class);
+    }
+}

--- a/tests/Feature/Push/LeaveByPushServiceTest.php
+++ b/tests/Feature/Push/LeaveByPushServiceTest.php
@@ -66,6 +66,25 @@ class LeaveByPushServiceTest extends TestCase
         });
     }
 
+    public function test_dispatches_departure_trigger_in_its_window(): void
+    {
+        Queue::fake();
+        // First item 14:00 Chicago (CDT, UTC-5) - 90min = 12:30 CT = 17:30 UTC.
+        [$event, $user] = $this->makeRosteredEvent('2026-06-14', '19:00', '2026-06-14 14:00:00');
+        Carbon::setTestNow(Carbon::parse('2026-06-14 17:30:00', 'UTC'));
+
+        $this->app->make(LeaveByPushService::class)->run(Carbon::now());
+
+        Queue::assertPushed(SendEventPush::class, function ($job) use ($event, $user) {
+            return $job->type === 'event_departure'
+                && $job->eventId === $event->id
+                && $job->userId === $user->id
+                && $job->payload['type'] === 'event_departure';
+        });
+        // The 8h window (06:00 CT) is long past, so it must NOT also fire.
+        Queue::assertNotPushed(SendEventPush::class, fn ($j) => $j->type === 'event_reminder_8h');
+    }
+
     public function test_does_not_dispatch_when_already_logged(): void
     {
         Queue::fake();

--- a/tests/Feature/Push/PayloadContractTest.php
+++ b/tests/Feature/Push/PayloadContractTest.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Tests\Feature\Push;
+
+use App\Jobs\SendEventPush;
+use App\Models\Bands;
+use App\Models\Bookings;
+use App\Models\DeviceToken;
+use App\Models\EventMember;
+use App\Models\Events;
+use App\Models\User;
+use App\Services\Push\LeaveByPushService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Queue;
+use Tests\TestCase;
+
+class PayloadContractTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function tearDown(): void
+    {
+        Carbon::setTestNow();
+        parent::tearDown();
+    }
+
+    public function test_payload_keys_match_mobile_contract(): void
+    {
+        Queue::fake();
+        $band = Bands::factory()->create();
+        $booking = Bookings::factory()->create(['band_id' => $band->id]);
+        $event = Events::factory()->create([
+            'eventable_id' => $booking->id, 'eventable_type' => Bookings::class,
+            'date' => '2026-06-14', 'start_time' => '19:00', 'title' => 'Gig',
+            'venue_address' => '100 Main St', 'venue_timezone' => 'America/Chicago',
+            'additional_data' => ['times' => [['title' => 'Load In', 'time' => '2026-06-14 14:00:00']]],
+        ]);
+        $user = User::factory()->create();
+        DeviceToken::factory()->create(['user_id' => $user->id, 'platform' => 'ios']);
+        EventMember::create(['event_id' => $event->id, 'band_id' => $band->id, 'user_id' => $user->id, 'attendance_status' => 'confirmed']);
+
+        Carbon::setTestNow(Carbon::parse('2026-06-14 11:00:00', 'UTC'));
+        $this->app->make(LeaveByPushService::class)->run(Carbon::now());
+
+        Queue::assertPushed(SendEventPush::class, function ($job) {
+            $allowed = ['type', 'eventKey', 'title', 'venueAddress', 'firstItemTitle', 'firstItemTime', 'showTime'];
+            foreach (array_keys($job->payload) as $k) {
+                if (!in_array($k, $allowed, true)) {
+                    return false;
+                }
+            }
+            return $job->payload['type'] === 'event_reminder_8h'
+                && $job->payload['eventKey'] !== ''
+                && array_key_exists('firstItemTitle', $job->payload)
+                && array_key_exists('showTime', $job->payload);
+        });
+    }
+}

--- a/tests/Feature/Push/SendEventPushTest.php
+++ b/tests/Feature/Push/SendEventPushTest.php
@@ -1,0 +1,96 @@
+<?php
+
+namespace Tests\Feature\Push;
+
+use App\Jobs\SendEventPush;
+use App\Models\Bands;
+use App\Models\Bookings;
+use App\Models\DeviceToken;
+use App\Models\Events;
+use App\Models\PushNotificationLog;
+use App\Models\User;
+use App\Services\Push\FcmSender;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class _FakeFcm extends FcmSender
+{
+    public array $sent = [];
+    public string $result = FcmSender::DELIVERED;
+    public function __construct() {}
+    public function sendData(string $token, array $data): string
+    {
+        $this->sent[] = ['token' => $token, 'data' => $data];
+        return $this->result;
+    }
+}
+
+class SendEventPushTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function event(): Events
+    {
+        $band = Bands::factory()->create();
+        $booking = Bookings::factory()->create(['band_id' => $band->id]);
+        return Events::factory()->create([
+            'eventable_id'   => $booking->id,
+            'eventable_type' => Bookings::class,
+            'title'          => 'Gig',
+            'venue_address'  => '100 Main St',
+        ]);
+    }
+
+    public function test_sends_data_only_payload_to_each_token_and_logs(): void
+    {
+        $fake = new _FakeFcm();
+        $this->app->instance(FcmSender::class, $fake);
+
+        $user = User::factory()->create();
+        DeviceToken::factory()->create(['user_id' => $user->id, 'token' => 'a', 'platform' => 'ios']);
+        DeviceToken::factory()->create(['user_id' => $user->id, 'token' => 'b', 'platform' => 'android']);
+        $event = $this->event();
+
+        (new SendEventPush(
+            eventId: $event->id,
+            userId: $user->id,
+            type: 'event_reminder_8h',
+            payload: [
+                'type' => 'event_reminder_8h',
+                'eventKey' => $event->key,
+                'title' => 'Gig',
+                'venueAddress' => '100 Main St',
+                'firstItemTitle' => 'Load In',
+                'firstItemTime' => '2026-06-14T14:00:00-05:00',
+                'showTime' => '2026-06-14T19:00:00-05:00',
+            ],
+        ))->handle($fake);
+
+        $this->assertCount(2, $fake->sent);
+        $this->assertSame('event_reminder_8h', $fake->sent[0]['data']['type']);
+        $this->assertSame($event->key, $fake->sent[0]['data']['eventKey']);
+        $this->assertDatabaseHas('push_notification_log', [
+            'event_id' => $event->id, 'user_id' => $user->id, 'type' => 'event_reminder_8h',
+        ]);
+    }
+
+    public function test_prunes_dead_tokens(): void
+    {
+        $fake = new _FakeFcm();
+        $fake->result = FcmSender::PRUNE;
+        $this->app->instance(FcmSender::class, $fake);
+
+        $user = User::factory()->create();
+        DeviceToken::factory()->create(['user_id' => $user->id, 'token' => 'dead', 'platform' => 'ios']);
+        $event = $this->event();
+
+        (new SendEventPush($event->id, $user->id, 'event_departure', [
+            'type' => 'event_departure', 'eventKey' => $event->key, 'title' => 'Gig',
+        ]))->handle($fake);
+
+        $this->assertDatabaseMissing('device_tokens', ['token' => 'dead']);
+        $this->assertDatabaseMissing('push_notification_log', [
+            'event_id' => $event->id, 'user_id' => $user->id, 'type' => 'event_departure',
+        ]);
+    }
+}

--- a/tests/Feature/Push/SendLeaveByNotificationsCommandTest.php
+++ b/tests/Feature/Push/SendLeaveByNotificationsCommandTest.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Tests\Feature\Push;
+
+use App\Services\Push\LeaveByPushService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Mockery;
+use Tests\TestCase;
+
+class SendLeaveByNotificationsCommandTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_tick_invokes_service_run(): void
+    {
+        $mock = Mockery::mock(LeaveByPushService::class);
+        $mock->shouldReceive('run')->once();
+        $this->app->instance(LeaveByPushService::class, $mock);
+
+        $this->artisan('notifications:tick')->assertExitCode(0);
+    }
+}

--- a/tests/Unit/Push/DeviceTokenTest.php
+++ b/tests/Unit/Push/DeviceTokenTest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Tests\Unit\Push;
+
+use App\Models\DeviceToken;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class DeviceTokenTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_belongs_to_a_user(): void
+    {
+        $user = User::factory()->create();
+        $token = DeviceToken::factory()->create(['user_id' => $user->id]);
+
+        $this->assertTrue($token->user->is($user));
+    }
+
+    public function test_token_is_unique(): void
+    {
+        DeviceToken::factory()->create(['token' => 'abc']);
+        $this->expectException(\Illuminate\Database\QueryException::class);
+        DeviceToken::factory()->create(['token' => 'abc']);
+    }
+}

--- a/tests/Unit/Push/PushNotificationLogTest.php
+++ b/tests/Unit/Push/PushNotificationLogTest.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Tests\Unit\Push;
+
+use App\Models\PushNotificationLog;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class PushNotificationLogTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_event_user_type_is_unique(): void
+    {
+        PushNotificationLog::create(['event_id' => 1, 'user_id' => 1, 'type' => 'event_reminder_8h']);
+        $this->expectException(\Illuminate\Database\QueryException::class);
+        PushNotificationLog::create(['event_id' => 1, 'user_id' => 1, 'type' => 'event_reminder_8h']);
+    }
+
+    public function test_same_event_user_different_type_allowed(): void
+    {
+        PushNotificationLog::create(['event_id' => 1, 'user_id' => 1, 'type' => 'event_reminder_8h']);
+        PushNotificationLog::create(['event_id' => 1, 'user_id' => 1, 'type' => 'event_departure']);
+        $this->assertSame(2, PushNotificationLog::count());
+    }
+}

--- a/tests/Unit/Push/VenueTimezoneResolverTest.php
+++ b/tests/Unit/Push/VenueTimezoneResolverTest.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Tests\Unit\Push;
+
+use App\Models\Bands;
+use App\Models\Bookings;
+use App\Models\Events;
+use App\Services\Push\VenueTimezoneResolver;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class VenueTimezoneResolverTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function eventWithAddress(?string $address): Events
+    {
+        $band = Bands::factory()->create();
+        $booking = Bookings::factory()->create(['band_id' => $band->id]);
+        return Events::factory()->create([
+            'eventable_id'   => $booking->id,
+            'eventable_type' => Bookings::class,
+            'venue_address'  => $address,
+        ]);
+    }
+
+    public function test_returns_cached_timezone_without_calling_lookup(): void
+    {
+        $event = $this->eventWithAddress('100 Main St');
+        $event->venue_timezone = 'America/Chicago';
+        $event->save();
+
+        $resolver = new VenueTimezoneResolver(function () {
+            $this->fail('should not look up when cached');
+        });
+
+        $this->assertSame('America/Chicago', $resolver->forEvent($event));
+    }
+
+    public function test_looks_up_caches_and_returns(): void
+    {
+        $event = $this->eventWithAddress('100 Main St, Austin TX');
+        $resolver = new VenueTimezoneResolver(fn (string $addr) => 'America/Chicago');
+
+        $this->assertSame('America/Chicago', $resolver->forEvent($event));
+        $this->assertSame('America/Chicago', $event->fresh()->venue_timezone);
+    }
+
+    public function test_falls_back_to_app_tz_without_caching_on_failure(): void
+    {
+        config(['app.timezone' => 'America/New_York']);
+        $event = $this->eventWithAddress('nowhere');
+        $resolver = new VenueTimezoneResolver(fn (string $addr) => null);
+
+        $this->assertSame('America/New_York', $resolver->forEvent($event));
+        $this->assertNull($event->fresh()->venue_timezone);
+    }
+
+    public function test_no_address_uses_app_tz(): void
+    {
+        config(['app.timezone' => 'America/New_York']);
+        $event = $this->eventWithAddress(null);
+        $resolver = new VenueTimezoneResolver(function () {
+            $this->fail('no lookup for empty address');
+        });
+
+        $this->assertSame('America/New_York', $resolver->forEvent($event));
+    }
+}


### PR DESCRIPTION
## Summary

Backend for the event-day "leave by" push notifications whose mobile client already shipped. Registers device tokens and, on a 5-minute scheduler tick, sends two data-only FCM pushes per rostered event per day — an 8h-before reminder and a departure trigger — at times computed in the **venue's** timezone, idempotently.

- **Device endpoints:** `POST /api/mobile/devices` (upsert by token) and `DELETE /api/mobile/devices` (token in body, scoped to the caller). Token travels in the body, not the URL, because FCM tokens can contain `/` and `:`.
- **FCM via `kreait/laravel-firebase`** (`FcmSender`) — data-only messages, delivers to both platforms; dead tokens are pruned, transient errors retried.
- **`VenueTimezoneResolver`** — derives the venue's IANA timezone (geocode → Time Zone API via the existing google-maps package), cached on `events.venue_timezone`; falls back to app tz without caching on failure.
- **`LeaveByPushService`** (tick → service → `SendEventPush` job → `FcmSender`) — selects today's rostered events, computes 8h/90-min send-times in venue tz, dispatches to active roster members who have a device, skipping anything already in the `push_notification_log` idempotency ledger (`(event_id, user_id, type)` unique index).
- **`notifications:tick`** command scheduled every 5 minutes, `onOneServer()`.

Payload contract (flat camelCase: `type`, `eventKey`, `title`, `venueAddress?`, `firstItemTitle?`, `firstItemTime?`, `showTime?`) is verified key-for-key against the merged mobile `PushPayload.fromData`.

New tables: `device_tokens`, `push_notification_log`; new column `events.venue_timezone`.

## Manual prerequisites before this delivers
- [ ] Firebase **service account JSON** (`FIREBASE_CREDENTIALS`) deployed (same Firebase project as the mobile client).
- [ ] Enable the **Google Time Zone API** on the `GOOGLE_MAPS_API_KEY` project.
- [ ] Confirm Horizon/queue workers run in the target environment.

## Test Plan
- [x] `php artisan test tests/Feature/Push tests/Unit/Push` — 23 passed (device register/deregister + ownership, idempotency, recipient filtering, dead-token pruning, venue-tz cache/fallback, 8h + departure timing windows, payload contract)
- [x] Full suite `php artisan test` — 1133 passed, 0 failures, 2 pre-existing incomplete (no regressions)
- [ ] Smoke test on staging with a real device token once Firebase credentials + Time Zone API are in place

🤖 Generated with [Claude Code](https://claude.com/claude-code)