### PR TITLE
fix(mobile): set permissions team before sub role check in getEvents

### DIFF
--- a/app/Services/UserEventsService.php
+++ b/app/Services/UserEventsService.php
@@ -39,6 +39,16 @@ class UserEventsService
 
         $user = Auth::user();
 
+        // The `sub` role is assigned globally (team_id 0). Spatie evaluates
+        // hasRole() against the CURRENT permissions team, so without a team set
+        // hasRole('sub') returns false and a sub-only user falls through to the
+        // band path and gets ZERO events. The web app runs inside middleware
+        // that sets the team; mobile (DashboardController) only calls
+        // Auth::setUser() and never sets it. Pin the team to 0 here so the role
+        // check is correct for every caller, regardless of entry point.
+        setPermissionsTeamId(0);
+        $user->unsetRelation('roles');
+
         // Check if user is ONLY a sub (has sub role and no band ownership/membership)
         // Use cached relationship properties to avoid duplicate queries within the same request
         $isSub = $user->hasRole('sub');

--- a/tests/Feature/Api/Mobile/DashboardTest.php
+++ b/tests/Feature/Api/Mobile/DashboardTest.php
@@ -4,11 +4,14 @@ namespace Tests\Feature\Api\Mobile;
 
 use App\Models\BandOwners;
 use App\Models\Bands;
+use App\Models\BandSubs;
 use App\Models\Bookings;
+use App\Models\EventMember;
 use App\Models\Events;
 use App\Models\EventTypes;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Spatie\Permission\Models\Role;
 use Tests\TestCase;
 
 class DashboardTest extends TestCase
@@ -92,5 +95,64 @@ class DashboardTest extends TestCase
         $sorted = $dates;
         sort($sorted);
         $this->assertEquals($sorted, $dates, 'events should be sorted by date ascending');
+    }
+
+    /**
+     * Regression for production user 40 (Wesley): a sub-only user saw their
+     * events on web but got an EMPTY dashboard on mobile.
+     *
+     * Cause: UserEventsService::getEvents() branches on $user->hasRole('sub'),
+     * which Spatie evaluates against the CURRENT permissions team. The mobile
+     * DashboardController only calls Auth::setUser() and never sets the team,
+     * so hasRole('sub') returned false, the sub branch was skipped, and the
+     * user (with no band ownership/membership) fell through to zero events.
+     */
+    public function test_dashboard_returns_assigned_events_for_sub_only_user(): void
+    {
+        // `sub` role is global; assignments live at team 0.
+        setPermissionsTeamId(0);
+        Role::firstOrCreate(['name' => 'sub', 'guard_name' => 'web']);
+
+        $band = Bands::factory()->create();
+
+        $sub = User::factory()->create();
+        $sub->assignRole('sub');
+        BandSubs::firstOrCreate(['user_id' => $sub->id, 'band_id' => $band->id]);
+
+        $eventType = EventTypes::factory()->create();
+        $booking = Bookings::factory()->create(['band_id' => $band->id]);
+        $assigned = Events::factory()->create([
+            'eventable_id'   => $booking->id,
+            'eventable_type' => 'App\\Models\\Bookings',
+            'event_type_id'  => $eventType->id,
+            'date'           => now()->addDays(7)->format('Y-m-d'),
+        ]);
+
+        // Assign the sub to the event (roster_member_id NULL == sub, like prod).
+        EventMember::create([
+            'event_id'         => $assigned->id,
+            'band_id'          => $band->id,
+            'user_id'          => $sub->id,
+            'roster_member_id' => null,
+            'name'             => $sub->name,
+        ]);
+
+        $token = $sub->createToken('test-device')->plainTextToken;
+
+        // Simulate a fresh request: no permissions team is set, exactly as the
+        // mobile DashboardController leaves it. Without the fix this yields 0
+        // events because hasRole('sub') resolves false here.
+        setPermissionsTeamId(0);
+        app(\Spatie\Permission\PermissionRegistrar::class)->setPermissionsTeamId(null);
+
+        $response = $this->withToken($token)->getJson('/api/mobile/dashboard');
+
+        $response->assertOk();
+
+        $ids = collect($response->json('events'))->pluck('id');
+        $this->assertTrue(
+            $ids->contains($assigned->id),
+            'sub-only user must see their assigned event on the mobile dashboard',
+        );
     }
 }


### PR DESCRIPTION
The mobile home page calls /api/mobile/dashboard, which uses UserEventsService::getEvents(). That method branches on $user->hasRole('sub'), and Spatie evaluates hasRole() against the CURRENT permissions team. The sub role is assigned globally (team_id 0), but the DashboardController only calls Auth::setUser() and never sets the team — so hasRole('sub') returned false, the sub branch was skipped, and a sub-only user (no band ownership/membership) fell through to the band path and got ZERO events. The web app works because its middleware sets the team.

Pin the permissions team to 0 (and reset the cached roles relation) at the top of getEvents() so the sub check is correct for every caller, regardless of entry point. This is the fix that actually restores the home page for sub-only users; the earlier read:events token fix was necessary for the events-index route but did not address the dashboard.

Verified against the production dump (user 40): dashboard now returns the same 8 events as web.