### PR TITLE
fix(bookings): generated event end_time uses derived value, not midnight

### DIFF
--- a/app/Http/Controllers/BookingsController.php
+++ b/app/Http/Controllers/BookingsController.php
@@ -115,12 +115,19 @@ class BookingsController extends Controller
         // Get default roster for the band
         $defaultRoster = $band->defaultRoster;
 
-        // Build event payload from REQUEST values, not from $booking (those columns are gone).
-        $eventDate    = $request->input('date');
-        $eventStart   = $request->input('start_time');
-        $eventEnd     = $request->input('end_time');
-        $venueName    = $request->input('venue_name');
-        $venueAddress = $request->input('venue_address');
+        // Build event payload from VALIDATED values, not from $booking (those
+        // columns are gone) nor from raw request input. The booking form submits
+        // start_time + duration and no end_time; StoreBookingsRequest::validated()
+        // derives end_time from start_time + duration. Reading $request->input()
+        // here would instead return the placeholder '00:00' that
+        // prepareForValidation() injects, pinning every generated event to
+        // midnight.
+        $validated    = $request->validated();
+        $eventDate    = $validated['date'];
+        $eventStart   = $validated['start_time'];
+        $eventEnd     = $validated['end_time'];
+        $venueName    = $validated['venue_name'] ?? null;
+        $venueAddress = $validated['venue_address'] ?? null;
 
         $startDateTime = \Carbon\Carbon::parse($eventDate . ' ' . $eventStart);
         $endDateTime   = \Carbon\Carbon::parse($eventDate . ' ' . $eventEnd);

--- a/tests/Feature/BookingsControllerTest.php
+++ b/tests/Feature/BookingsControllerTest.php
@@ -161,6 +161,38 @@ class BookingsControllerTest extends TestCase
         \Illuminate\Support\Facades\DB::rollBack();
     }
 
+    public function test_created_booking_event_end_time_is_start_plus_duration()
+    {
+        // Regression: the booking form submits start_time + duration and no
+        // end_time. StoreBookingsRequest injects a placeholder end_time of
+        // '00:00' before deriving the real end_time (start + duration) in
+        // validated(). The controller must read the derived value, not the
+        // placeholder, or every generated event ends at midnight.
+        $duration = 3;
+        \Illuminate\Support\Facades\DB::beginTransaction();
+        setPermissionsTeamId($this->band->id);
+        $this->member->givePermissionTo(['read:bookings', 'write:bookings']);
+        setPermissionsTeamId(0);
+
+        $bookingData = Bookings::factory()->withGigDetails()->duration($duration)->make(['band_id' => $this->band->id])->toArray();
+        $bookingData['duration'] = $duration;
+        $bookingData['start_time'] = '19:00';
+        unset($bookingData['end_time']);
+
+        $response = $this->actingAs($this->member)->post(route('bands.booking.store', $this->band), $bookingData);
+        $response->assertStatus(302);
+
+        $booking = $this->band->bookings()->where('name', $bookingData['name'])->firstOrFail();
+        $event = $booking->events()->firstOrFail();
+
+        // start 19:00 + 3h duration = 22:00, NOT midnight.
+        $this->assertSame('19:00', $event->start_time->format('H:i'));
+        $this->assertSame('22:00', $event->end_time->format('H:i'));
+        $this->assertNotSame('00:00', $event->end_time->format('H:i'));
+
+        \Illuminate\Support\Facades\DB::rollBack();
+    }
+
     public function test_non_member_cannot_create_booking()
     {
         $bookingData = Bookings::factory()->withGigDetails()->make(['band_id' => $this->band->id])->toArray();


### PR DESCRIPTION
## Problem

After the bookings↔events decoupling, every newly generated booking ended at **midnight**. The end time couldn't be corrected from the event editor — the only way to fix it was to edit the booking and set the end time from its event subresource.

## Root cause

The new-booking form submits `start_time` + `duration` and **no** `end_time`.

- `StoreBookingsRequest::prepareForValidation()` injects a placeholder `end_time => '00:00'` when it's missing.
- `StoreBookingsRequest::validated()` then derives the real `end_time` from `start_time + duration`.
- But `BookingsController::store()` built the generated event from `$request->input('end_time')`, which returns the **raw `'00:00'` placeholder** — bypassing the derived value in `validated()`.

Result: the generated event was always saved with `end_time = 00:00`.

## Fix

Source the event's date/time/venue fields from `$request->validated()` instead of `$request->input()`, so the derived `end_time` (start + duration) is used.

## Tests

- Added regression test `test_created_booking_event_end_time_is_start_plus_duration`: a 19:00 start with a 3h duration now yields a 22:00 end, not 00:00.
- Confirmed the test fails without the fix and passes with it.
- Full related suite green: **39 passed (184 assertions)** across `BookingsControllerTest`, `BookingSubresourceEventsTest`, `ProcessBookingCreatedTest`.

## Out of scope

The "can't edit from the event editor" symptom also stems from a pre-existing model mismatch in the legacy `EventsController` (`edit()` loads an `Events` record while `update()` queries `BandEvents`). That path now redirects booking events to the booking-page editor, so it's effectively dead code for booking events. Left untouched to keep this fix focused; can clean it up separately if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)