### PR TITLE
refactor: address Copilot review on account-deletion

### DIFF
--- a/app/Http/Controllers/AccountController.php
+++ b/app/Http/Controllers/AccountController.php
@@ -11,7 +11,6 @@ use App\Models\Country;
 use App\Services\AccountDeletionService;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\Mail;
-use Illuminate\Support\Facades\URL;
 use Inertia\Inertia;
 
 class AccountController extends Controller
@@ -121,35 +120,17 @@ class AccountController extends Controller
      *
      * @return \Illuminate\Http\RedirectResponse
      */
-    public function requestDeletion(Request $request)
+    public function requestDeletion(Request $request): \Illuminate\Http\RedirectResponse
     {
-        $user = Auth::user();
+        $user = $request->user();
 
         Mail::to($user->email)->send(
-            new AccountDeletionConfirmation($user, $this->deletionConfirmationUrl($user))
+            new AccountDeletionConfirmation($user, AccountDeletionService::confirmationUrl($user))
         );
 
         return redirect()->back()->with(
             'successMessage',
             'Check your email to confirm account deletion. The link expires in 60 minutes.'
-        );
-    }
-
-    /**
-     * Build the signed, expiring URL for the account-deletion confirmation page.
-     * Shared by the web (requestDeletion) and mobile (Api\Mobile\AuthController)
-     * request flows so both email the same neutral confirmation link.
-     */
-    public static function deletionConfirmationUrl(User $user): string
-    {
-        // Points at the GET confirmation PAGE (not the deleting action). The page
-        // POSTs back to the same signed URL to actually delete — so a link
-        // prefetch/scanner (which only issues GETs) can never trigger the
-        // irreversible delete.
-        return URL::temporarySignedRoute(
-            'account.confirm-deletion',
-            now()->addMinutes(60),
-            ['user' => $user->id],
         );
     }
 

--- a/app/Http/Controllers/Api/Mobile/AuthController.php
+++ b/app/Http/Controllers/Api/Mobile/AuthController.php
@@ -2,13 +2,13 @@
 
 namespace App\Http\Controllers\Api\Mobile;
 
-use App\Http\Controllers\AccountController;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\Mobile\TokenRequest;
 use App\Mail\AccountDeletionConfirmation;
 use App\Models\Country;
 use App\Models\State;
 use App\Models\User;
+use App\Services\AccountDeletionService;
 use App\Services\Mobile\TokenService;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
@@ -158,7 +158,7 @@ class AuthController extends Controller
         // (account.confirm-deletion) — the same page the web flow uses. The page
         // POSTs back to actually delete, so a GET prefetch can never trigger it.
         Mail::to($user->email)->send(
-            new AccountDeletionConfirmation($user, AccountController::deletionConfirmationUrl($user))
+            new AccountDeletionConfirmation($user, AccountDeletionService::confirmationUrl($user))
         );
 
         return response()->json([

--- a/app/Services/AccountDeletionService.php
+++ b/app/Services/AccountDeletionService.php
@@ -7,10 +7,30 @@ use App\Models\EventSubs;
 use App\Models\Invitations;
 use App\Models\User;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\URL;
 
 class AccountDeletionService
 {
     public function __construct(protected BandMemberRemovalService $removalService) {}
+
+    /**
+     * Build the signed, expiring URL for the account-deletion confirmation page.
+     * Shared by the web and mobile request flows so both email the same neutral
+     * confirmation link.
+     *
+     * Points at the GET confirmation PAGE (not the deleting action). The page
+     * POSTs back to the same signed URL to actually delete — so a link
+     * prefetch/scanner (which only issues GETs) can never trigger the
+     * irreversible delete.
+     */
+    public static function confirmationUrl(User $user): string
+    {
+        return URL::temporarySignedRoute(
+            'account.confirm-deletion',
+            now()->addMinutes(60),
+            ['user' => $user->id],
+        );
+    }
 
     /**
      * Permanently delete a user account and all of its personal associations.

--- a/resources/js/Pages/Account/Index.vue
+++ b/resources/js/Pages/Account/Index.vue
@@ -131,35 +131,42 @@
         </div>
 
         <!-- Delete account confirmation modal -->
-        <div v-if="showDeleteModal" class="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-50 p-4" @click.self="showDeleteModal = false">
-            <div class="bg-white dark:bg-slate-700 rounded-lg shadow-xl max-w-md w-full p-6">
-                <h3 class="text-xl font-bold text-gray-900 dark:text-white">Delete your account?</h3>
-                <p class="text-sm text-gray-600 dark:text-gray-200 mt-2">
-                    For your security, we'll email <span class="font-semibold">{{ user.email }}</span> a confirmation
-                    link. Your account is only deleted after you open that link and confirm. The link expires in 60 minutes.
-                </p>
-                <div class="flex justify-end gap-3 mt-6">
-                    <button v-on:click="showDeleteModal = false" :disabled="deleting" class="px-4 py-2 text-sm font-semibold text-gray-700 dark:text-gray-200 rounded hover:bg-gray-100 dark:hover:bg-slate-600">
+        <Dialog
+            v-model:visible="showDeleteModal"
+            modal
+            :closable="!deleting"
+            header="Delete your account?"
+            class="w-full max-w-md"
+        >
+            <p class="text-sm text-gray-600 dark:text-gray-200">
+                For your security, we'll email <span class="font-semibold">{{ user.email }}</span> a confirmation
+                link. Your account is only deleted after you open that link and confirm. The link expires in 60 minutes.
+            </p>
+            <template #footer>
+                <div class="flex justify-end gap-3">
+                    <button v-on:click="showDeleteModal = false" :disabled="deleting" class="px-4 py-2 text-sm font-semibold text-gray-700 dark:text-gray-200 rounded hover:bg-gray-100 dark:hover:bg-slate-600 disabled:opacity-60">
                         Cancel
                     </button>
                     <button v-on:click="requestDeletion" :disabled="deleting" class="bg-red-600 px-4 py-2 text-sm font-semibold text-white rounded hover:bg-red-700 disabled:opacity-60">
                         {{ deleting ? 'Sending…' : 'Send confirmation email' }}
                     </button>
                 </div>
-            </div>
-        </div>
+            </template>
+        </Dialog>
     </breeze-authenticated-layout>
 </template>
 
 <script>
     import BreezeAuthenticatedLayout from '@/Layouts/Authenticated'
     import InputSwitch from 'primevue/inputswitch';
+    import Dialog from 'primevue/dialog';
 
     export default {
         props:['user','states','countries','successMessage'],
         components: {
             BreezeAuthenticatedLayout,
             InputSwitch,
+            Dialog,
         },
         data(){
             return{
@@ -205,9 +212,14 @@
             requestDeletion(){
                 this.deleting = true;
                 this.$inertia.post('/account/delete', {}, {
+                    // Close the modal only when the request actually succeeds, so
+                    // a 419/500/network error keeps it open with the button
+                    // re-enabled rather than implying the email was sent.
+                    onSuccess:()=>{
+                        this.showDeleteModal = false;
+                    },
                     onFinish:()=>{
                         this.deleting = false;
-                        this.showDeleteModal = false;
                     }
                 })
             }


### PR DESCRIPTION
Follow-up to #429. That PR auto-merged on Copilot's (COMMENTED) review before these review fixes were pushed, so this PR lands them.

Addresses all four Copilot comments from #429:

1. **Modal hides errors** — the delete-confirmation modal now closes only on `onSuccess`; `onFinish` just resets the sending flag, so a 419/500/network error keeps it open and the button re-enabled rather than implying the email was sent.
2. **Custom modal vs PrimeVue Dialog** — converted the hand-rolled overlay to a PrimeVue `<Dialog modal header>` with a `#footer` slot (accessible dialog semantics + focus management, consistent with the rest of the app). `:closable` is gated on `!deleting`.
3. **Missing return type / static-via-`$this`** — `AccountController::requestDeletion()` now declares a `RedirectResponse` return type and uses `$request->user()`. The static-via-instance call is gone (see #4).
4. **Cross-controller dependency** — moved the signed confirmation-URL builder out of `AccountController` into `AccountDeletionService::confirmationUrl()`. The mobile `AuthController` no longer imports the web controller; both flows call the service.

## Verification

- 9 deletion tests pass (`9 passed (28 assertions)`).
- PHP lint clean; frontend builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)