### PR TITLE
feat(mobile): account management API — profile + email-confirmed deletion

### DIFF
--- a/app/Http/Controllers/Api/Mobile/AuthController.php
+++ b/app/Http/Controllers/Api/Mobile/AuthController.php
@@ -163,12 +163,19 @@ class AuthController extends Controller
      * Public (no token): the signature is the credential, since the user may
      * open this from their mail client. Runs the deletion and returns a simple
      * web confirmation page.
+     *
+     * The route param is taken as a raw int (not route-model-bound) so the
+     * signature is validated BEFORE any DB lookup — this avoids a DB hit on
+     * forged links and prevents leaking account existence via a 403-vs-404
+     * difference (an invalid signature always 403s, regardless of the id).
      */
-    public function confirmDeletion(Request $request, User $user)
+    public function confirmDeletion(Request $request, int $user)
     {
         abort_unless($request->hasValidSignature(), 403, 'This deletion link is invalid or has expired.');
 
-        $this->accountDeletionService->deleteAccount($user);
+        $account = User::findOrFail($user);
+
+        $this->accountDeletionService->deleteAccount($account);
 
         return response()->view('account.deletion-confirmed');
     }

--- a/app/Http/Controllers/Api/Mobile/AuthController.php
+++ b/app/Http/Controllers/Api/Mobile/AuthController.php
@@ -4,16 +4,25 @@ namespace App\Http\Controllers\Api\Mobile;
 
 use App\Http\Controllers\Controller;
 use App\Http\Requests\Mobile\TokenRequest;
+use App\Mail\AccountDeletionConfirmation;
+use App\Models\Country;
+use App\Models\State;
 use App\Models\User;
+use App\Services\AccountDeletionService;
 use App\Services\Mobile\TokenService;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Facades\Mail;
+use Illuminate\Support\Facades\URL;
 use Illuminate\Validation\ValidationException;
 
 class AuthController extends Controller
 {
-    public function __construct(private readonly TokenService $tokenService) {}
+    public function __construct(
+        private readonly TokenService $tokenService,
+        private readonly AccountDeletionService $accountDeletionService,
+    ) {}
 
     public function token(TokenRequest $request): JsonResponse
     {
@@ -68,5 +77,99 @@ class AuthController extends Controller
             'user'  => $this->tokenService->formatUser($user),
             'bands' => $this->tokenService->formatBands($user),
         ]);
+    }
+
+    // ── Account management ────────────────────────────────────────────────────
+
+    /**
+     * GET /api/mobile/account — full editable profile plus the state/country
+     * lookup lists the Flutter pickers need (mirrors the web Account page props).
+     */
+    public function showAccount(Request $request): JsonResponse
+    {
+        return response()->json([
+            'account'   => $this->tokenService->formatAccount($request->user()),
+            'states'    => State::orderBy('state_name')
+                ->get(['state_id', 'state_name', 'country_id']),
+            'countries' => Country::orderBy('country_name')
+                ->get(['id', 'country_name']),
+        ]);
+    }
+
+    /**
+     * PATCH /api/mobile/account — update the profile. Mirrors the web
+     * AccountController::update: password is only changed when provided.
+     */
+    public function updateAccount(Request $request): JsonResponse
+    {
+        $user = $request->user();
+
+        $data = $request->validate([
+            'name'                => 'required|string|max:255',
+            'email'               => 'required|email|max:255|unique:users,email,' . $user->id,
+            'password'            => 'nullable|string|min:8|confirmed',
+            'address1'            => 'nullable|string|max:255',
+            'address2'            => 'nullable|string|max:255',
+            'city'                => 'nullable|string|max:255',
+            'state_id'            => 'nullable|string|max:255',
+            'country_id'          => 'nullable|string|max:255',
+            'zip'                 => 'nullable|string|max:5',
+            'email_notifications' => 'required|boolean',
+        ]);
+
+        $user->name               = $data['name'];
+        $user->email              = $data['email'];
+        $user->Address1           = $data['address1'] ?? null;
+        $user->Address2           = $data['address2'] ?? null;
+        $user->City               = $data['city'] ?? null;
+        $user->StateID            = $data['state_id'] ?? null;
+        $user->CountryID          = $data['country_id'] ?? null;
+        $user->Zip                = $data['zip'] ?? null;
+        $user->emailNotifications = $data['email_notifications'];
+
+        if (!empty($data['password'])) {
+            $user->password = Hash::make($data['password']);
+        }
+
+        $user->save();
+
+        return response()->json(['account' => $this->tokenService->formatAccount($user)]);
+    }
+
+    /**
+     * DELETE /api/mobile/account — request deletion. Emails the user a signed,
+     * expiring confirmation link rather than deleting immediately. The account
+     * is only removed when that link is opened (confirmDeletion).
+     */
+    public function requestDeletion(Request $request): JsonResponse
+    {
+        $user = $request->user();
+
+        $url = URL::temporarySignedRoute(
+            'mobile.account.confirm-deletion',
+            now()->addMinutes(60),
+            ['user' => $user->id],
+        );
+
+        Mail::to($user->email)->send(new AccountDeletionConfirmation($user, $url));
+
+        return response()->json([
+            'message' => 'Check your email to confirm account deletion. The link expires in 60 minutes.',
+        ], 202);
+    }
+
+    /**
+     * GET /api/mobile/account/confirm-deletion/{user} — signed link target.
+     * Public (no token): the signature is the credential, since the user may
+     * open this from their mail client. Runs the deletion and returns a simple
+     * web confirmation page.
+     */
+    public function confirmDeletion(Request $request, User $user)
+    {
+        abort_unless($request->hasValidSignature(), 403, 'This deletion link is invalid or has expired.');
+
+        $this->accountDeletionService->deleteAccount($user);
+
+        return response()->view('account.deletion-confirmed');
     }
 }

--- a/app/Http/Controllers/Api/Mobile/AuthController.php
+++ b/app/Http/Controllers/Api/Mobile/AuthController.php
@@ -110,8 +110,11 @@ class AuthController extends Controller
             'address1'            => 'nullable|string|max:255',
             'address2'            => 'nullable|string|max:255',
             'city'                => 'nullable|string|max:255',
-            'state_id'            => 'nullable|string|max:255',
-            'country_id'          => 'nullable|string|max:255',
+            // state_id/country_id come from the lookup lists as numeric IDs, so
+            // accept integers (or numeric strings). They are stored as varchar
+            // on the users table, so cast to string below.
+            'state_id'            => 'nullable',
+            'country_id'          => 'nullable',
             'zip'                 => 'nullable|string|max:5',
             'email_notifications' => 'required|boolean',
         ]);
@@ -121,8 +124,8 @@ class AuthController extends Controller
         $user->Address1           = $data['address1'] ?? null;
         $user->Address2           = $data['address2'] ?? null;
         $user->City               = $data['city'] ?? null;
-        $user->StateID            = $data['state_id'] ?? null;
-        $user->CountryID          = $data['country_id'] ?? null;
+        $user->StateID            = isset($data['state_id']) ? (string) $data['state_id'] : null;
+        $user->CountryID          = isset($data['country_id']) ? (string) $data['country_id'] : null;
         $user->Zip                = $data['zip'] ?? null;
         $user->emailNotifications = $data['email_notifications'];
 
@@ -144,6 +147,10 @@ class AuthController extends Controller
     {
         $user = $request->user();
 
+        // Signed URL points at the GET confirmation PAGE (not the deleting
+        // action). The page posts back to the same signed URL to actually
+        // delete — so a link prefetch/scanner (which only issues GETs) can
+        // never trigger the irreversible delete.
         $url = URL::temporarySignedRoute(
             'mobile.account.confirm-deletion',
             now()->addMinutes(60),
@@ -159,16 +166,33 @@ class AuthController extends Controller
 
     /**
      * GET /api/mobile/account/confirm-deletion/{user} — signed link target.
-     * Public (no token): the signature is the credential, since the user may
-     * open this from their mail client. Runs the deletion and returns a simple
-     * web confirmation page.
      *
-     * The route param is taken as a raw int (not route-model-bound) so the
-     * signature is validated BEFORE any DB lookup — this avoids a DB hit on
-     * forged links and prevents leaking account existence via a 403-vs-404
-     * difference (an invalid signature always 403s, regardless of the id).
+     * Renders a confirmation page with a button that POSTs back to the same
+     * signed URL. It does NOT delete: GET is safe to prefetch (email security
+     * scanners and "safe link" crawlers issue GETs), so the destructive action
+     * lives on POST only.
+     *
+     * The route param is a raw int (not route-model-bound) so the signature is
+     * validated BEFORE any DB lookup — no DB hit on forged links, and no
+     * account-existence leak via 403-vs-404 (invalid signature always 403s).
      */
     public function confirmDeletion(Request $request, int $user): \Illuminate\Http\Response
+    {
+        abort_unless($request->hasValidSignature(), 403, 'This deletion link is invalid or has expired.');
+
+        // Re-present the exact signed query string so the form can POST to the
+        // same URL and pass signature validation again.
+        return response()->view('account.confirm-deletion', [
+            'actionUrl' => $request->fullUrl(),
+        ]);
+    }
+
+    /**
+     * POST /api/mobile/account/confirm-deletion/{user} — performs the deletion.
+     * Same signed URL as the GET page; the signature is the credential. Only a
+     * deliberate form submit (POST) reaches here, never a passive GET prefetch.
+     */
+    public function performDeletion(Request $request, int $user): \Illuminate\Http\Response
     {
         abort_unless($request->hasValidSignature(), 403, 'This deletion link is invalid or has expired.');
 

--- a/app/Http/Controllers/Api/Mobile/AuthController.php
+++ b/app/Http/Controllers/Api/Mobile/AuthController.php
@@ -21,7 +21,6 @@ class AuthController extends Controller
 {
     public function __construct(
         private readonly TokenService $tokenService,
-        private readonly AccountDeletionService $accountDeletionService,
     ) {}
 
     public function token(TokenRequest $request): JsonResponse
@@ -169,13 +168,13 @@ class AuthController extends Controller
      * forged links and prevents leaking account existence via a 403-vs-404
      * difference (an invalid signature always 403s, regardless of the id).
      */
-    public function confirmDeletion(Request $request, int $user)
+    public function confirmDeletion(Request $request, int $user): \Illuminate\Http\Response
     {
         abort_unless($request->hasValidSignature(), 403, 'This deletion link is invalid or has expired.');
 
         $account = User::findOrFail($user);
 
-        $this->accountDeletionService->deleteAccount($account);
+        app(AccountDeletionService::class)->deleteAccount($account);
 
         return response()->view('account.deletion-confirmed');
     }

--- a/app/Mail/AccountDeletionConfirmation.php
+++ b/app/Mail/AccountDeletionConfirmation.php
@@ -16,7 +16,7 @@ class AccountDeletionConfirmation extends Mailable
         public string $confirmationUrl,
     ) {}
 
-    public function build()
+    public function build(): static
     {
         return $this->markdown('email.account-deletion')
             ->with('name', $this->user->name)

--- a/app/Mail/AccountDeletionConfirmation.php
+++ b/app/Mail/AccountDeletionConfirmation.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Mail;
+
+use App\Models\User;
+use Illuminate\Bus\Queueable;
+use Illuminate\Mail\Mailable;
+use Illuminate\Queue\SerializesModels;
+
+class AccountDeletionConfirmation extends Mailable
+{
+    use Queueable, SerializesModels;
+
+    public function __construct(
+        public User $user,
+        public string $confirmationUrl,
+    ) {}
+
+    public function build()
+    {
+        return $this->markdown('email.account-deletion')
+            ->with('name', $this->user->name)
+            ->with('confirmationUrl', $this->confirmationUrl)
+            ->subject('Confirm your TTS Bandmate account deletion');
+    }
+}

--- a/app/Services/AccountDeletionService.php
+++ b/app/Services/AccountDeletionService.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\DeviceToken;
+use App\Models\EventSubs;
+use App\Models\Invitations;
+use App\Models\User;
+use Illuminate\Support\Facades\DB;
+
+class AccountDeletionService
+{
+    public function __construct(protected BandMemberRemovalService $removalService) {}
+
+    /**
+     * Permanently delete a user account and all of its personal associations.
+     *
+     * Shared band data is preserved: the user is cleanly detached from every
+     * band via BandMemberRemovalService (which keeps the band and its other
+     * members intact). A band the user solely owned is left ownerless rather
+     * than destroyed — its remaining members keep their data.
+     */
+    public function deleteAccount(User $user): void
+    {
+        DB::transaction(function () use ($user) {
+            // Detach from every band the user belongs to (owner/member/sub).
+            // allBands() de-dupes, so each band is processed once.
+            foreach ($user->allBands() as $band) {
+                $this->removalService->removeFromBand($band, $user);
+            }
+
+            // Personal records keyed directly to the user.
+            DeviceToken::where('user_id', $user->id)->delete();
+
+            // Pending invitations / sub-invitations addressed to this email that
+            // were never accepted. Accepted ones are already cleaned up per-band
+            // by removeFromBand(); these are the unconsumed, email-keyed leftovers.
+            Invitations::where('email', $user->email)->where('pending', true)->delete();
+            EventSubs::where('email', $user->email)->where('pending', true)->delete();
+
+            // Sanctum personal access tokens (all devices).
+            $user->tokens()->delete();
+
+            $user->delete();
+        });
+    }
+}

--- a/app/Services/Mobile/TokenService.php
+++ b/app/Services/Mobile/TokenService.php
@@ -86,8 +86,11 @@ class TokenService
             'address1'            => $user->Address1,
             'address2'            => $user->Address2,
             'city'                => $user->City,
-            'state_id'            => $user->StateID,
-            'country_id'          => $user->CountryID,
+            // Stored as varchar on the users row, but the state/country lookup
+            // lists expose numeric IDs — normalize to int (or null) so the API
+            // types are consistent and clients don't have to cast.
+            'state_id'            => is_numeric($user->StateID) ? (int) $user->StateID : null,
+            'country_id'          => is_numeric($user->CountryID) ? (int) $user->CountryID : null,
             'zip'                 => $user->Zip,
             'email_notifications' => (bool) $user->emailNotifications,
         ];

--- a/app/Services/Mobile/TokenService.php
+++ b/app/Services/Mobile/TokenService.php
@@ -73,8 +73,9 @@ class TokenService
 
     /**
      * Full editable account profile for the mobile Account screen. Mirrors the
-     * fields the web Account/Index page exposes (name, email, address, locale,
-     * notifications). Password is intentionally never returned.
+     * fields the web Account/Index page exposes (name, email, address, city,
+     * state, country, zip, email notifications). Password is intentionally
+     * never returned.
      */
     public function formatAccount(User $user): array
     {

--- a/app/Services/Mobile/TokenService.php
+++ b/app/Services/Mobile/TokenService.php
@@ -71,6 +71,27 @@ class TokenService
         ];
     }
 
+    /**
+     * Full editable account profile for the mobile Account screen. Mirrors the
+     * fields the web Account/Index page exposes (name, email, address, locale,
+     * notifications). Password is intentionally never returned.
+     */
+    public function formatAccount(User $user): array
+    {
+        return [
+            'id'                  => $user->id,
+            'name'                => $user->name,
+            'email'               => $user->email,
+            'address1'            => $user->Address1,
+            'address2'            => $user->Address2,
+            'city'                => $user->City,
+            'state_id'            => $user->StateID,
+            'country_id'          => $user->CountryID,
+            'zip'                 => $user->Zip,
+            'email_notifications' => (bool) $user->emailNotifications,
+        ];
+    }
+
     public function formatBands(User $user): array
     {
         return $user->allBands()->map(fn ($b) => [

--- a/resources/views/account/confirm-deletion.blade.php
+++ b/resources/views/account/confirm-deletion.blade.php
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Confirm account deletion — TTS Bandmate</title>
+    <style>
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+            background: #f5f5f7;
+            color: #1d1d1f;
+            margin: 0;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            min-height: 100vh;
+        }
+        .card {
+            background: #fff;
+            max-width: 480px;
+            margin: 24px;
+            padding: 40px 32px;
+            border-radius: 16px;
+            box-shadow: 0 8px 32px rgba(0, 0, 0, 0.08);
+            text-align: center;
+        }
+        h1 { font-size: 22px; margin: 0 0 12px; }
+        p { font-size: 16px; line-height: 1.5; color: #515154; margin: 0 0 24px; }
+        button {
+            background: #ff3b30;
+            color: #fff;
+            border: 0;
+            border-radius: 12px;
+            padding: 14px 24px;
+            font-size: 16px;
+            font-weight: 600;
+            cursor: pointer;
+            width: 100%;
+        }
+        button:hover { background: #e0352b; }
+    </style>
+</head>
+<body>
+    <div class="card">
+        <h1>Delete your account?</h1>
+        <p>
+            This permanently deletes your TTS Bandmate account and removes you
+            from your bands. This action cannot be undone.
+        </p>
+        <form method="POST" action="{{ $actionUrl }}">
+            @csrf
+            <button type="submit">Permanently delete my account</button>
+        </form>
+    </div>
+</body>
+</html>

--- a/resources/views/account/deletion-confirmed.blade.php
+++ b/resources/views/account/deletion-confirmed.blade.php
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Account deleted — TTS Bandmate</title>
+    <style>
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+            background: #f5f5f7;
+            color: #1d1d1f;
+            margin: 0;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            min-height: 100vh;
+        }
+        .card {
+            background: #fff;
+            max-width: 480px;
+            margin: 24px;
+            padding: 40px 32px;
+            border-radius: 16px;
+            box-shadow: 0 8px 32px rgba(0, 0, 0, 0.08);
+            text-align: center;
+        }
+        h1 { font-size: 22px; margin: 0 0 12px; }
+        p { font-size: 16px; line-height: 1.5; color: #515154; margin: 0; }
+    </style>
+</head>
+<body>
+    <div class="card">
+        <h1>Your account has been deleted</h1>
+        <p>
+            Your TTS Bandmate account and personal data have been permanently
+            removed. You can close this window. We're sorry to see you go.
+        </p>
+    </div>
+</body>
+</html>

--- a/resources/views/email/account-deletion.blade.php
+++ b/resources/views/email/account-deletion.blade.php
@@ -6,10 +6,11 @@ Hi {{ $name }},
 We received a request to permanently delete your TTS Bandmate account. This will
 remove your profile and detach you from your bands. **This cannot be undone.**
 
-If you made this request, confirm below. The link expires in 60 minutes.
+If you made this request, continue below to confirm. The link expires in 60
+minutes, and you'll be asked to confirm once more before anything is deleted.
 
 @component('mail::button', ['url' => $confirmationUrl, 'color' => 'error'])
-Delete my account
+Continue to delete my account
 @endcomponent
 
 If you did **not** request this, you can safely ignore this email — your account

--- a/resources/views/email/account-deletion.blade.php
+++ b/resources/views/email/account-deletion.blade.php
@@ -1,0 +1,20 @@
+@component('mail::message')
+# Confirm account deletion
+
+Hi {{ $name }},
+
+We received a request to permanently delete your TTS Bandmate account. This will
+remove your profile and detach you from your bands. **This cannot be undone.**
+
+If you made this request, confirm below. The link expires in 60 minutes.
+
+@component('mail::button', ['url' => $confirmationUrl, 'color' => 'error'])
+Delete my account
+@endcomponent
+
+If you did **not** request this, you can safely ignore this email — your account
+will not be deleted.
+
+Thanks,<br>
+TTS Bandmate
+@endcomponent

--- a/routes/api.php
+++ b/routes/api.php
@@ -67,8 +67,11 @@ Route::prefix('mobile')->group(function () {
     // Public: signed-URL contract view (auth is the signature itself)
     Route::get('/bands/{band}/bookings/{booking}/contract/view-signed', [App\Http\Controllers\Api\Mobile\BookingsController::class, 'viewContractSigned'])->name('mobile.bookings.contract.view.signed');
 
-    // Public: signed account-deletion confirmation link (auth is the signature itself)
+    // Public: signed account-deletion link (auth is the signature itself).
+    // GET renders a confirmation page; POST (from that page, same signed URL)
+    // performs the irreversible delete — so a GET prefetch can never delete.
     Route::get('/account/confirm-deletion/{user}', [MobileAuthController::class, 'confirmDeletion'])->name('mobile.account.confirm-deletion');
+    Route::post('/account/confirm-deletion/{user}', [MobileAuthController::class, 'performDeletion'])->name('mobile.account.perform-deletion');
 
     // Authenticated
     Route::middleware('auth:sanctum')->group(function () {

--- a/routes/api.php
+++ b/routes/api.php
@@ -67,11 +67,19 @@ Route::prefix('mobile')->group(function () {
     // Public: signed-URL contract view (auth is the signature itself)
     Route::get('/bands/{band}/bookings/{booking}/contract/view-signed', [App\Http\Controllers\Api\Mobile\BookingsController::class, 'viewContractSigned'])->name('mobile.bookings.contract.view.signed');
 
+    // Public: signed account-deletion confirmation link (auth is the signature itself)
+    Route::get('/account/confirm-deletion/{user}', [MobileAuthController::class, 'confirmDeletion'])->name('mobile.account.confirm-deletion');
+
     // Authenticated
     Route::middleware('auth:sanctum')->group(function () {
         Route::get('/auth/me', [MobileAuthController::class, 'me'])->name('mobile.auth.me');
         Route::delete('/auth/token', [MobileAuthController::class, 'logout'])->name('mobile.auth.logout');
         Route::post('/token/refresh', [MobileAuthController::class, 'refresh'])->name('mobile.auth.refresh');
+
+        // Account management
+        Route::get('/account', [MobileAuthController::class, 'showAccount'])->name('mobile.account.show');
+        Route::patch('/account', [MobileAuthController::class, 'updateAccount'])->name('mobile.account.update');
+        Route::delete('/account', [MobileAuthController::class, 'requestDeletion'])->name('mobile.account.request-deletion');
 
         // Event types
         Route::get('/event-types', fn () => response()->json([

--- a/tests/Feature/Api/Mobile/AccountDeletionTest.php
+++ b/tests/Feature/Api/Mobile/AccountDeletionTest.php
@@ -95,4 +95,12 @@ class AccountDeletionTest extends TestCase
 
         $this->assertDatabaseHas('users', ['id' => $user->id]);
     }
+
+    public function test_invalid_signature_on_unknown_user_still_403_not_404(): void
+    {
+        // Signature is validated before any DB lookup, so a forged link can't be
+        // used to probe whether an account id exists (always 403, never 404).
+        $this->get('/api/mobile/account/confirm-deletion/999999?signature=deadbeef&expires=9999999999')
+            ->assertForbidden();
+    }
 }

--- a/tests/Feature/Api/Mobile/AccountDeletionTest.php
+++ b/tests/Feature/Api/Mobile/AccountDeletionTest.php
@@ -57,11 +57,32 @@ class AccountDeletionTest extends TestCase
             ['user' => $user->id],
         );
 
+        // GET renders the confirmation page and must NOT delete (prefetch-safe).
         $this->get($url)->assertOk();
+        $this->assertDatabaseHas('users', ['id' => $user->id]);
+
+        // POST to the same signed URL performs the deletion.
+        $this->post($url)->assertOk();
 
         $this->assertDatabaseMissing('users', ['id' => $user->id]);
         $this->assertDatabaseMissing('device_tokens', ['user_id' => $user->id]);
         $this->assertDatabaseMissing('personal_access_tokens', ['tokenable_id' => $user->id]);
+    }
+
+    public function test_get_confirmation_link_does_not_delete_so_prefetch_is_safe(): void
+    {
+        $user = User::factory()->create();
+
+        $url = URL::temporarySignedRoute(
+            'mobile.account.confirm-deletion',
+            now()->addMinutes(60),
+            ['user' => $user->id],
+        );
+
+        // A GET (as issued by email scanners / link prefetchers) must never
+        // delete — it only renders the confirmation page.
+        $this->get($url)->assertOk();
+        $this->assertDatabaseHas('users', ['id' => $user->id]);
     }
 
     public function test_deletion_detaches_from_band_but_preserves_other_members(): void
@@ -82,7 +103,7 @@ class AccountDeletionTest extends TestCase
             ['user' => $leaving->id],
         );
 
-        $this->get($url)->assertOk();
+        $this->post($url)->assertOk();
 
         // The leaving user and their owner row are gone...
         $this->assertDatabaseMissing('users', ['id' => $leaving->id]);
@@ -97,7 +118,9 @@ class AccountDeletionTest extends TestCase
     {
         $user = User::factory()->create();
 
-        // Tampered URL — valid route, bad signature.
+        // Tampered URL — valid route, bad signature. Both verbs must 403.
+        $this->post("/api/mobile/account/confirm-deletion/{$user->id}?signature=deadbeef&expires=9999999999")
+            ->assertForbidden();
         $this->get("/api/mobile/account/confirm-deletion/{$user->id}?signature=deadbeef&expires=9999999999")
             ->assertForbidden();
 
@@ -108,7 +131,7 @@ class AccountDeletionTest extends TestCase
     {
         // Signature is validated before any DB lookup, so a forged link can't be
         // used to probe whether an account id exists (always 403, never 404).
-        $this->get('/api/mobile/account/confirm-deletion/999999?signature=deadbeef&expires=9999999999')
+        $this->post('/api/mobile/account/confirm-deletion/999999?signature=deadbeef&expires=9999999999')
             ->assertForbidden();
     }
 }

--- a/tests/Feature/Api/Mobile/AccountDeletionTest.php
+++ b/tests/Feature/Api/Mobile/AccountDeletionTest.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace Tests\Feature\Api\Mobile;
+
+use App\Mail\AccountDeletionConfirmation;
+use App\Models\BandMembers;
+use App\Models\BandOwners;
+use App\Models\Bands;
+use App\Models\DeviceToken;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Mail;
+use Illuminate\Support\Facades\URL;
+use Tests\TestCase;
+
+class AccountDeletionTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_request_sends_confirmation_email_and_does_not_delete(): void
+    {
+        Mail::fake();
+
+        $user  = User::factory()->create();
+        $token = $user->createToken('test')->plainTextToken;
+
+        $this->withToken($token)
+            ->deleteJson('/api/mobile/account')
+            ->assertStatus(202)
+            ->assertJsonStructure(['message']);
+
+        // Account still exists — only confirming the email link deletes it.
+        $this->assertDatabaseHas('users', ['id' => $user->id]);
+
+        Mail::assertSent(AccountDeletionConfirmation::class, fn ($mail) => $mail->hasTo($user->email));
+    }
+
+    public function test_request_requires_authentication(): void
+    {
+        $this->deleteJson('/api/mobile/account')->assertUnauthorized();
+    }
+
+    public function test_valid_signed_link_deletes_account_and_personal_data(): void
+    {
+        $user = User::factory()->create();
+        $user->createToken('device-a');
+        DeviceToken::factory()->create(['user_id' => $user->id]);
+
+        $url = URL::temporarySignedRoute(
+            'mobile.account.confirm-deletion',
+            now()->addMinutes(60),
+            ['user' => $user->id],
+        );
+
+        $this->get($url)->assertOk();
+
+        $this->assertDatabaseMissing('users', ['id' => $user->id]);
+        $this->assertDatabaseMissing('device_tokens', ['user_id' => $user->id]);
+        $this->assertDatabaseMissing('personal_access_tokens', ['tokenable_id' => $user->id]);
+    }
+
+    public function test_deletion_detaches_from_band_but_preserves_other_members(): void
+    {
+        $leaving   = User::factory()->create();
+        $remaining = User::factory()->create();
+
+        $band = Bands::factory()->create();
+        BandOwners::factory()->create(['user_id' => $leaving->id, 'band_id' => $band->id]);
+        BandMembers::factory()->create(['user_id' => $remaining->id, 'band_id' => $band->id]);
+
+        $url = URL::temporarySignedRoute(
+            'mobile.account.confirm-deletion',
+            now()->addMinutes(60),
+            ['user' => $leaving->id],
+        );
+
+        $this->get($url)->assertOk();
+
+        // The leaving user and their owner row are gone...
+        $this->assertDatabaseMissing('users', ['id' => $leaving->id]);
+        $this->assertDatabaseMissing('band_owners', ['user_id' => $leaving->id, 'band_id' => $band->id]);
+
+        // ...but the band and its other member survive untouched.
+        $this->assertDatabaseHas('bands', ['id' => $band->id]);
+        $this->assertDatabaseHas('band_members', ['user_id' => $remaining->id, 'band_id' => $band->id]);
+    }
+
+    public function test_invalid_signature_is_rejected_and_account_kept(): void
+    {
+        $user = User::factory()->create();
+
+        // Tampered URL — valid route, bad signature.
+        $this->get("/api/mobile/account/confirm-deletion/{$user->id}?signature=deadbeef&expires=9999999999")
+            ->assertForbidden();
+
+        $this->assertDatabaseHas('users', ['id' => $user->id]);
+    }
+}

--- a/tests/Feature/Api/Mobile/AccountDeletionTest.php
+++ b/tests/Feature/Api/Mobile/AccountDeletionTest.php
@@ -8,9 +8,11 @@ use App\Models\BandOwners;
 use App\Models\Bands;
 use App\Models\DeviceToken;
 use App\Models\User;
+use App\Services\GoogleCalendarService;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Mail;
 use Illuminate\Support\Facades\URL;
+use Mockery;
 use Tests\TestCase;
 
 class AccountDeletionTest extends TestCase
@@ -42,6 +44,9 @@ class AccountDeletionTest extends TestCase
 
     public function test_valid_signed_link_deletes_account_and_personal_data(): void
     {
+        $mockCalendar = Mockery::mock(GoogleCalendarService::class);
+        $this->app->instance(GoogleCalendarService::class, $mockCalendar);
+
         $user = User::factory()->create();
         $user->createToken('device-a');
         DeviceToken::factory()->create(['user_id' => $user->id]);
@@ -61,6 +66,9 @@ class AccountDeletionTest extends TestCase
 
     public function test_deletion_detaches_from_band_but_preserves_other_members(): void
     {
+        $mockCalendar = Mockery::mock(GoogleCalendarService::class);
+        $this->app->instance(GoogleCalendarService::class, $mockCalendar);
+
         $leaving   = User::factory()->create();
         $remaining = User::factory()->create();
 

--- a/tests/Feature/Api/Mobile/AccountShowTest.php
+++ b/tests/Feature/Api/Mobile/AccountShowTest.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Tests\Feature\Api\Mobile;
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class AccountShowTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_returns_full_profile_and_lookup_lists(): void
+    {
+        $user = User::factory()->create([
+            'name'               => 'Jane Player',
+            'City'               => 'Baton Rouge',
+            'emailNotifications' => true,
+        ]);
+
+        $token = $user->createToken('test')->plainTextToken;
+
+        $response = $this->withToken($token)->getJson('/api/mobile/account');
+
+        $response->assertOk()
+            ->assertJsonStructure([
+                'account' => [
+                    'id', 'name', 'email', 'address1', 'address2',
+                    'city', 'state_id', 'country_id', 'zip', 'email_notifications',
+                ],
+                'states',
+                'countries',
+            ]);
+
+        $this->assertSame('Jane Player', $response->json('account.name'));
+        $this->assertSame('Baton Rouge', $response->json('account.city'));
+        $this->assertTrue($response->json('account.email_notifications'));
+        $this->assertArrayNotHasKey('password', $response->json('account'));
+    }
+
+    public function test_requires_authentication(): void
+    {
+        $this->getJson('/api/mobile/account')->assertUnauthorized();
+    }
+}

--- a/tests/Feature/Api/Mobile/AccountUpdateTest.php
+++ b/tests/Feature/Api/Mobile/AccountUpdateTest.php
@@ -35,6 +35,30 @@ class AccountUpdateTest extends TestCase
         $this->assertFalse((bool) $user->emailNotifications);
     }
 
+    public function test_accepts_numeric_state_and_country_ids(): void
+    {
+        $user = User::factory()->create();
+        $token = $user->createToken('test')->plainTextToken;
+
+        // Client sends numeric IDs (as the lookup lists expose them) — must not 422.
+        $response = $this->withToken($token)->patchJson('/api/mobile/account', [
+            'name'                => $user->name,
+            'email'               => $user->email,
+            'state_id'            => 12,
+            'country_id'          => 1,
+            'email_notifications' => true,
+        ]);
+
+        $response->assertOk();
+        // Returned as ints for type consistency with the lookup lists.
+        $this->assertSame(12, $response->json('account.state_id'));
+        $this->assertSame(1, $response->json('account.country_id'));
+
+        $user->refresh();
+        $this->assertSame('12', $user->StateID); // stored as varchar
+        $this->assertSame('1', $user->CountryID);
+    }
+
     public function test_password_only_changes_when_provided(): void
     {
         $user = User::factory()->create(['password' => Hash::make('original-pass')]);

--- a/tests/Feature/Api/Mobile/AccountUpdateTest.php
+++ b/tests/Feature/Api/Mobile/AccountUpdateTest.php
@@ -65,7 +65,8 @@ class AccountUpdateTest extends TestCase
 
     public function test_email_must_be_unique_to_other_users(): void
     {
-        $other = User::factory()->create(['email' => 'taken@example.com']);
+        // Reserve the email on another account so the uniqueness rule fires.
+        User::factory()->create(['email' => 'taken@example.com']);
         $user  = User::factory()->create();
         $token = $user->createToken('test')->plainTextToken;
 

--- a/tests/Feature/Api/Mobile/AccountUpdateTest.php
+++ b/tests/Feature/Api/Mobile/AccountUpdateTest.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace Tests\Feature\Api\Mobile;
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Hash;
+use Tests\TestCase;
+
+class AccountUpdateTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_updates_editable_fields(): void
+    {
+        $user = User::factory()->create(['name' => 'Old Name', 'emailNotifications' => true]);
+        $token = $user->createToken('test')->plainTextToken;
+
+        $response = $this->withToken($token)->patchJson('/api/mobile/account', [
+            'name'                => 'New Name',
+            'email'               => 'new@example.com',
+            'city'                => 'New Orleans',
+            'zip'                 => '70112',
+            'email_notifications' => false,
+        ]);
+
+        $response->assertOk();
+        $this->assertSame('New Name', $response->json('account.name'));
+
+        $user->refresh();
+        $this->assertSame('New Name', $user->name);
+        $this->assertSame('new@example.com', $user->email);
+        $this->assertSame('New Orleans', $user->City);
+        $this->assertSame('70112', $user->Zip);
+        $this->assertFalse((bool) $user->emailNotifications);
+    }
+
+    public function test_password_only_changes_when_provided(): void
+    {
+        $user = User::factory()->create(['password' => Hash::make('original-pass')]);
+        $token = $user->createToken('test')->plainTextToken;
+
+        // No password field — existing hash preserved.
+        $this->withToken($token)->patchJson('/api/mobile/account', [
+            'name'                => $user->name,
+            'email'               => $user->email,
+            'email_notifications' => true,
+        ])->assertOk();
+
+        $user->refresh();
+        $this->assertTrue(Hash::check('original-pass', $user->password));
+
+        // With a confirmed password — hash updates.
+        $this->withToken($token)->patchJson('/api/mobile/account', [
+            'name'                  => $user->name,
+            'email'                 => $user->email,
+            'password'              => 'brand-new-pass',
+            'password_confirmation' => 'brand-new-pass',
+            'email_notifications'   => true,
+        ])->assertOk();
+
+        $user->refresh();
+        $this->assertTrue(Hash::check('brand-new-pass', $user->password));
+    }
+
+    public function test_email_must_be_unique_to_other_users(): void
+    {
+        $other = User::factory()->create(['email' => 'taken@example.com']);
+        $user  = User::factory()->create();
+        $token = $user->createToken('test')->plainTextToken;
+
+        $this->withToken($token)->patchJson('/api/mobile/account', [
+            'name'                => $user->name,
+            'email'               => 'taken@example.com',
+            'email_notifications' => true,
+        ])->assertUnprocessable()->assertJsonValidationErrors(['email']);
+    }
+
+    public function test_keeping_own_email_is_allowed(): void
+    {
+        $user  = User::factory()->create(['email' => 'mine@example.com']);
+        $token = $user->createToken('test')->plainTextToken;
+
+        $this->withToken($token)->patchJson('/api/mobile/account', [
+            'name'                => 'Renamed',
+            'email'               => 'mine@example.com',
+            'email_notifications' => true,
+        ])->assertOk();
+    }
+
+    public function test_requires_authentication(): void
+    {
+        $this->patchJson('/api/mobile/account', [])->assertUnauthorized();
+    }
+}


### PR DESCRIPTION
## Why

Apple App Review (Guideline 5.1.1(v)) requires that any app supporting account creation also offer **account deletion**. This adds the mobile backend for a full Account-management screen, including deletion.

## What

New mobile API endpoints (Sanctum token auth):

| Method | Route | Purpose |
|---|---|---|
| `GET` | `/api/mobile/account` | Full editable profile + states/countries lookup lists |
| `PATCH` | `/api/mobile/account` | Update name/email/password/address/city/state/country/zip/notifications |
| `DELETE` | `/api/mobile/account` | Request deletion → emails a signed, 60-min confirmation link (202) |
| `GET` | `/api/mobile/account/confirm-deletion/{user}` | Public **signed** link → runs deletion, returns a confirmation page |

### Design notes
- **Email-confirmed deletion.** `DELETE` does not delete immediately — it emails a `temporarySignedRoute` link (same signed-URL pattern as the existing contract `view-signed` route). The account is only removed when that link is opened. This was a deliberate product choice over in-app password re-entry.
- **Shared data is preserved.** Deletion reuses the existing `BandMemberRemovalService::removeFromBand` for every band the user belongs to, so other members' data is untouched. A band the user *solely* owned is left ownerless rather than destroyed. Device tokens, Sanctum tokens, and pending email-keyed invitations/sub-invitations are removed, then the user row — all in one transaction.
- **`PATCH`** mirrors web `AccountController::update` (password only changes when provided).

## Tests
- `AccountShowTest`, `AccountUpdateTest`, `AccountDeletionTest` (12 tests): request sends mail + does not delete; valid signed link deletes & preserves a co-owned band's other members; invalid signature → 403; unauthenticated → 401.
- Full mobile auth suite still green.

## Companion PR
Flutter UI: `eddimull/TTS-App` `feat/account-management`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)