### PR TITLE
ci: gate auto-merge on Copilot review for staging PRs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,10 +2,18 @@ name: CI Pipeline
 
 on:
   pull_request:
-    types: [opened, synchronize]
+    types: [opened, synchronize, reopened]
     branches: [master, staging, dev]
+  # Re-evaluate auto-merge when a review lands (e.g. Copilot finishes its review
+  # on a staging PR after the tests have already passed).
+  pull_request_review:
+    types: [submitted]
+
 jobs:
   frontend:
+    # Only the code-changing events need to (re)run tests; a review submission
+    # reuses the checks already on the PR head.
+    if: github.event_name == 'pull_request'
     uses: ./.github/workflows/frontend.yml
     with:
       node-version: ${{ vars.NODE_VERSION }}
@@ -13,21 +21,84 @@ jobs:
       php-version: ${{ vars.PHP_VERSION }}
 
   backend:
+    if: github.event_name == 'pull_request'
     uses: ./.github/workflows/backendTests.yml
     with:
       node-version: ${{ vars.NODE_VERSION }}
       npm-version: ${{ vars.NPM_VERSION }}
       php-version: ${{ vars.PHP_VERSION }}
 
+  # Copilot reviews every PR automatically via the repo's "automatic code
+  # review" rule, so there's no job here to request it. The auto-merge gate
+  # below waits for that review to land before merging staging PRs.
+
   auto-merge:
+    # Always run so it can gate on the real outcomes below; the guards inside
+    # decide whether to actually merge. needs the test jobs so that on a
+    # pull_request event we only proceed once they have finished.
     needs: [frontend, backend]
+    # On a pull_request event, the test jobs must have succeeded. On a review
+    # event the test jobs are skipped, so don't require them — we re-check their
+    # status via the API instead.
+    if: |
+      always()
+      && github.event.pull_request.draft == false
+      && (
+        github.event_name == 'pull_request_review'
+        || (needs.frontend.result == 'success' && needs.backend.result == 'success')
+      )
     runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request' && github.event.pull_request.draft == false
     steps:
-      - uses: actions/checkout@v4
-      - name: Merge pull request
-        run: |
-          gh pr merge --merge "${{ github.event.pull_request.number }}"
+      - name: Evaluate gates and merge
         env:
           GH_TOKEN: ${{ secrets.GH_PAT }}
-  
+          REPO: ${{ github.repository }}
+          PR: ${{ github.event.pull_request.number }}
+          BASE: ${{ github.event.pull_request.base.ref }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+
+          # 1) All required checks on the PR head commit must be passing. This
+          #    covers both the pull_request path (jobs just finished) and the
+          #    review path (jobs ran earlier on the same commit). The auto-merge
+          #    job itself is excluded so it doesn't wait on its own "in_progress".
+          echo "Checking combined check status for $HEAD_SHA..."
+          rollup=$(gh api "repos/$REPO/commits/$HEAD_SHA/check-runs" --paginate \
+            --jq '[.check_runs[] | select(.name != "auto-merge")] as $runs
+                  | { incomplete: ([ $runs[] | select(.status != "completed") ] | length),
+                      failed: ([ $runs[] | select(.conclusion != null and (.conclusion | IN("success","neutral","skipped") | not)) ] | length) }')
+          incomplete=$(echo "$rollup" | jq -s -r 'reduce .[] as $r ({incomplete:0,failed:0}; {incomplete:(.incomplete+$r.incomplete), failed:(.failed+$r.failed)}) | .incomplete')
+          failed=$(echo "$rollup" | jq -s -r 'reduce .[] as $r ({incomplete:0,failed:0}; {incomplete:(.incomplete+$r.incomplete), failed:(.failed+$r.failed)}) | .failed')
+          echo "  incomplete=$incomplete failed=$failed"
+
+          if [ "$failed" -ne 0 ]; then
+            echo "Checks failing — not merging."
+            exit 0
+          fi
+          if [ "$incomplete" -ne 0 ]; then
+            echo "Checks still running — not merging yet (a later event will re-evaluate)."
+            exit 0
+          fi
+
+          # 2) Staging PRs additionally require a completed Copilot review (any
+          #    state). Master PRs skip the review gate.
+          if [ "$BASE" = "staging" ]; then
+            echo "Base is staging — checking for a Copilot review..."
+            # Match any reviewer whose login contains "copilot" (case-insensitive)
+            # so this is robust to the exact bot login
+            # (e.g. "copilot-pull-request-reviewer[bot]" or "Copilot").
+            copilot_reviews=$(gh api "repos/$REPO/pulls/$PR/reviews" --paginate \
+              --jq '[.[] | select(.user.login | ascii_downcase | contains("copilot"))] | length' \
+              | jq -s 'add')
+            echo "  copilot reviews found: $copilot_reviews"
+            if [ "$copilot_reviews" -eq 0 ]; then
+              echo "Awaiting Copilot review — not merging yet (the review event will re-evaluate)."
+              exit 0
+            fi
+          else
+            echo "Base is $BASE — no review gate."
+          fi
+
+          echo "All gates satisfied — merging PR #$PR."
+          gh pr merge --merge "$PR" --repo "$REPO"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -59,18 +59,43 @@ jobs:
         run: |
           set -euo pipefail
 
+          # 0) Only ever auto-merge into branches we actually run this policy for.
+          #    The pull_request_review trigger has no branch filter, so a review
+          #    on a PR targeting some other base (e.g. release/*) would otherwise
+          #    reach this job; bail out explicitly rather than fall through to a
+          #    "no review gate -> merge on green" default.
+          case "$BASE" in
+            master|staging|dev) ;;
+            *)
+              echo "Base '$BASE' is not an auto-merge target — not merging."
+              exit 0
+              ;;
+          esac
+
           # 1) All required checks on the PR head commit must be passing. This
           #    covers both the pull_request path (jobs just finished) and the
           #    review path (jobs ran earlier on the same commit). The auto-merge
           #    job itself is excluded so it doesn't wait on its own "in_progress".
           echo "Checking combined check status for $HEAD_SHA..."
-          rollup=$(gh api "repos/$REPO/commits/$HEAD_SHA/check-runs" --paginate \
-            --jq '[.check_runs[] | select(.name != "auto-merge")] as $runs
-                  | { incomplete: ([ $runs[] | select(.status != "completed") ] | length),
-                      failed: ([ $runs[] | select(.conclusion != null and (.conclusion | IN("success","neutral","skipped") | not)) ] | length) }')
-          incomplete=$(echo "$rollup" | jq -s -r 'reduce .[] as $r ({incomplete:0,failed:0}; {incomplete:(.incomplete+$r.incomplete), failed:(.failed+$r.failed)}) | .incomplete')
-          failed=$(echo "$rollup" | jq -s -r 'reduce .[] as $r ({incomplete:0,failed:0}; {incomplete:(.incomplete+$r.incomplete), failed:(.failed+$r.failed)}) | .failed')
-          echo "  incomplete=$incomplete failed=$failed"
+          checks=$(gh api "repos/$REPO/commits/$HEAD_SHA/check-runs" --paginate \
+            --jq '.check_runs[] | select(.name != "auto-merge") | {name, status, conclusion}' \
+            | jq -s '.')
+          total=$(echo "$checks" | jq 'length')
+          incomplete=$(echo "$checks" | jq '[.[] | select(.status != "completed")] | length')
+          failed=$(echo "$checks" | jq '[.[] | select(.conclusion != null and (.conclusion | IN("success","neutral","skipped") | not))] | length')
+          echo "  total=$total incomplete=$incomplete failed=$failed"
+
+          # Guard against an empty/partial result reading as "all green": the
+          # required test contexts must actually be present and successful on this
+          # SHA before we trust the rollup. (A genuinely empty set here means the
+          # checks haven't been created yet, not that there's nothing to pass.)
+          required_ok=$(echo "$checks" | jq '
+            [.[] | select(
+              (.name | test("laravel-tests|backend|frontend"; "i"))
+              and .status == "completed"
+              and (.conclusion | IN("success","neutral","skipped"))
+            )] | length')
+          echo "  required test checks passing: $required_ok"
 
           if [ "$failed" -ne 0 ]; then
             echo "Checks failing — not merging."
@@ -80,9 +105,13 @@ jobs:
             echo "Checks still running — not merging yet (a later event will re-evaluate)."
             exit 0
           fi
+          if [ "$required_ok" -eq 0 ]; then
+            echo "Required test checks not yet present/successful on $HEAD_SHA — not merging (a later event will re-evaluate)."
+            exit 0
+          fi
 
           # 2) Staging PRs additionally require a completed Copilot review (any
-          #    state). Master PRs skip the review gate.
+          #    state). Master / dev skip the review gate.
           if [ "$BASE" = "staging" ]; then
             echo "Base is staging — checking for a Copilot review..."
             # Match any reviewer whose login contains "copilot" (case-insensitive)


### PR DESCRIPTION
## What

Makes the `auto-merge` job in `main.yml` base-branch-aware instead of merging any passing PR with no review.

| PR base | Gate to auto-merge |
|---|---|
| `staging` | all tests pass **AND** a Copilot review has been posted |
| `master` | all tests pass only |
| `dev` | all tests pass only |

## How

- `auto-merge` now also triggers on `pull_request_review`, so it re-evaluates when Copilot's automatic review lands — in either order relative to the tests finishing.
- On each trigger it re-checks the real state via the API: every check-run on the PR head SHA must be green, and for `staging` it additionally requires ≥1 Copilot review (any verdict). If a gate isn't met it exits cleanly and a later event re-evaluates.
- Copilot reviews every PR via the repo's **automatic code-review** rule, so nothing in CI requests it.

## Notes

- The Copilot-review check matches any reviewer login containing `copilot` (case-insensitive), so it's robust to the exact bot login.
- Policy enforcement against *manual* merges still depends on branch protection requiring the relevant status checks — out of scope for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)