### PR TITLE
fix(push): prune tokens on invalid-token errors

### DIFF
--- a/app/Services/Push/FcmSender.php
+++ b/app/Services/Push/FcmSender.php
@@ -4,6 +4,8 @@ namespace App\Services\Push;
 
 use Illuminate\Support\Facades\Log;
 use Kreait\Firebase\Contract\Messaging;
+use Kreait\Firebase\Exception\Messaging\InvalidArgument;
+use Kreait\Firebase\Exception\Messaging\InvalidMessage;
 use Kreait\Firebase\Exception\Messaging\NotFound;
 use Kreait\Firebase\Exception\MessagingException;
 use Kreait\Firebase\Messaging\CloudMessage;
@@ -26,7 +28,9 @@ class FcmSender
             $message = CloudMessage::new()->withToken($token)->withData($data);
             $this->messaging->send($message);
             return self::DELIVERED;
-        } catch (NotFound $e) {
+        } catch (NotFound | InvalidMessage | InvalidArgument) {
+            // Permanently bad token: unregistered (404) or malformed/invalid
+            // registration token (400). It will never become valid — prune it.
             return self::PRUNE;
         } catch (MessagingException $e) {
             Log::warning('FcmSender transient error', ['error' => $e->getMessage()]);


### PR DESCRIPTION
Follow-up to #412 (already merged).

While verifying Firebase credentials end-to-end, a diagnostic send to a malformed token returned `InvalidMessage` (HTTP 400 "not a valid FCM registration token") — which `FcmSender` was classifying as `transient` (retryable). A token that's malformed/invalid is permanently bad, just like a 404 `NotFound`, so it should be pruned rather than retried forever by the queue.

`FcmSender::sendData` now returns `PRUNE` for `NotFound | InvalidMessage | InvalidArgument`. Verified end-to-end: a malformed token now returns `prune` (was `transient`), and the existing `SendEventPushTest` still passes (a `PRUNE` result deletes the device token).

## Test Plan
- [x] `php artisan test tests/Feature/Push/SendEventPushTest.php` — 2 passed
- [x] Live: `FcmSender->sendData('bogus', [...])` returns `prune` (real FCM round-trip, auth confirmed working)

🤖 Generated with [Claude Code](https://claude.com/claude-code)