### PR TITLE
ci: require an approving human review to merge staging PRs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -110,19 +110,32 @@ jobs:
             exit 0
           fi
 
-          # 2) Staging PRs additionally require a completed Copilot review (any
-          #    state). Master / dev skip the review gate.
+          # 2) Staging PRs additionally require at least one APPROVING human
+          #    review. Copilot reviews every PR automatically but only ever
+          #    comments, so its review must NOT satisfy this gate — the gate is
+          #    what makes a human sign-off mandatory. Master / dev skip review.
+          #
+          #    This is the primary enforcement: the GH_PAT is an owner token and
+          #    staging has enforce_admins=false, so `gh pr merge` would otherwise
+          #    bypass the branch-protection approval rule. Gating here means the
+          #    bot won't even attempt the merge until an approval exists.
           if [ "$BASE" = "staging" ]; then
-            echo "Base is staging — checking for a Copilot review..."
-            # Match any reviewer whose login contains "copilot" (case-insensitive)
-            # so this is robust to the exact bot login
-            # (e.g. "copilot-pull-request-reviewer[bot]" or "Copilot").
-            copilot_reviews=$(gh api "repos/$REPO/pulls/$PR/reviews" --paginate \
-              --jq '[.[] | select(.user.login | ascii_downcase | contains("copilot"))] | length' \
-              | jq -s 'add')
-            echo "  copilot reviews found: $copilot_reviews"
-            if [ "$copilot_reviews" -eq 0 ]; then
-              echo "Awaiting Copilot review — not merging yet (the review event will re-evaluate)."
+            echo "Base is staging — requiring an approving human review..."
+            # Reviews come back in chronological order; reduce to each reviewer's
+            # LATEST review state, drop bots (Copilot et al.), then count APPROVED.
+            # A later CHANGES_REQUESTED from the same person overrides an earlier
+            # APPROVED, so a stale approval can't slip a change-requested PR through.
+            approvals=$(gh api "repos/$REPO/pulls/$PR/reviews" --paginate \
+              --jq '[.[] | select((.user.type // "User") != "Bot")
+                         | select(.state == "APPROVED" or .state == "CHANGES_REQUESTED" or .state == "DISMISSED")]' \
+              | jq -s '
+                  add // []
+                  | group_by(.user.login)
+                  | map(max_by(.submitted_at) | select(.state == "APPROVED"))
+                  | length')
+            echo "  current approvals: $approvals"
+            if [ "${approvals:-0}" -eq 0 ]; then
+              echo "Awaiting an approving review — not merging yet (a review event will re-evaluate)."
               exit 0
             fi
           else

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -120,22 +120,29 @@ jobs:
           #    bypass the branch-protection approval rule. Gating here means the
           #    bot won't even attempt the merge until an approval exists.
           if [ "$BASE" = "staging" ]; then
-            echo "Base is staging — requiring an approving human review..."
-            # Reviews come back in chronological order; reduce to each reviewer's
-            # LATEST review state, drop bots (Copilot et al.), then count APPROVED.
-            # A later CHANGES_REQUESTED from the same person overrides an earlier
-            # APPROVED, so a stale approval can't slip a change-requested PR through.
+            echo "Base is staging — requiring an approving human review on $HEAD_SHA..."
+            # Only reviews submitted against the CURRENT head commit count: a new
+            # push must get a fresh approval. We can't rely on branch protection's
+            # "dismiss stale approvals" because the owner GH_PAT bypasses it, so
+            # the staleness check has to live here.
+            #
+            # Among reviews on HEAD_SHA, reduce each reviewer to their latest
+            # meaningful state (bots dropped, COMMENTED ignored) and count
+            # APPROVED — so a CHANGES_REQUESTED on HEAD overrides an earlier
+            # APPROVED on the same commit.
             approvals=$(gh api "repos/$REPO/pulls/$PR/reviews" --paginate \
-              --jq '[.[] | select((.user.type // "User") != "Bot")
-                         | select(.state == "APPROVED" or .state == "CHANGES_REQUESTED" or .state == "DISMISSED")]' \
+              --jq --arg head "$HEAD_SHA" \
+                '[.[] | select((.user.type // "User") != "Bot")
+                      | select(.commit_id == $head)
+                      | select(.state == "APPROVED" or .state == "CHANGES_REQUESTED" or .state == "DISMISSED")]' \
               | jq -s '
                   add // []
                   | group_by(.user.login)
                   | map(max_by(.submitted_at) | select(.state == "APPROVED"))
                   | length')
-            echo "  current approvals: $approvals"
+            echo "  approvals on current head: $approvals"
             if [ "${approvals:-0}" -eq 0 ]; then
-              echo "Awaiting an approving review — not merging yet (a review event will re-evaluate)."
+              echo "Awaiting an approving review on the current commit — not merging yet (a review event will re-evaluate)."
               exit 0
             fi
           else


### PR DESCRIPTION
## Why

The staging auto-merge gate previously merged as soon as *any* Copilot review existed. Since Copilot reviews every PR automatically but only ever **comments** (never approves), PRs merged the instant Copilot posted — with its suggestions unaddressed. (This is exactly what happened to #429.)

You added branch protection requiring 1 approval, but the `GH_PAT` is an owner token and staging has `enforce_admins=false`, so the workflow's `gh pr merge` would **bypass** that rule. So the enforcement has to live in the workflow itself.

## What

- Staging gate now requires **≥1 approving human review** instead of "any Copilot review".
- Bot reviews (Copilot) are excluded from the count, so Copilot can comment all it likes but only a human approval unblocks the merge.
- Approval counting reduces each reviewer to their **latest** review state, so a later `CHANGES_REQUESTED` overrides an earlier `APPROVED` (a stale approval can't slip a change-requested PR through).
- `master` / `dev` are unchanged (tests-only, no review gate).

Branch protection's approval requirement stays as a backstop.

## Verification

Validated the YAML and unit-tested the approval logic across review histories: human-approved + copilot-commented → 1; copilot-only → 0; approve-then-changes → 0; changes-then-approve → 1; comment-only → 0; empty → 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)