### PR TITLE
fix(events): add End Time field to the booking event editor

### DIFF
--- a/resources/js/Pages/Bookings/Components/EventEditor/BasicInfo.vue
+++ b/resources/js/Pages/Bookings/Components/EventEditor/BasicInfo.vue
@@ -28,6 +28,16 @@
         class="w-full p-2 border dark:bg-slate-700 dark:text-gray-50 rounded"
       />
     </div>
+    <div>
+      <Input
+        id="end_time"
+        v-model="modelValue.end_time"
+        label="End Time"
+        type="time"
+        dusk="event-end-time"
+        class="w-full p-2 border dark:bg-slate-700 dark:text-gray-50 rounded"
+      />
+    </div>
   </div>
 </template>
 

--- a/tests/Feature/BookingSubresourceEventsTest.php
+++ b/tests/Feature/BookingSubresourceEventsTest.php
@@ -119,6 +119,26 @@ class BookingSubresourceEventsTest extends TestCase
         ]);
     }
 
+    public function test_owner_can_update_event_end_time_via_subresource_endpoint(): void
+    {
+        // Backs the End Time field in the event editor's BasicInfo section.
+        // The editor PUTs the whole event (incl. end_time) to this endpoint,
+        // so end_time must round-trip and persist on the events table.
+        $event = $this->booking->events()->first();
+
+        $response = $this->actingAs($this->owner)->put(
+            route('Update Booking Event', [$this->band, $this->booking, $event]),
+            $this->eventPayload(['start_time' => '19:00', 'end_time' => '23:30']),
+        );
+
+        $response->assertRedirect();
+        $response->assertSessionHas('successMessage', 'Event Updated');
+
+        $event->refresh();
+        $this->assertSame('19:00', $event->start_time->format('H:i'));
+        $this->assertSame('23:30', $event->end_time->format('H:i'));
+    }
+
     public function test_deleting_the_last_event_returns_an_error_and_keeps_the_event(): void
     {
         $event = $this->booking->events()->first();


### PR DESCRIPTION
## Problem

Follow-up to #422. After the bookings↔events decoupling, a booking event's **end time could not be changed from the event editor**. The editor's BasicInfo section exposed only Title, Date, and Show Time (`start_time`) — there was no end-time input at all. The only way to set an end time was the separate booking-event subform (the workaround originally reported).

## Fix

Add an **End Time** field to `EventEditor/BasicInfo.vue`, bound to `event.end_time`. The editor already PUTs the whole event to `updateOrCreateEvent`, which fills and persists `end_time` via `UpdateBookingEventRequest` (`nullable|date_format:H:i`), so no backend change is needed — the field was simply missing from the form.

`end_time` is cast `datetime:H:i` and serializes to `"HH:mm"`, matching `<input type="time">` exactly as `start_time` already does.

## Tests

- Strengthened `test_owner_can_update_existing_event_via_subresource_endpoint` coverage with a new `test_owner_can_update_event_end_time_via_subresource_endpoint` asserting `end_time` round-trips (19:00 → 23:30) — this is the backend contract the new field relies on.
- `npm run build` compiles cleanly.
- Full related suite green: **39 passed** across `BookingsControllerTest` + `BookingSubresourceEventsTest`.

## Note on the timeline

`Timeline.vue` manages free-form `additional_data.times` markers (Load In, Soundcheck, "End Time", etc.) and a synthetic Show-Time pin derived from `start_time`. It is intentionally **not** coupled to the canonical `end_time` column (which drives Google Calendar via `getEndDateTimeAttribute`). This PR fixes the canonical end-time edit path; it does not auto-sync the free-form "End Time" marker, to avoid clobbering markers users have deliberately positioned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)