### PR TITLE
fix(mobile): account API follow-up — validation tightening + full-replace contract

### DIFF
--- a/app/Http/Controllers/Api/Mobile/AuthController.php
+++ b/app/Http/Controllers/Api/Mobile/AuthController.php
@@ -111,11 +111,13 @@ class AuthController extends Controller
             'address2'            => 'nullable|string|max:255',
             'city'                => 'nullable|string|max:255',
             // state_id/country_id come from the lookup lists as numeric IDs, so
-            // accept integers (or numeric strings). They are stored as varchar
-            // on the users table, so cast to string below.
-            'state_id'            => 'nullable',
-            'country_id'          => 'nullable',
-            'zip'                 => 'nullable|string|max:5',
+            // accept integers (or numeric strings) only — `integer` rejects
+            // arrays/objects that would otherwise cast to the string "Array"
+            // and corrupt the profile. Stored as varchar, so cast to string below.
+            'state_id'            => 'nullable|integer',
+            'country_id'          => 'nullable|integer',
+            // Match the band-settings address fields (ZIP+4 / international).
+            'zip'                 => 'nullable|string|max:20',
             'email_notifications' => 'required|boolean',
         ]);
 

--- a/app/Http/Controllers/Api/Mobile/AuthController.php
+++ b/app/Http/Controllers/Api/Mobile/AuthController.php
@@ -98,6 +98,12 @@ class AuthController extends Controller
     /**
      * PATCH /api/mobile/account — update the profile. Mirrors the web
      * AccountController::update: password is only changed when provided.
+     *
+     * Full-replace semantics (by design): the client always submits the entire
+     * form, so an omitted optional field (address/city/state/country/zip) is
+     * treated as "cleared" and set to null — it is NOT a partial patch. The one
+     * exception is `password`, which is left untouched unless a new value is
+     * sent. See test_omitting_optional_fields_clears_them for the contract.
      */
     public function updateAccount(Request $request): JsonResponse
     {

--- a/tests/Feature/Api/Mobile/AccountUpdateTest.php
+++ b/tests/Feature/Api/Mobile/AccountUpdateTest.php
@@ -59,6 +59,20 @@ class AccountUpdateTest extends TestCase
         $this->assertSame('1', $user->CountryID);
     }
 
+    public function test_rejects_non_scalar_state_and_country_ids(): void
+    {
+        $user = User::factory()->create();
+        $token = $user->createToken('test')->plainTextToken;
+
+        // An array would otherwise cast to the string "Array" and corrupt data.
+        $this->withToken($token)->patchJson('/api/mobile/account', [
+            'name'                => $user->name,
+            'email'               => $user->email,
+            'state_id'            => ['evil'],
+            'email_notifications' => true,
+        ])->assertUnprocessable()->assertJsonValidationErrors(['state_id']);
+    }
+
     public function test_password_only_changes_when_provided(): void
     {
         $user = User::factory()->create(['password' => Hash::make('original-pass')]);

--- a/tests/Feature/Api/Mobile/AccountUpdateTest.php
+++ b/tests/Feature/Api/Mobile/AccountUpdateTest.php
@@ -59,6 +59,33 @@ class AccountUpdateTest extends TestCase
         $this->assertSame('1', $user->CountryID);
     }
 
+    public function test_omitting_optional_fields_clears_them(): void
+    {
+        // Full-replace semantics by design: the client submits the whole form,
+        // so omitting an optional field clears it (this is intentional, not a
+        // partial patch). This test pins that contract.
+        $user = User::factory()->create([
+            'City'     => 'Old City',
+            'Zip'      => '70112',
+            'Address1' => '1 Old St',
+            'StateID'  => '12',
+        ]);
+        $token = $user->createToken('test')->plainTextToken;
+
+        $this->withToken($token)->patchJson('/api/mobile/account', [
+            'name'                => $user->name,
+            'email'               => $user->email,
+            'email_notifications' => true,
+            // address/city/state/country/zip intentionally omitted
+        ])->assertOk();
+
+        $user->refresh();
+        $this->assertNull($user->City);
+        $this->assertNull($user->Zip);
+        $this->assertNull($user->Address1);
+        $this->assertNull($user->StateID);
+    }
+
     public function test_rejects_non_scalar_state_and_country_ids(): void
     {
         $user = User::factory()->create();


### PR DESCRIPTION
## Why

Follow-up to #425, which auto-merged at commit `1bfdb67` **before** two later review-fix commits landed on its branch. Those two commits therefore never reached `staging`. This PR brings them in.

## What (2 commits, 2 files)

From the Copilot review rounds after #425 merged:

- **Tighten `state_id` / `country_id` validation** → `nullable|integer`. They were briefly loosened to bare `nullable`, which would let an array/object pass and cast to the string `"Array"` in the DB, corrupting the profile. Also widens `zip` to `max:20` (ZIP+4 / international), matching the band-settings address fields.
- **Document & test full-replace PATCH semantics.** The endpoint intentionally treats an omitted optional field as "cleared" (the client always submits the whole form). Documented on `updateAccount()` and pinned with `test_omitting_optional_fields_clears_them` so it reads as a deliberate contract, not accidental data loss.

## Tests

`AccountUpdateTest` now covers: numeric IDs accepted, non-scalar IDs rejected (422), and full-replace clearing. Full account suite green (17 tests, 70 assertions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)