### PR TITLE
fix(mobile): show subs the same events as web

### DIFF
--- a/app/Http/Controllers/Api/Mobile/EventsController.php
+++ b/app/Http/Controllers/Api/Mobile/EventsController.php
@@ -17,8 +17,10 @@ use App\Models\EventMember;
 use App\Models\LiveSetlistSession;
 use App\Models\SubstituteCallList;
 use App\Services\Mobile\EventDataService;
+use App\Services\UserEventsService;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
+use Illuminate\Support\Carbon;
 use Illuminate\Support\Str;
 
 class EventsController extends Controller
@@ -34,21 +36,35 @@ class EventsController extends Controller
             abort(403);
         }
 
-        $events = Events::where(function ($q) use ($band) {
-            $q->where(function ($inner) use ($band) {
-                $inner->where('eventable_type', Bookings::class)
-                    ->whereHas('eventable', fn ($bq) => $bq->where('band_id', $band->id));
-            })->orWhere(function ($inner) use ($band) {
-                $inner->where('eventable_type', BandEvents::class)
-                    ->whereHas('eventable', fn ($bq) => $bq->where('band_id', $band->id));
-            })->orWhere(function ($inner) use ($band) {
-                $inner->where('eventable_type', 'App\\Models\\Rehearsal')
-                    ->whereHas('eventable', fn ($rq) => $rq->where('band_id', $band->id));
-            });
-        })
+        // Resolve the exact set of events this user is entitled to see using the
+        // same logic the web dashboard uses (UserEventsService). For a sub-only
+        // user this is just their assigned events, not every band event — which
+        // is what keeps the mobile list identical to the web list. The service
+        // owns the date window (default: now()->subHours(72)); the {band} route
+        // then narrows that user-scoped set to this band.
+        $afterDate  = $request->filled('from') ? Carbon::parse($request->input('from')) : null;
+        $beforeDate = $request->filled('to') ? Carbon::parse($request->input('to'))->addDay() : null;
+
+        $entitledIds = (new UserEventsService())->getEventIds($afterDate, $beforeDate);
+
+        if (empty($entitledIds)) {
+            return response()->json(['events' => []]);
+        }
+
+        $events = Events::whereIn('id', $entitledIds)
+            ->where(function ($q) use ($band) {
+                $q->where(function ($inner) use ($band) {
+                    $inner->where('eventable_type', Bookings::class)
+                        ->whereHas('eventable', fn ($bq) => $bq->where('band_id', $band->id));
+                })->orWhere(function ($inner) use ($band) {
+                    $inner->where('eventable_type', BandEvents::class)
+                        ->whereHas('eventable', fn ($bq) => $bq->where('band_id', $band->id));
+                })->orWhere(function ($inner) use ($band) {
+                    $inner->where('eventable_type', 'App\\Models\\Rehearsal')
+                        ->whereHas('eventable', fn ($rq) => $rq->where('band_id', $band->id));
+                });
+            })
             ->with(['eventable', 'type'])
-            ->when($request->filled('from'), fn ($q) => $q->whereDate('date', '>=', $request->input('from')))
-            ->when($request->filled('to'),   fn ($q) => $q->whereDate('date', '<=', $request->input('to')))
             ->orderBy('date')->orderBy('start_time')
             ->get();
 

--- a/app/Services/Mobile/TokenService.php
+++ b/app/Services/Mobile/TokenService.php
@@ -12,23 +12,21 @@ class TokenService
     {
         $abilities = ['mobile'];
 
+        // Delegate to User::canRead()/canWrite() rather than re-checking Spatie
+        // permissions directly. Those methods already encode the owner shortcut
+        // AND the sub exception (a sub-of-band can read events even without the
+        // `read:events` permission). Re-implementing the check here is what let
+        // the token abilities drift from the controller's canRead() gate, so a
+        // sub passed canRead() inside the controller but their token lacked
+        // `read:events` and the mobile.band:read:events middleware 403'd them.
         foreach ($user->allBands() as $band) {
-            if ($user->ownsBand($band->id)) {
-                foreach (self::RESOURCES as $resource) {
+            foreach (self::RESOURCES as $resource) {
+                if ($user->canRead($resource, $band->id)) {
                     $abilities[] = "read:{$resource}";
+                }
+                if ($user->canWrite($resource, $band->id)) {
                     $abilities[] = "write:{$resource}";
                 }
-            } else {
-                setPermissionsTeamId($band->id);
-                foreach (self::RESOURCES as $resource) {
-                    if ($user->hasPermissionTo("read:{$resource}")) {
-                        $abilities[] = "read:{$resource}";
-                    }
-                    if ($user->hasPermissionTo("write:{$resource}")) {
-                        $abilities[] = "write:{$resource}";
-                    }
-                }
-                setPermissionsTeamId(0);
             }
         }
 

--- a/app/Services/UserEventsService.php
+++ b/app/Services/UserEventsService.php
@@ -11,6 +11,26 @@ use Illuminate\Support\Carbon;
 
 class UserEventsService
 {
+    /**
+     * Return the set of event IDs the authenticated user is entitled to see,
+     * using the exact same scoping rules as getEvents() (owner/member → all
+     * band events; sub-only → assigned events), including the default
+     * now()->subHours(72) window.
+     *
+     * This is the single source of truth for "which events does this user
+     * see" so the mobile API and the web dashboard cannot diverge. Virtual
+     * rehearsals (which have no real event id) are naturally excluded.
+     */
+    public function getEventIds($afterDate = null, $beforeDate = null)
+    {
+        return $this->getEvents($afterDate, $beforeDate)
+            ->pluck('id')
+            ->filter()
+            ->unique()
+            ->values()
+            ->all();
+    }
+
     public function getEvents($afterDate = null, $beforeDate = null, $limit = null)
     {
         if ($afterDate === null) {

--- a/tests/Feature/Api/Mobile/MobileSubEventsParityTest.php
+++ b/tests/Feature/Api/Mobile/MobileSubEventsParityTest.php
@@ -1,0 +1,163 @@
+<?php
+
+namespace Tests\Feature\Api\Mobile;
+
+use App\Models\BandSubs;
+use App\Models\Bands;
+use App\Models\Bookings;
+use App\Models\EventMember;
+use App\Models\Events;
+use App\Models\EventSubs;
+use App\Models\EventTypes;
+use App\Models\User;
+use App\Services\Mobile\TokenService;
+use App\Services\UserEventsService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Auth;
+use Spatie\Permission\Models\Role;
+use Tests\TestCase;
+
+/**
+ * Regression test for: a user who is ONLY a sub of a band sees their events on
+ * the WEB app (UserEventsService) but NOT on mobile.
+ *
+ * Reproduces production user 40 (band 1):
+ *  - role `sub` WITHOUT the Spatie `read:events` permission (matches prod, where
+ *    the sub role only carries view-* permissions)
+ *  - in band_subs for the band (no band_owners / band_members)
+ *  - assigned to some events via event_members (roster_member_id NULL) / event_subs
+ *
+ * The mobile events index must return EXACTLY the set UserEventsService returns
+ * for the same user, using a REAL token built by TokenService (not a wildcard
+ * test token, which masked the ability gate).
+ */
+class MobileSubEventsParityTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private Bands $band;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // Sub role is global; assignments live at team_id=0.
+        setPermissionsTeamId(0);
+
+        // Create the `sub` role WITHOUT read:events — matching production, where
+        // the sub role carries only view-* permissions and relies on the
+        // isSubOfBand() exception in User::canRead() for event access.
+        Role::firstOrCreate(['name' => 'sub', 'guard_name' => 'web']);
+
+        $this->band = Bands::factory()->create();
+    }
+
+    /**
+     * Build a sub-only user: in band_subs for the band, role `sub`, assigned to
+     * the given events. Returns the user.
+     */
+    private function makeSubAssignedTo(array $events): User
+    {
+        $sub = User::factory()->create();
+        $sub->assignRole('sub');
+
+        BandSubs::firstOrCreate(['user_id' => $sub->id, 'band_id' => $this->band->id]);
+
+        foreach ($events as $event) {
+            EventMember::create([
+                'event_id'         => $event->id,
+                'band_id'          => $this->band->id,
+                'user_id'          => $sub->id,
+                'roster_member_id' => null,
+                'name'             => $sub->name,
+            ]);
+        }
+
+        return $sub;
+    }
+
+    private function makeBookingEvent(string $date): Events
+    {
+        $eventType = EventTypes::factory()->create();
+        $booking   = Bookings::factory()->create(['band_id' => $this->band->id]);
+
+        return Events::factory()->create([
+            'eventable_id'   => $booking->id,
+            'eventable_type' => 'App\\Models\\Bookings',
+            'event_type_id'  => $eventType->id,
+            'date'           => $date,
+        ]);
+    }
+
+    private function realTokenFor(User $user): string
+    {
+        $abilities = app(TokenService::class)->buildAbilities($user);
+
+        return $user->createToken('test-device', $abilities)->plainTextToken;
+    }
+
+    public function test_sub_can_reach_events_index_with_real_token(): void
+    {
+        $assigned = $this->makeBookingEvent(now()->addDays(7)->format('Y-m-d'));
+        $sub      = $this->makeSubAssignedTo([$assigned]);
+
+        $this->withToken($this->realTokenFor($sub))
+            ->withHeaders(['X-Band-ID' => $this->band->id])
+            ->getJson("/api/mobile/bands/{$this->band->id}/events")
+            ->assertOk();
+    }
+
+    public function test_mobile_returns_exactly_the_web_event_set_for_a_sub(): void
+    {
+        // Two assigned (future) events and one unassigned band event.
+        $assigned1  = $this->makeBookingEvent(now()->addDays(7)->format('Y-m-d'));
+        $assigned2  = $this->makeBookingEvent(now()->addDays(14)->format('Y-m-d'));
+        $unassigned = $this->makeBookingEvent(now()->addDays(21)->format('Y-m-d'));
+
+        $sub = $this->makeSubAssignedTo([$assigned1, $assigned2]);
+
+        // What web returns for this user (the source of truth).
+        Auth::login($sub);
+        $webIds = (new UserEventsService())->getEvents()->pluck('id')->sort()->values()->all();
+        Auth::logout();
+
+        $response = $this->withToken($this->realTokenFor($sub))
+            ->withHeaders(['X-Band-ID' => $this->band->id])
+            ->getJson("/api/mobile/bands/{$this->band->id}/events")
+            ->assertOk();
+
+        $mobileIds = collect($response->json('events'))->pluck('id')->sort()->values()->all();
+
+        // Mobile must equal web exactly.
+        $this->assertSame($webIds, $mobileIds, 'Mobile event set must match web UserEventsService set.');
+
+        // And concretely: the two assigned events are present, the unassigned is not.
+        $this->assertContains($assigned1->id, $mobileIds);
+        $this->assertContains($assigned2->id, $mobileIds);
+        $this->assertNotContains($unassigned->id, $mobileIds);
+    }
+
+    public function test_mobile_excludes_past_events_outside_default_window_like_web(): void
+    {
+        // Assigned but well in the past (outside web's now-72h default window).
+        $pastAssigned   = $this->makeBookingEvent(now()->subDays(30)->format('Y-m-d'));
+        $futureAssigned = $this->makeBookingEvent(now()->addDays(10)->format('Y-m-d'));
+
+        $sub = $this->makeSubAssignedTo([$pastAssigned, $futureAssigned]);
+
+        Auth::login($sub);
+        $webIds = (new UserEventsService())->getEvents()->pluck('id')->sort()->values()->all();
+        Auth::logout();
+
+        $response = $this->withToken($this->realTokenFor($sub))
+            ->withHeaders(['X-Band-ID' => $this->band->id])
+            ->getJson("/api/mobile/bands/{$this->band->id}/events")
+            ->assertOk();
+
+        $mobileIds = collect($response->json('events'))->pluck('id')->sort()->values()->all();
+
+        $this->assertSame($webIds, $mobileIds);
+        $this->assertNotContains($pastAssigned->id, $mobileIds, 'Past event outside 72h window must be hidden on mobile, as on web.');
+        $this->assertContains($futureAssigned->id, $mobileIds);
+    }
+}


### PR DESCRIPTION
## Summary

Sub-only users (in `band_subs`, role `sub`, on `event_members` with `roster_member_id` NULL) saw their events on the **web** app but got an **empty list on mobile**. Root cause was two compounding backend bugs — the mobile API never actually used `UserEventsService` like the web does.

- **403 before the controller ran.** `TokenService::buildAbilities()` only granted `read:events` via the Spatie `read:events` permission, which the `sub` role lacks. `User::canRead()` special-cases `isSubOfBand()`, so the controller *would* allow it — but the `mobile.band:read:events` middleware (`tokenCan`) rejected the request first. Fixed by delegating `buildAbilities()` to `canRead()`/`canWrite()` so token abilities can't drift from the controller gate.
- **Wrong event set even past the 403.** `EventsController::index` returned *all* band events, whereas web's `UserEventsService` returns only a sub's *assigned* events (with a `now-72h` default window). Added `UserEventsService::getEventIds()` as the single source of truth and scoped the mobile index to it, then formatted via the existing `formatForList` (Flutter `EventSummary` shape unchanged).

Verified against the production dump (user 40, band 1): mobile now returns **exactly the same 8 events** as web.

## Why the tests didn't catch it

Existing mobile tests minted wildcard `['*']` tokens, which masks the ability gate entirely. The new `MobileSubEventsParityTest` builds **real** `TokenService` tokens and asserts the mobile event set equals the `UserEventsService` set.

## Test Plan

- [x] `MobileSubEventsParityTest` (new) — sub reaches index with a real token; mobile set == web set; past events outside the 72h window excluded
- [x] `EventsTest`, `AssignSubBandAccessTest`, `SubEventFilteringTest` pass (no regressions)
- [x] Broader sub/dashboard/token/permission suites: 213 passing
- [ ] Manual: log in as a sub-only user on mobile and confirm the event list matches web

## ⚠️ Deploy note

Token abilities are computed at **login**, so existing issued sub tokens still lack `read:events` until those users re-login. If we want affected subs fixed immediately, we should revoke stale sub tokens (happy to add a migration/command in a follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)