### PR TITLE
feat: web account deletion (shared signed-link confirmation)

### DIFF
--- a/app/Http/Controllers/AccountController.php
+++ b/app/Http/Controllers/AccountController.php
@@ -4,10 +4,14 @@ namespace App\Http\Controllers;
 
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
+use App\Mail\AccountDeletionConfirmation;
 use App\Models\User;
 use App\Models\State;
 use App\Models\Country;
+use App\Services\AccountDeletionService;
 use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Facades\Mail;
+use Illuminate\Support\Facades\URL;
 use Inertia\Inertia;
 
 class AccountController extends Controller
@@ -105,6 +109,88 @@ class AccountController extends Controller
         $user->save();
 
         return redirect()->back()->with('successMessage', 'User was successfully updated');   
+    }
+
+    /**
+     * Request account deletion from the web app.
+     *
+     * Rather than deleting immediately, this emails the user a signed, expiring
+     * confirmation link. The account is only removed when that link is opened and
+     * the confirmation form is submitted (confirmDeletion / performDeletion). A
+     * GET prefetch of the link can never trigger the delete (POST-only).
+     *
+     * @return \Illuminate\Http\RedirectResponse
+     */
+    public function requestDeletion(Request $request)
+    {
+        $user = Auth::user();
+
+        Mail::to($user->email)->send(
+            new AccountDeletionConfirmation($user, $this->deletionConfirmationUrl($user))
+        );
+
+        return redirect()->back()->with(
+            'successMessage',
+            'Check your email to confirm account deletion. The link expires in 60 minutes.'
+        );
+    }
+
+    /**
+     * Build the signed, expiring URL for the account-deletion confirmation page.
+     * Shared by the web (requestDeletion) and mobile (Api\Mobile\AuthController)
+     * request flows so both email the same neutral confirmation link.
+     */
+    public static function deletionConfirmationUrl(User $user): string
+    {
+        // Points at the GET confirmation PAGE (not the deleting action). The page
+        // POSTs back to the same signed URL to actually delete — so a link
+        // prefetch/scanner (which only issues GETs) can never trigger the
+        // irreversible delete.
+        return URL::temporarySignedRoute(
+            'account.confirm-deletion',
+            now()->addMinutes(60),
+            ['user' => $user->id],
+        );
+    }
+
+    /**
+     * GET /account/confirm-deletion/{user} — signed link target. Shared by web
+     * and mobile request flows.
+     *
+     * Renders a confirmation page with a button that POSTs back to the same
+     * signed URL. It does NOT delete: GET is safe to prefetch (email security
+     * scanners and "safe link" crawlers issue GETs), so the destructive action
+     * lives on POST only.
+     *
+     * The route param is a raw int (not route-model-bound) so the signature is
+     * validated BEFORE any DB lookup — no DB hit on forged links, and no
+     * account-existence leak via 403-vs-404 (invalid signature always 403s).
+     */
+    public function confirmDeletion(Request $request, int $user): \Illuminate\Http\Response
+    {
+        abort_unless($request->hasValidSignature(), 403, 'This deletion link is invalid or has expired.');
+
+        // Re-present the exact signed query string so the form can POST to the
+        // same URL and pass signature validation again.
+        return response()->view('account.confirm-deletion', [
+            'actionUrl' => $request->fullUrl(),
+        ]);
+    }
+
+    /**
+     * POST /account/confirm-deletion/{user} — performs the deletion. Same signed
+     * URL as the GET page; the signature is the credential. Only a deliberate
+     * form submit (POST) reaches here, never a passive GET prefetch.
+     */
+    public function performDeletion(Request $request, int $user): \Illuminate\Http\Response
+    {
+        abort_unless($request->hasValidSignature(), 403, 'This deletion link is invalid or has expired.');
+
+        $account = User::findOrFail($user);
+
+        app(AccountDeletionService::class)->deleteAccount($account);
+
+        return response()->view('account.deletion-confirmed');
     }
 
     /**

--- a/app/Http/Controllers/Api/Mobile/AuthController.php
+++ b/app/Http/Controllers/Api/Mobile/AuthController.php
@@ -2,19 +2,18 @@
 
 namespace App\Http\Controllers\Api\Mobile;
 
+use App\Http\Controllers\AccountController;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\Mobile\TokenRequest;
 use App\Mail\AccountDeletionConfirmation;
 use App\Models\Country;
 use App\Models\State;
 use App\Models\User;
-use App\Services\AccountDeletionService;
 use App\Services\Mobile\TokenService;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\Mail;
-use Illuminate\Support\Facades\URL;
 use Illuminate\Validation\ValidationException;
 
 class AuthController extends Controller
@@ -155,59 +154,15 @@ class AuthController extends Controller
     {
         $user = $request->user();
 
-        // Signed URL points at the GET confirmation PAGE (not the deleting
-        // action). The page posts back to the same signed URL to actually
-        // delete — so a link prefetch/scanner (which only issues GETs) can
-        // never trigger the irreversible delete.
-        $url = URL::temporarySignedRoute(
-            'mobile.account.confirm-deletion',
-            now()->addMinutes(60),
-            ['user' => $user->id],
+        // Emails a signed link to the neutral, shared confirmation page
+        // (account.confirm-deletion) — the same page the web flow uses. The page
+        // POSTs back to actually delete, so a GET prefetch can never trigger it.
+        Mail::to($user->email)->send(
+            new AccountDeletionConfirmation($user, AccountController::deletionConfirmationUrl($user))
         );
-
-        Mail::to($user->email)->send(new AccountDeletionConfirmation($user, $url));
 
         return response()->json([
             'message' => 'Check your email to confirm account deletion. The link expires in 60 minutes.',
         ], 202);
-    }
-
-    /**
-     * GET /api/mobile/account/confirm-deletion/{user} — signed link target.
-     *
-     * Renders a confirmation page with a button that POSTs back to the same
-     * signed URL. It does NOT delete: GET is safe to prefetch (email security
-     * scanners and "safe link" crawlers issue GETs), so the destructive action
-     * lives on POST only.
-     *
-     * The route param is a raw int (not route-model-bound) so the signature is
-     * validated BEFORE any DB lookup — no DB hit on forged links, and no
-     * account-existence leak via 403-vs-404 (invalid signature always 403s).
-     */
-    public function confirmDeletion(Request $request, int $user): \Illuminate\Http\Response
-    {
-        abort_unless($request->hasValidSignature(), 403, 'This deletion link is invalid or has expired.');
-
-        // Re-present the exact signed query string so the form can POST to the
-        // same URL and pass signature validation again.
-        return response()->view('account.confirm-deletion', [
-            'actionUrl' => $request->fullUrl(),
-        ]);
-    }
-
-    /**
-     * POST /api/mobile/account/confirm-deletion/{user} — performs the deletion.
-     * Same signed URL as the GET page; the signature is the credential. Only a
-     * deliberate form submit (POST) reaches here, never a passive GET prefetch.
-     */
-    public function performDeletion(Request $request, int $user): \Illuminate\Http\Response
-    {
-        abort_unless($request->hasValidSignature(), 403, 'This deletion link is invalid or has expired.');
-
-        $account = User::findOrFail($user);
-
-        app(AccountDeletionService::class)->deleteAccount($account);
-
-        return response()->view('account.deletion-confirmed');
     }
 }

--- a/resources/js/Pages/Account/Index.vue
+++ b/resources/js/Pages/Account/Index.vue
@@ -115,7 +115,36 @@
                       <div class="flex justify-end p-2">
                         <button v-on:click="updateAccount" class="bg-blue-500 px-4 py-2 text-lg font-semibold tracking-wider flex-end text-white rounded hover:bg-blue-600">Save</button>
                       </div>
+
+                      <div class="border-t border-red-200 dark:border-red-900 mt-8 pt-6 px-2">
+                        <h3 class="text-lg font-bold text-red-600 dark:text-red-400">Danger Zone</h3>
+                        <p class="text-sm text-gray-600 dark:text-gray-300 mt-1 mb-3">
+                          Permanently delete your account. This removes you from your bands and cannot be undone.
+                        </p>
+                        <button v-on:click="showDeleteModal = true" class="bg-red-600 px-4 py-2 text-sm font-semibold tracking-wider text-white rounded hover:bg-red-700">
+                          Delete Account
+                        </button>
+                      </div>
                     </div>
+                </div>
+            </div>
+        </div>
+
+        <!-- Delete account confirmation modal -->
+        <div v-if="showDeleteModal" class="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-50 p-4" @click.self="showDeleteModal = false">
+            <div class="bg-white dark:bg-slate-700 rounded-lg shadow-xl max-w-md w-full p-6">
+                <h3 class="text-xl font-bold text-gray-900 dark:text-white">Delete your account?</h3>
+                <p class="text-sm text-gray-600 dark:text-gray-200 mt-2">
+                    For your security, we'll email <span class="font-semibold">{{ user.email }}</span> a confirmation
+                    link. Your account is only deleted after you open that link and confirm. The link expires in 60 minutes.
+                </p>
+                <div class="flex justify-end gap-3 mt-6">
+                    <button v-on:click="showDeleteModal = false" :disabled="deleting" class="px-4 py-2 text-sm font-semibold text-gray-700 dark:text-gray-200 rounded hover:bg-gray-100 dark:hover:bg-slate-600">
+                        Cancel
+                    </button>
+                    <button v-on:click="requestDeletion" :disabled="deleting" class="bg-red-600 px-4 py-2 text-sm font-semibold text-white rounded hover:bg-red-700 disabled:opacity-60">
+                        {{ deleting ? 'Sending…' : 'Send confirmation email' }}
+                    </button>
                 </div>
             </div>
         </div>
@@ -145,9 +174,11 @@
                     address2:this.user.Address2,
                     emailNotifications:this.user.emailNotifications
                 },
-                filteredStateList:this.states
+                filteredStateList:this.states,
+                showDeleteModal:false,
+                deleting:false
             }
-        }, 
+        },
         computed:{
             },
         watch:{
@@ -165,12 +196,21 @@
                 }
             },
             updateAccount(){
-                
+
                 this.$inertia.patch('/account/update',this.form)
                     .then(()=>{
                         this.loading = false;
                     })
+            },
+            requestDeletion(){
+                this.deleting = true;
+                this.$inertia.post('/account/delete', {}, {
+                    onFinish:()=>{
+                        this.deleting = false;
+                        this.showDeleteModal = false;
+                    }
+                })
             }
-        }       
+        }
     }
 </script>

--- a/routes/account.php
+++ b/routes/account.php
@@ -5,3 +5,16 @@ use Illuminate\Support\Facades\Route;
 
 Route::any('/account', 'AccountController@index')->middleware(['auth', 'verified'])->name('account');
 Route::patch('/account/update', 'AccountController@update')->middleware(['auth', 'verified'])->name('account.update');
+
+// Request account deletion. This does not delete immediately: it emails the
+// user a signed, expiring link that performs the irreversible delete (the
+// confirm-deletion routes below). Shared by the mobile DELETE /account flow.
+Route::post('/account/delete', 'AccountController@requestDeletion')->middleware(['auth', 'verified'])->name('account.delete');
+
+// Public, signed account-deletion confirmation (auth is the signature itself,
+// so a logged-out user following the emailed link still reaches it). GET renders
+// the confirmation page; POST (from that page, same signed URL) performs the
+// irreversible delete — so a GET prefetch can never delete. Used by both web and
+// mobile request flows.
+Route::get('/account/confirm-deletion/{user}', 'AccountController@confirmDeletion')->name('account.confirm-deletion');
+Route::post('/account/confirm-deletion/{user}', 'AccountController@performDeletion')->name('account.perform-deletion');

--- a/routes/api.php
+++ b/routes/api.php
@@ -67,11 +67,9 @@ Route::prefix('mobile')->group(function () {
     // Public: signed-URL contract view (auth is the signature itself)
     Route::get('/bands/{band}/bookings/{booking}/contract/view-signed', [App\Http\Controllers\Api\Mobile\BookingsController::class, 'viewContractSigned'])->name('mobile.bookings.contract.view.signed');
 
-    // Public: signed account-deletion link (auth is the signature itself).
-    // GET renders a confirmation page; POST (from that page, same signed URL)
-    // performs the irreversible delete — so a GET prefetch can never delete.
-    Route::get('/account/confirm-deletion/{user}', [MobileAuthController::class, 'confirmDeletion'])->name('mobile.account.confirm-deletion');
-    Route::post('/account/confirm-deletion/{user}', [MobileAuthController::class, 'performDeletion'])->name('mobile.account.perform-deletion');
+    // Account-deletion confirmation lives at a neutral, shared path defined in
+    // routes/account.php (account.confirm-deletion / account.perform-deletion).
+    // The mobile DELETE /account flow below emails a link to those routes.
 
     // Authenticated
     Route::middleware('auth:sanctum')->group(function () {

--- a/tests/Feature/AccountDeletionTest.php
+++ b/tests/Feature/AccountDeletionTest.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Mail\AccountDeletionConfirmation;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Mail;
+use Tests\TestCase;
+
+/**
+ * Web (session) account-deletion request flow. The destructive confirmation
+ * step is shared with the mobile flow and is covered by
+ * Tests\Feature\Api\Mobile\AccountDeletionTest — here we only assert that the
+ * authenticated web request emails the signed link and never deletes directly.
+ */
+class AccountDeletionTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_request_sends_confirmation_email_and_does_not_delete(): void
+    {
+        Mail::fake();
+
+        $user = User::factory()->create();
+
+        $this->actingAs($user)
+            ->post('/account/delete')
+            ->assertRedirect();
+
+        // Account still exists — only confirming the emailed link deletes it.
+        $this->assertDatabaseHas('users', ['id' => $user->id]);
+
+        Mail::assertSent(AccountDeletionConfirmation::class, fn ($mail) => $mail->hasTo($user->email));
+    }
+
+    public function test_request_requires_authentication(): void
+    {
+        Mail::fake();
+
+        $this->post('/account/delete')->assertRedirect('/login');
+
+        Mail::assertNothingSent();
+    }
+}

--- a/tests/Feature/Api/Mobile/AccountDeletionTest.php
+++ b/tests/Feature/Api/Mobile/AccountDeletionTest.php
@@ -52,7 +52,7 @@ class AccountDeletionTest extends TestCase
         DeviceToken::factory()->create(['user_id' => $user->id]);
 
         $url = URL::temporarySignedRoute(
-            'mobile.account.confirm-deletion',
+            'account.confirm-deletion',
             now()->addMinutes(60),
             ['user' => $user->id],
         );
@@ -74,7 +74,7 @@ class AccountDeletionTest extends TestCase
         $user = User::factory()->create();
 
         $url = URL::temporarySignedRoute(
-            'mobile.account.confirm-deletion',
+            'account.confirm-deletion',
             now()->addMinutes(60),
             ['user' => $user->id],
         );
@@ -98,7 +98,7 @@ class AccountDeletionTest extends TestCase
         BandMembers::factory()->create(['user_id' => $remaining->id, 'band_id' => $band->id]);
 
         $url = URL::temporarySignedRoute(
-            'mobile.account.confirm-deletion',
+            'account.confirm-deletion',
             now()->addMinutes(60),
             ['user' => $leaving->id],
         );
@@ -119,9 +119,9 @@ class AccountDeletionTest extends TestCase
         $user = User::factory()->create();
 
         // Tampered URL — valid route, bad signature. Both verbs must 403.
-        $this->post("/api/mobile/account/confirm-deletion/{$user->id}?signature=deadbeef&expires=9999999999")
+        $this->post("/account/confirm-deletion/{$user->id}?signature=deadbeef&expires=9999999999")
             ->assertForbidden();
-        $this->get("/api/mobile/account/confirm-deletion/{$user->id}?signature=deadbeef&expires=9999999999")
+        $this->get("/account/confirm-deletion/{$user->id}?signature=deadbeef&expires=9999999999")
             ->assertForbidden();
 
         $this->assertDatabaseHas('users', ['id' => $user->id]);
@@ -131,7 +131,7 @@ class AccountDeletionTest extends TestCase
     {
         // Signature is validated before any DB lookup, so a forged link can't be
         // used to probe whether an account id exists (always 403, never 404).
-        $this->post('/api/mobile/account/confirm-deletion/999999?signature=deadbeef&expires=9999999999')
+        $this->post('/account/confirm-deletion/999999?signature=deadbeef&expires=9999999999')
             ->assertForbidden();
     }
 }


### PR DESCRIPTION
## What

Adds **account deletion to the web app**, mirroring the flow already shipped on mobile. Requesting deletion does not delete immediately — it emails the user a signed, expiring (60 min) confirmation link; the account is removed only when that link is opened and the confirmation form is submitted. A GET prefetch of the link can never delete (POST-only).

## Key change: neutral shared confirmation path

The signed confirmation page + handlers moved from the mobile-only `/api/mobile/account/confirm-deletion` routes to a neutral shared path:

- `GET  /account/confirm-deletion/{user}` → `account.confirm-deletion`
- `POST /account/confirm-deletion/{user}` → `account.perform-deletion`

Both the web and mobile request flows now email links to these routes, so the emailed URL no longer contains `mobile`. As a bonus, the destructive confirm POST is now under the `web` middleware group, so it gains CSRF protection it didn't have as an API route.

## Changes

- **`AccountController`** — `requestDeletion()` (web), plus the shared `deletionConfirmationUrl()` / `confirmDeletion()` / `performDeletion()` relocated here from the mobile controller.
- **`Api\Mobile\AuthController`** — `requestDeletion()` now emails the shared link; relocated handlers and now-unused imports removed.
- **`routes/account.php`** / **`routes/api.php`** — neutral routes added; old mobile confirm-deletion routes removed.
- **`Account/Index.vue`** — a "Danger Zone" with a Delete Account button and a confirmation modal that POSTs to `/account/delete`.
- **Tests** — new web `AccountDeletionTest`; mobile test updated to the neutral route name/path.

The underlying `AccountDeletionService` (hard delete, band detachment preserving other members, personal-data cleanup) is unchanged and shared by both flows.

## Verification

All 9 deletion tests pass locally (2 new web + 7 existing mobile):

```
Tests:    9 passed (28 assertions)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)