### PR TITLE
Add per-user ICS calendar feed for mobile subscription

### DIFF
--- a/app/Http/Controllers/Api/Mobile/CalendarFeedController.php
+++ b/app/Http/Controllers/Api/Mobile/CalendarFeedController.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace App\Http\Controllers\Api\Mobile;
+
+use App\Http\Controllers\Controller;
+use App\Models\User;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+class CalendarFeedController extends Controller
+{
+    /**
+     * Return the authenticated user's calendar subscription URLs.
+     *
+     * Mints the calendar token on first call. The app uses these to offer
+     * "Subscribe in Google Calendar" (google_subscribe_url) and a generic
+     * "Copy link" for Apple Calendar / Outlook (webcal_url).
+     */
+    public function show(Request $request): JsonResponse
+    {
+        /** @var User $user */
+        $user = $request->user();
+
+        return response()->json($this->payload($user));
+    }
+
+    /**
+     * Regenerate the token, invalidating the previously shared feed URL, and
+     * return the new URLs.
+     */
+    public function reset(Request $request): JsonResponse
+    {
+        /** @var User $user */
+        $user = $request->user();
+        $user->regenerateCalendarToken();
+
+        return response()->json($this->payload($user));
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private function payload(User $user): array
+    {
+        $token = $user->getCalendarToken();
+
+        // Absolute https URL to the public ICS feed.
+        $httpsUrl = route('calendar.feed', ['token' => $token . '.ics']);
+
+        // webcal:// makes Apple Calendar / Outlook subscribe (rather than
+        // download) when the link is tapped.
+        $webcalUrl = preg_replace('/^https?:\/\//', 'webcal://', $httpsUrl);
+
+        // Deep link that opens Google Calendar's "add by URL" flow prefilled
+        // with the feed. Google expects the feed URL (webcal or https) in cid.
+        $googleSubscribeUrl = 'https://calendar.google.com/calendar/r?cid=' . urlencode($webcalUrl);
+
+        return [
+            'url'                  => $httpsUrl,
+            'webcal_url'           => $webcalUrl,
+            'google_subscribe_url' => $googleSubscribeUrl,
+        ];
+    }
+}

--- a/app/Http/Controllers/CalendarFeedController.php
+++ b/app/Http/Controllers/CalendarFeedController.php
@@ -1,0 +1,144 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Events;
+use App\Models\User;
+use App\Services\UserEventsService;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Auth;
+use Spatie\IcalendarGenerator\Components\Calendar;
+use Spatie\IcalendarGenerator\Components\Event as CalendarEvent;
+use Symfony\Component\HttpFoundation\Response;
+
+class CalendarFeedController extends Controller
+{
+    /**
+     * How far back the feed reaches. Subscriptions want some recent history so
+     * a just-passed gig doesn't vanish, but there's no reason to ship years of
+     * old events to every calendar client.
+     */
+    private const PAST_WINDOW_DAYS = 30;
+
+    /**
+     * How far forward the feed reaches. Twelve months covers planning horizons
+     * for bookings/rehearsals without unbounded growth.
+     */
+    private const FUTURE_WINDOW_MONTHS = 12;
+
+    /**
+     * Serve a user's personal ICS calendar feed.
+     *
+     * This endpoint is intentionally unauthenticated — Google/Apple Calendar
+     * fetch it on a schedule with no session — so the long, random
+     * calendar_token in the URL is the credential. The set of events is the
+     * SAME set the user sees on their dashboard: we reuse UserEventsService so
+     * the feed can never diverge from the app (members see all band events,
+     * sub-only users see only what they're assigned).
+     *
+     * Only member-appropriate fields are emitted (title, time, venue, a short
+     * description). Financial fields (price, deposits, contracts) are never
+     * included.
+     */
+    public function show(string $token): Response
+    {
+        // Strip a trailing ".ics" so both /calendar/{token} and
+        // /calendar/{token}.ics resolve to the same user.
+        $token = preg_replace('/\.ics$/', '', $token);
+
+        $user = User::where('calendar_token', $token)->first();
+
+        abort_if($user === null, 404);
+
+        // UserEventsService reads Auth::user() internally; Sanctum/session are
+        // absent here, so bind the resolved user to the guard exactly like the
+        // mobile DashboardController does. setUser() avoids firing login events.
+        Auth::setUser($user);
+
+        $after  = Carbon::now()->subDays(self::PAST_WINDOW_DAYS);
+        $before = Carbon::now()->addMonths(self::FUTURE_WINDOW_MONTHS);
+
+        // getEventIds() applies the full entitlement rules and naturally
+        // excludes virtual rehearsals (which have no real event id and thus no
+        // stable UID for a subscription).
+        $eventIds = (new UserEventsService())->getEventIds($after, $before);
+
+        $events = empty($eventIds)
+            ? collect()
+            : Events::whereIn('id', $eventIds)
+                ->with('eventable.band')
+                ->orderBy('date')
+                ->orderBy('start_time')
+                ->get();
+
+        $calendar = Calendar::create($this->calendarName($user))
+            // Hint to clients how often to re-poll the feed.
+            ->refreshInterval(60 * 6);
+
+        foreach ($events as $event) {
+            $calendarEvent = $this->buildEvent($event);
+            if ($calendarEvent !== null) {
+                $calendar->event($calendarEvent);
+            }
+        }
+
+        return response($calendar->get(), 200, [
+            'Content-Type'        => 'text/calendar; charset=utf-8',
+            'Content-Disposition' => 'inline; filename="thatstheticket.ics"',
+            // The feed is per-user and changes as events change; don't let
+            // proxies cache it across users or for long.
+            'Cache-Control'       => 'private, max-age=300',
+        ]);
+    }
+
+    private function calendarName(User $user): string
+    {
+        $appName = config('app.name', 'TTS');
+
+        return trim($user->name) !== ''
+            ? "{$user->name} — {$appName}"
+            : $appName;
+    }
+
+    /**
+     * Map a single Events model to an iCalendar VEVENT, or null if it lacks the
+     * minimum data to render. Reuses the model's existing Google Calendar
+     * helpers so the feed stays consistent with the server-side group sync.
+     */
+    private function buildEvent(Events $event): ?CalendarEvent
+    {
+        if ($event->date === null) {
+            return null;
+        }
+
+        $start = Carbon::parse($event->startDateTime, config('app.timezone'));
+        $end   = Carbon::parse($event->endDateTime, config('app.timezone'));
+
+        $calendarEvent = CalendarEvent::create()
+            ->uniqueIdentifier('event-' . $event->id . '@thatstheticket')
+            ->name($event->getGoogleCalendarSummary() ?? ($event->title ?: 'Event'));
+
+        // Events with no explicit start time use a noon placeholder in
+        // startDateTime; treat those as all-day so calendars don't show a
+        // misleading 12:00 slot.
+        if ($event->start_time === null) {
+            $calendarEvent->startsAt($start, withTime: false)->fullDay();
+        } else {
+            $calendarEvent->startsAt($start)->endsAt($end);
+        }
+
+        $description = $event->getGoogleCalendarDescription();
+        if (!empty($description)) {
+            $calendarEvent->description($description);
+        }
+
+        if (!empty($event->venue_name)) {
+            $calendarEvent->address(
+                $event->venue_address ? $event->venue_name . ', ' . $event->venue_address : $event->venue_name,
+                $event->venue_name,
+            );
+        }
+
+        return $calendarEvent;
+    }
+}

--- a/app/Http/Controllers/CalendarFeedController.php
+++ b/app/Http/Controllers/CalendarFeedController.php
@@ -111,8 +111,15 @@ class CalendarFeedController extends Controller
             return null;
         }
 
-        $start = Carbon::parse($event->startDateTime, config('app.timezone'));
-        $end   = Carbon::parse($event->endDateTime, config('app.timezone'));
+        // startDateTime/endDateTime are naive wall-clock strings; interpret them
+        // in the event's venue timezone when set (for out-of-timezone gigs),
+        // falling back to the app timezone.
+        $timezone = !empty($event->venue_timezone)
+            ? $event->venue_timezone
+            : config('app.timezone');
+
+        $start = Carbon::parse($event->startDateTime, $timezone);
+        $end   = Carbon::parse($event->endDateTime, $timezone);
 
         $calendarEvent = CalendarEvent::create()
             ->uniqueIdentifier('event-' . $event->id . '@thatstheticket')
@@ -132,10 +139,16 @@ class CalendarFeedController extends Controller
             $calendarEvent->description($description);
         }
 
-        if (!empty($event->venue_name)) {
+        // Venue fields live on the event row for booking-derived events, but
+        // fall back to the polymorphic eventable for rehearsals / legacy rows
+        // that weren't backfilled (mirrors CalendarEventFormatter).
+        $venueName    = $event->venue_name ?? ($event->eventable?->venue_name ?? null);
+        $venueAddress = $event->venue_address ?? ($event->eventable?->venue_address ?? null);
+
+        if (!empty($venueName)) {
             $calendarEvent->address(
-                $event->venue_address ? $event->venue_name . ', ' . $event->venue_address : $event->venue_name,
-                $event->venue_name,
+                $venueAddress ? $venueName . ', ' . $venueAddress : $venueName,
+                $venueName,
             );
         }
 

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -45,6 +45,7 @@ class User extends Authenticatable
     protected $hidden = [
         'password',
         'remember_token',
+        'calendar_token',
     ];
 
     /**
@@ -77,6 +78,34 @@ class User extends Authenticatable
     public function isSubOfBand($bandId): bool
     {
         return $this->bandSub->contains('id', $bandId);
+    }
+
+    /**
+     * Return this user's calendar feed token, minting one on first access.
+     *
+     * The token authenticates the unauthenticated ICS subscription URL
+     * (/calendar/{token}.ics), so it is long and random rather than guessable.
+     * Generated lazily so existing users get one only when they first open the
+     * "subscribe" screen.
+     */
+    public function getCalendarToken(): string
+    {
+        if (empty($this->calendar_token)) {
+            $this->forceFill(['calendar_token' => \Illuminate\Support\Str::random(48)])->save();
+        }
+
+        return $this->calendar_token;
+    }
+
+    /**
+     * Issue a fresh calendar token, invalidating any previously shared feed
+     * URL. Used by the "reset link" action.
+     */
+    public function regenerateCalendarToken(): string
+    {
+        $this->forceFill(['calendar_token' => \Illuminate\Support\Str::random(48)])->save();
+
+        return $this->calendar_token;
     }
 
     public function permissionsForBand($id)

--- a/composer.json
+++ b/composer.json
@@ -30,6 +30,7 @@
         "pusher/pusher-php-server": "^7.2",
         "sentry/sentry-laravel": "^4.8",
         "spatie/browsershot": "^4.0|^5.0",
+        "spatie/icalendar-generator": "^3.3",
         "spatie/laravel-activitylog": "^4.10",
         "spatie/laravel-google-calendar": "^3.8",
         "spatie/laravel-permission": "^6.23",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d6616655190a6757bb015f8209d35f9f",
+    "content-hash": "53f250f40ea625af52b04a54404c47b2",
     "packages": [
         {
             "name": "alexpechkarev/geometry-library",
@@ -7428,6 +7428,65 @@
                 }
             ],
             "time": "2026-02-18T16:10:58+00:00"
+        },
+        {
+            "name": "spatie/icalendar-generator",
+            "version": "3.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/spatie/icalendar-generator.git",
+                "reference": "6817d3f405563eca1afc9ea870077a898e11bc27"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/spatie/icalendar-generator/zipball/6817d3f405563eca1afc9ea870077a898e11bc27",
+                "reference": "6817d3f405563eca1afc9ea870077a898e11bc27",
+                "shasum": ""
+            },
+            "require": {
+                "ext-mbstring": "*",
+                "php": "^8.2"
+            },
+            "require-dev": {
+                "ext-json": "*",
+                "larapack/dd": "^1.1",
+                "nesbot/carbon": "^3.5",
+                "pestphp/pest": "^2.34 || ^3.0 || ^4.0",
+                "phpstan/phpstan": "^2.0",
+                "spatie/pest-plugin-snapshots": "^2.1"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Spatie\\IcalendarGenerator\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ruben Van Assche",
+                    "email": "ruben@spatie.be",
+                    "homepage": "https://spatie.be",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Build calendars in the iCalendar format",
+            "homepage": "https://github.com/spatie/icalendar-generator",
+            "keywords": [
+                "calendar",
+                "iCalendar",
+                "ical",
+                "ics",
+                "spatie"
+            ],
+            "support": {
+                "issues": "https://github.com/spatie/icalendar-generator/issues",
+                "source": "https://github.com/spatie/icalendar-generator/tree/3.3.0"
+            },
+            "time": "2026-03-18T09:51:41+00:00"
         },
         {
             "name": "spatie/laravel-activitylog",

--- a/database/migrations/2026_06_18_000001_add_calendar_token_to_users_table.php
+++ b/database/migrations/2026_06_18_000001_add_calendar_token_to_users_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Per-user calendar feed token. This backs the unauthenticated ICS
+     * subscription URL (/calendar/{token}.ics) that members add to Google
+     * Calendar / Apple Calendar. It is minted lazily the first time a user
+     * requests their feed URL and can be regenerated to revoke an old link,
+     * so the column is nullable. Unique + indexed because every feed request
+     * resolves the user by this token.
+     */
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->string('calendar_token', 64)->nullable()->unique()->after('remember_token');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropUnique(['calendar_token']);
+            $table->dropColumn('calendar_token');
+        });
+    }
+};

--- a/routes/api.php
+++ b/routes/api.php
@@ -99,6 +99,10 @@ Route::prefix('mobile')->group(function () {
         // Aggregating bookings across all of the user's bands (band-agnostic).
         Route::get('/me/bookings', [App\Http\Controllers\Api\Mobile\BookingsController::class, 'indexForUser'])->name('mobile.me.bookings');
 
+        // Personal calendar subscription URLs (ICS feed for Google/Apple Calendar).
+        Route::get('/me/calendar-feed', [App\Http\Controllers\Api\Mobile\CalendarFeedController::class, 'show'])->name('mobile.me.calendar-feed');
+        Route::post('/me/calendar-feed/reset', [App\Http\Controllers\Api\Mobile\CalendarFeedController::class, 'reset'])->name('mobile.me.calendar-feed.reset');
+
         // Contract audit trail (band-agnostic — keyed by PandaDoc envelope id).
         Route::get('/contracts/{contract:envelope_id}/history', [App\Http\Controllers\Api\Mobile\BookingsController::class, 'contractHistory'])->name('mobile.contracts.history');
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -41,6 +41,13 @@ Route::get('/stats', 'UserStatsController@index')
 Route::get('/contracts/{contractId}/public', [App\Http\Controllers\ContractsController::class, 'publicView'])
     ->name('contracts.public.view');
 
+// Public per-user ICS calendar feed (subscribed in Google/Apple Calendar).
+// Authenticated by the random calendar_token in the URL; no session/Sanctum.
+// The {token} may carry a trailing ".ics" so calendar clients treat it as a file.
+Route::get('/calendar/{token}', [App\Http\Controllers\CalendarFeedController::class, 'show'])
+    ->where('token', '[A-Za-z0-9]+(?:\.ics)?')
+    ->name('calendar.feed');
+
 // Include all route files
 require __DIR__ . '/account.php';
 require __DIR__ . '/auth.php';

--- a/tests/Feature/CalendarFeedTest.php
+++ b/tests/Feature/CalendarFeedTest.php
@@ -51,6 +51,24 @@ class CalendarFeedTest extends TestCase
         $this->assertStringContainsString('Saturday Night Gig', $body);
     }
 
+    public function test_feed_uses_event_venue_timezone_when_set(): void
+    {
+        Events::factory()->forBand($this->band)->create([
+            'title'          => 'Out Of Town Gig',
+            'date'           => now()->addDays(10)->toDateString(),
+            'start_time'     => '20:00',
+            'end_time'       => '23:00',
+            'venue_timezone' => 'America/New_York',
+        ]);
+
+        $token = $this->owner->getCalendarToken();
+        $body  = $this->get('/calendar/' . $token . '.ics')->assertOk()->getContent();
+
+        // The VEVENT start must be expressed in the venue's timezone, not the
+        // app default, so out-of-timezone gigs show the correct local time.
+        $this->assertStringContainsString('DTSTART;TZID=America/New_York:', $body);
+    }
+
     public function test_feed_returns_404_for_unknown_token(): void
     {
         $this->get('/calendar/this-token-does-not-exist.ics')->assertNotFound();
@@ -109,7 +127,7 @@ class CalendarFeedTest extends TestCase
         $this->assertNotEmpty($token);
 
         $response->assertJsonFragment([
-            'webcal_url' => str_replace('https://', 'webcal://', route('calendar.feed', ['token' => $token . '.ics'])),
+            'webcal_url' => preg_replace('#^https?://#', 'webcal://', route('calendar.feed', ['token' => $token . '.ics'])),
         ]);
     }
 

--- a/tests/Feature/CalendarFeedTest.php
+++ b/tests/Feature/CalendarFeedTest.php
@@ -1,0 +1,134 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Bands;
+use App\Models\Events;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Sanctum\Sanctum;
+use Tests\TestCase;
+
+class CalendarFeedTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private Bands $band;
+    private User $owner;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->artisan('db:seed', ['--class' => 'ApiPermissionsSeeder']);
+        // Provides the global "sub" role used by UserEventsService entitlement.
+        $this->artisan('db:seed', ['--class' => 'SubRolesPermissionsSeeder']);
+        // The sub role is global (team_id 0), matching UserEventsService.
+        setPermissionsTeamId(0);
+
+        $this->band = Bands::factory()->create();
+        $this->owner = User::factory()->create();
+        $this->band->owners()->create(['user_id' => $this->owner->id]);
+    }
+
+    public function test_feed_resolves_user_by_token_and_returns_ics(): void
+    {
+        Events::factory()->forBand($this->band)->create([
+            'title' => 'Saturday Night Gig',
+            'date'  => now()->addDays(7)->toDateString(),
+        ]);
+
+        $token = $this->owner->getCalendarToken();
+
+        $response = $this->get('/calendar/' . $token . '.ics');
+
+        $response->assertOk();
+        $response->assertHeader('Content-Type', 'text/calendar; charset=utf-8');
+
+        $body = $response->getContent();
+        $this->assertStringContainsString('BEGIN:VCALENDAR', $body);
+        $this->assertStringContainsString('END:VCALENDAR', $body);
+        $this->assertStringContainsString('Saturday Night Gig', $body);
+    }
+
+    public function test_feed_returns_404_for_unknown_token(): void
+    {
+        $this->get('/calendar/this-token-does-not-exist.ics')->assertNotFound();
+    }
+
+    public function test_feed_omits_financial_fields(): void
+    {
+        Events::factory()->forBand($this->band)->create([
+            'title' => 'High Roller Wedding',
+            'date'  => now()->addDays(3)->toDateString(),
+            'price' => '5000.00',
+            'notes' => 'Standard prep notes',
+        ]);
+
+        $token = $this->owner->getCalendarToken();
+        $body  = $this->get('/calendar/' . $token . '.ics')->assertOk()->getContent();
+
+        // The member-facing feed must never leak pricing/financial data.
+        $this->assertStringNotContainsStringIgnoringCase('price', $body);
+        $this->assertStringNotContainsStringIgnoringCase('deposit', $body);
+        $this->assertStringNotContainsString('5000', $body);
+        $this->assertStringNotContainsString('$', $body);
+    }
+
+    public function test_sub_only_user_sees_only_assigned_events(): void
+    {
+        // An event for the band the sub is NOT a member of.
+        Events::factory()->forBand($this->band)->create([
+            'title' => 'Members Only Show',
+            'date'  => now()->addDays(5)->toDateString(),
+        ]);
+
+        // A user who is only a sub (no ownership/membership) and is not invited
+        // to anything should get an empty (but valid) calendar.
+        $sub = User::factory()->create();
+        $sub->assignRole('sub');
+
+        $token = $sub->getCalendarToken();
+        $body  = $this->get('/calendar/' . $token . '.ics')->assertOk()->getContent();
+
+        $this->assertStringContainsString('BEGIN:VCALENDAR', $body);
+        $this->assertStringNotContainsString('Members Only Show', $body);
+        $this->assertStringNotContainsString('BEGIN:VEVENT', $body);
+    }
+
+    public function test_mobile_endpoint_returns_subscription_urls(): void
+    {
+        Sanctum::actingAs($this->owner);
+
+        $response = $this->getJson('/api/mobile/me/calendar-feed');
+
+        $response->assertOk();
+        $response->assertJsonStructure(['url', 'webcal_url', 'google_subscribe_url']);
+
+        $token = $this->owner->fresh()->calendar_token;
+        $this->assertNotEmpty($token);
+
+        $response->assertJsonFragment([
+            'webcal_url' => str_replace('https://', 'webcal://', route('calendar.feed', ['token' => $token . '.ics'])),
+        ]);
+    }
+
+    public function test_mobile_reset_rotates_token(): void
+    {
+        $original = $this->owner->getCalendarToken();
+
+        Sanctum::actingAs($this->owner);
+
+        $this->postJson('/api/mobile/me/calendar-feed/reset')->assertOk();
+
+        $this->assertNotEquals($original, $this->owner->fresh()->calendar_token);
+
+        // The old feed URL must stop working once rotated.
+        $this->get('/calendar/' . $original . '.ics')->assertNotFound();
+    }
+
+    public function test_mobile_endpoint_requires_authentication(): void
+    {
+        $this->getJson('/api/mobile/me/calendar-feed')->assertUnauthorized();
+    }
+}


### PR DESCRIPTION
## Summary

Lets a mobile member subscribe their personal Google/Apple Calendar to the band events they're entitled to see. The feed reuses the existing `UserEventsService` (the single source of truth for "which events does this user see"), so it can never diverge from the in-app dashboard. It emits **member-appropriate fields only** — title, time, venue, member-safe description — and **never** price/deposit/contract data.

## Changes

- **Migration**: nullable, unique, indexed `calendar_token` on `users`, minted lazily on first feed request. `User::getCalendarToken()` / `regenerateCalendarToken()`.
- **Public feed**: `GET /calendar/{token}.ics` → `CalendarFeedController`. Unauthenticated by design (calendar clients poll it with no session) — the long random token in the URL is the credential. Resolves the user, reuses `UserEventsService` entitlement, builds timezone-aware VEVENTs over a −30d…+12mo window. Reuses the model's existing Google Calendar helpers so it stays consistent with the server-side group sync.
- **Mobile endpoints** (Sanctum): `GET /api/mobile/me/calendar-feed` → `{url, webcal_url, google_subscribe_url}`; `POST /api/mobile/me/calendar-feed/reset` rotates the token to revoke a shared link.
- Adds `spatie/icalendar-generator`.

## Tests

`tests/Feature/CalendarFeedTest.php` — 7 passing:
- token resolution + valid ICS structure
- 404 on unknown token
- **no financial leakage** (asserts `price`/`deposit`/`$`/amounts absent)
- sub-only user sees only assigned events (empty but valid calendar otherwise)
- mobile endpoint returns subscription URLs
- reset rotates token and revokes the old link
- mobile endpoint requires auth

## Notes

- The mobile app is the consumer of these endpoints (companion PR in TTS-App).
- `google_subscribe_url` embeds a `webcal://` URL in `cid`, which Google resolves against the public HTTPS host — test it from staging, not a localhost/self-signed dev build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)