### PR TITLE
fix(events): show member+sub users their cross-band sub assignments

### DIFF
--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -260,29 +260,57 @@ class User extends Authenticatable
         $subBandIds = $this->bandSub->pluck('id')->toArray();
         $bandIds = $this->bands()->pluck('id')->toArray();
 
-        // Subs only see their specifically assigned events
-        if (!empty($subBandIds) && empty($bandIds)) {
-            $assignedEventIds = \DB::table('event_subs')
+        // The user's individually-assigned sub events, across ANY band: accepted
+        // event_subs invitations plus event_members rows where they fill a sub
+        // slot (roster_member_id NULL). These must be shown IN ADDITION to the
+        // events of bands they own/are a member of — being a member of one band
+        // must not hide sub assignments in another. Mirrors getSubEvents().
+        $subAssignedEventIds = array_values(array_unique(array_merge(
+            \DB::table('event_subs')
                 ->where('user_id', $this->id)
+                ->where('pending', false)
                 ->pluck('event_id')
-                ->toArray();
+                ->toArray(),
+            \DB::table('event_members')
+                ->where('user_id', $this->id)
+                ->whereNull('roster_member_id')
+                ->whereNull('deleted_at')
+                ->pluck('event_id')
+                ->toArray(),
+        )));
 
-            if (empty($assignedEventIds)) {
+        // Pure-sub users (no owned/member bands) are routed to getSubEvents()
+        // by UserEventsService before reaching here, but keep the standalone
+        // behaviour correct: restrict the query to their assigned events only.
+        if (!empty($subBandIds) && empty($bandIds)) {
+            if (empty($subAssignedEventIds)) {
                 return collect();
             }
 
+            $assignedEventIds = $subAssignedEventIds;
             $bandIds = $subBandIds;
         } else {
             $assignedEventIds = null;
         }
 
-        if (empty($bandIds)) {
+        if (empty($bandIds) && empty($subAssignedEventIds)) {
             return collect();
         }
         
+        // Member/owner bands contribute all their events; cross-band sub
+        // assignments contribute their specific events. For a member+sub user
+        // ($assignedEventIds === null but $subAssignedEventIds non-empty) these
+        // are OR'd together so neither hides the other.
+        $bookingBandFilter = function ($q) use ($bandIds, $assignedEventIds, $subAssignedEventIds) {
+            $q->whereIn('bookings.band_id', $bandIds);
+            if ($assignedEventIds === null && !empty($subAssignedEventIds)) {
+                $q->orWhereIn('events.id', $subAssignedEventIds);
+            }
+        };
+
         // Build the main booking events query
         $bookingQuery = Events::join('bookings', 'events.eventable_id', '=', 'bookings.id')
-            ->whereIn('bookings.band_id', $bandIds)
+            ->where($bookingBandFilter)
             ->where('events.eventable_type', 'App\\Models\\Bookings')
             ->select([
                 'events.date',

--- a/tests/Feature/SubEventFilteringTest.php
+++ b/tests/Feature/SubEventFilteringTest.php
@@ -193,6 +193,102 @@ class SubEventFilteringTest extends TestCase
         $this->assertCount(2, $events);
     }
 
+    public function test_member_of_one_band_also_sees_sub_events_from_another_band()
+    {
+        // User is a MEMBER of band A (this->band) and a SUB for a different band B.
+        // They must see band A's events AND their assigned band B event — being a
+        // member of one band must not hide sub assignments in another.
+        $memberSub = User::factory()->create();
+        $memberSub->assignRole('sub');
+
+        BandMembers::create([
+            'user_id' => $memberSub->id,
+            'band_id' => $this->band->id,
+        ]);
+
+        // Band A event (visible because they're a member of band A)
+        $bookingA = Bookings::factory()->create(['band_id' => $this->band->id]);
+        $eventA = Events::factory()->create([
+            'eventable_id' => $bookingA->id,
+            'eventable_type' => 'App\Models\Bookings',
+            'date' => now()->addDays(5),
+        ]);
+
+        // Band B (different band) — they are NOT a member, only a sub on one event
+        $bandB = Bands::factory()->create(['name' => 'Other Band']);
+        $bookingB = Bookings::factory()->create(['band_id' => $bandB->id]);
+        $eventBAssigned = Events::factory()->create([
+            'eventable_id' => $bookingB->id,
+            'eventable_type' => 'App\Models\Bookings',
+            'date' => now()->addDays(8),
+        ]);
+        // A band B event they are NOT on — must remain hidden
+        $bookingBOther = Bookings::factory()->create(['band_id' => $bandB->id]);
+        $eventBUnassigned = Events::factory()->create([
+            'eventable_id' => $bookingBOther->id,
+            'eventable_type' => 'App\Models\Bookings',
+            'date' => now()->addDays(9),
+        ]);
+
+        EventSubs::create([
+            'event_id' => $eventBAssigned->id,
+            'band_id' => $bandB->id,
+            'user_id' => $memberSub->id,
+            'email' => $memberSub->email,
+            'pending' => false,
+        ]);
+
+        Auth::login($memberSub);
+        $events = $this->userEventsService->getEvents();
+        $ids = $events->pluck('id')->toArray();
+
+        $this->assertContains($eventA->id, $ids, 'must see their own band events');
+        $this->assertContains($eventBAssigned->id, $ids, 'must see sub-assigned events in another band');
+        $this->assertNotContains($eventBUnassigned->id, $ids, 'must NOT see unassigned events in a band they only sub for');
+    }
+
+    public function test_member_also_sees_event_member_sub_assignments_from_another_band()
+    {
+        // Same as above but the cross-band assignment is via event_members
+        // (roster_member_id NULL), the path Wesley actually came in through.
+        $memberSub = User::factory()->create();
+        $memberSub->assignRole('sub');
+
+        BandMembers::create([
+            'user_id' => $memberSub->id,
+            'band_id' => $this->band->id,
+        ]);
+
+        $bookingA = Bookings::factory()->create(['band_id' => $this->band->id]);
+        $eventA = Events::factory()->create([
+            'eventable_id' => $bookingA->id,
+            'eventable_type' => 'App\Models\Bookings',
+            'date' => now()->addDays(5),
+        ]);
+
+        $bandB = Bands::factory()->create(['name' => 'Other Band']);
+        $bookingB = Bookings::factory()->create(['band_id' => $bandB->id]);
+        $eventBAssigned = Events::factory()->create([
+            'eventable_id' => $bookingB->id,
+            'eventable_type' => 'App\Models\Bookings',
+            'date' => now()->addDays(8),
+        ]);
+
+        \App\Models\EventMember::create([
+            'event_id' => $eventBAssigned->id,
+            'band_id' => $bandB->id,
+            'user_id' => $memberSub->id,
+            'roster_member_id' => null,
+            'name' => $memberSub->name,
+        ]);
+
+        Auth::login($memberSub);
+        $ids = $this->userEventsService->getEvents()->pluck('id')->toArray();
+
+        $this->assertContains($eventA->id, $ids);
+        $this->assertContains($eventBAssigned->id, $ids, 'must see event_members sub assignments from another band');
+    }
+
     public function test_band_owner_sees_all_events()
     {
         // Owners should see all events regardless of sub invitations


### PR DESCRIPTION
## Summary

Follow-up to the mobile sub-events fixes already merged to staging (#415). Fixes a related latent bug in `User::getEventsAttribute()`.

A user who is a **member/owner of band X** *and* a **sub for band Y** saw only X's events — their cross-band Y sub assignments silently disappeared. The query only included sub assignments when the user had **no** owned/member bands (`if (!empty($subBandIds) && empty($bandIds))`), treating sub-vs-member as mutually exclusive.

Now the query always computes the user's individual sub-assigned event IDs (`event_subs` accepted ∪ `event_members` with `roster_member_id` NULL, by `user_id`, across any band) and ORs them into the booking query **additively**, so member/owner band events **and** cross-band sub assignments both show. The pure-sub path (via `getSubEvents`) and pure-member/owner paths are unchanged.

Affects web and mobile identically (shared `getEventsAttribute`); its only parameterized caller is `UserEventsService::getEvents()`, so the blast radius is contained.

## Test Plan

- [x] New `SubEventFilteringTest` cases — member of band X + sub of band Y sees both (via `event_subs` and via `event_members`); unassigned Y events stay hidden. Fail before the fix, pass after.
- [x] Existing pure-sub / pure-member / pure-owner cases unchanged
- [x] `DashboardTest`, `MobileSubEventsParityTest` pass on the current staging base
- [x] Verified against the production dump: a user who is a member of band 2 and sub of band 1 now sees all 9 events (8 band-1 sub + 1 band-2 member) instead of 1; mobile band-1 index still scopes back to the 8 band-1 events

🤖 Generated with [Claude Code](https://claude.com/claude-code)