### PR TITLE
Add mobile user stats endpoint

### DIFF
--- a/app/Http/Controllers/Api/Mobile/StatsController.php
+++ b/app/Http/Controllers/Api/Mobile/StatsController.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace App\Http\Controllers\Api\Mobile;
+
+use App\Http\Controllers\Controller;
+use App\Models\User;
+use App\Services\UserStatsService;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\DB;
+
+class StatsController extends Controller
+{
+    /**
+     * Return the authenticated user's personal stats (earnings, travel, and
+     * performance locations) across all their bands — the same data the web
+     * /stats page shows, computed by the shared UserStatsService so the two
+     * can't diverge.
+     *
+     * Performance locations are additionally enriched with cached lat/lng from
+     * venue_cache so the mobile map can render markers without a per-address
+     * client-side geocoding round-trip.
+     */
+    public function index(Request $request): JsonResponse
+    {
+        /** @var User $user */
+        $user = $request->user();
+
+        // UserStatsService is constructed with the user, but several of the
+        // queries it reaches into (and helpers it shares) read Auth::user();
+        // bind the guard like the other mobile controllers do.
+        Auth::setUser($user);
+
+        $stats = (new UserStatsService($user))->getUserStats();
+
+        $stats['locations'] = $this->attachCoordinates($stats['locations'] ?? []);
+
+        return response()->json(['stats' => $stats]);
+    }
+
+    /**
+     * Attach cached lat/lng to each location by matching its address against
+     * venue_cache (the same table the web geocoding endpoint writes). The web
+     * geocodes the "venue_name, address" full_address string, so that's what
+     * venue_cache.address holds — match on full_address first, then fall back
+     * to the bare venue_address. Uncached locations keep null coordinates and
+     * simply won't get a map marker — they still appear in the locations list.
+     *
+     * @param  array<int, array<string, mixed>>  $locations
+     * @return array<int, array<string, mixed>>
+     */
+    private function attachCoordinates(array $locations): array
+    {
+        if (empty($locations)) {
+            return $locations;
+        }
+
+        $addresses = collect($locations)
+            ->flatMap(fn (array $l) => [$l['full_address'] ?? null, $l['venue_address'] ?? null])
+            ->filter()
+            ->unique()
+            ->values()
+            ->all();
+
+        if (empty($addresses)) {
+            return $locations;
+        }
+
+        $coords = DB::table('venue_cache')
+            ->whereIn('address', $addresses)
+            ->whereNotNull('latitude')
+            ->whereNotNull('longitude')
+            ->get(['address', 'latitude', 'longitude'])
+            ->keyBy('address');
+
+        return collect($locations)->map(function (array $location) use ($coords) {
+            $match = $coords->get($location['full_address'] ?? '')
+                ?? $coords->get($location['venue_address'] ?? '');
+
+            $location['lat'] = $match ? (float) $match->latitude : null;
+            $location['lng'] = $match ? (float) $match->longitude : null;
+
+            return $location;
+        })->all();
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -103,6 +103,9 @@ Route::prefix('mobile')->group(function () {
         Route::get('/me/calendar-feed', [App\Http\Controllers\Api\Mobile\CalendarFeedController::class, 'show'])->name('mobile.me.calendar-feed');
         Route::post('/me/calendar-feed/reset', [App\Http\Controllers\Api\Mobile\CalendarFeedController::class, 'reset'])->name('mobile.me.calendar-feed.reset');
 
+        // Personal stats (earnings, travel, performance locations) across all bands.
+        Route::get('/me/stats', [App\Http\Controllers\Api\Mobile\StatsController::class, 'index'])->name('mobile.me.stats');
+
         // Contract audit trail (band-agnostic — keyed by PandaDoc envelope id).
         Route::get('/contracts/{contract:envelope_id}/history', [App\Http\Controllers\Api\Mobile\BookingsController::class, 'contractHistory'])->name('mobile.contracts.history');
 

--- a/tests/Feature/MobileStatsTest.php
+++ b/tests/Feature/MobileStatsTest.php
@@ -1,0 +1,128 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Bands;
+use App\Models\Bookings;
+use App\Models\Events;
+use App\Models\User;
+use Carbon\Carbon;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Laravel\Sanctum\Sanctum;
+use Tests\TestCase;
+
+class MobileStatsTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private User $user;
+    private Bands $band;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->user = User::factory()->create();
+        $this->band = Bands::factory()->create();
+
+        // Member + a second member so the equal-split payout gives a known share.
+        DB::table('band_members')->insert([
+            ['user_id' => $this->user->id, 'band_id' => $this->band->id, 'created_at' => Carbon::now()->subYears(2), 'updated_at' => Carbon::now()->subYears(2)],
+            ['user_id' => User::factory()->create()->id, 'band_id' => $this->band->id, 'created_at' => Carbon::now()->subYears(2), 'updated_at' => Carbon::now()->subYears(2)],
+        ]);
+    }
+
+    private function seedConfirmedBookingWithVenue(string $venueName, string $venueAddress): Events
+    {
+        $booking = Bookings::factory()->create([
+            'band_id' => $this->band->id,
+            'price'   => 2000,
+            'status'  => 'confirmed',
+        ]);
+
+        return Events::factory()->create([
+            'eventable_type' => 'App\\Models\\Bookings',
+            'eventable_id'   => $booking->id,
+            // Comfortably after the 2-years-ago join date and not in the future,
+            // so it counts toward both earnings and locations/travel.
+            'date'           => Carbon::now()->subYear(),
+            'venue_name'     => $venueName,
+            'venue_address'  => $venueAddress,
+        ]);
+    }
+
+    public function test_endpoint_requires_authentication(): void
+    {
+        $this->getJson('/api/mobile/me/stats')->assertUnauthorized();
+    }
+
+    public function test_endpoint_returns_payment_travel_and_location_blocks(): void
+    {
+        $this->seedConfirmedBookingWithVenue('The Ruins', '123 Main St, Lafayette, LA 70508, USA');
+
+        Sanctum::actingAs($this->user);
+
+        $response = $this->getJson('/api/mobile/me/stats');
+
+        $response->assertOk();
+        $response->assertJsonStructure([
+            'stats' => [
+                'payments' => ['total_earnings', 'booking_count', 'by_year', 'by_band', 'bookings_by_year'],
+                'travel'   => ['total_miles', 'total_minutes', 'total_hours', 'event_count', 'by_year'],
+                'locations',
+            ],
+        ]);
+
+        // Equal split of a $2000 booking between two members → $1000 share.
+        $response->assertJsonPath('stats.payments.booking_count', 1);
+        $response->assertJsonPath('stats.payments.total_earnings', '1000.00');
+    }
+
+    public function test_locations_are_enriched_with_cached_coordinates(): void
+    {
+        $venueName    = 'Board of Trade Place';
+        $venueAddress = 'Board of Trade Pl, New Orleans, LA 70130, USA';
+        $fullAddress  = $venueName . ', ' . $venueAddress;
+
+        $this->seedConfirmedBookingWithVenue($venueName, $venueAddress);
+
+        // venue_cache keys on the full_address string (as the web geocoder writes it).
+        DB::table('venue_cache')->insert([
+            'address'      => $fullAddress,
+            'latitude'     => 29.9504042,
+            'longitude'    => -90.0673988,
+            'usage_count'  => 1,
+            'last_used_at' => now(),
+            'created_at'   => now(),
+            'updated_at'   => now(),
+        ]);
+
+        Sanctum::actingAs($this->user);
+
+        $locations = $this->getJson('/api/mobile/me/stats')
+            ->assertOk()
+            ->json('stats.locations');
+
+        $match = collect($locations)->firstWhere('full_address', $fullAddress);
+        $this->assertNotNull($match);
+        $this->assertEquals(29.9504042, $match['lat']);
+        $this->assertEquals(-90.0673988, $match['lng']);
+    }
+
+    public function test_uncached_locations_have_null_coordinates(): void
+    {
+        $this->seedConfirmedBookingWithVenue('Unknown Hall', '999 Nowhere Rd, Erath, LA 70533, USA');
+
+        Sanctum::actingAs($this->user);
+
+        $locations = $this->getJson('/api/mobile/me/stats')
+            ->assertOk()
+            ->json('stats.locations');
+
+        $match = collect($locations)->firstWhere('venue_name', 'Unknown Hall');
+        $this->assertNotNull($match);
+        $this->assertNull($match['lat']);
+        $this->assertNull($match['lng']);
+    }
+}


### PR DESCRIPTION
## Summary

Backend for the mobile "My Stats" feature (companion app PR: eddimull/TTS-App). Exposes the same personal stats the web `/stats` page shows.

- **`GET /api/mobile/me/stats`** (Sanctum) → `Api/Mobile/StatsController`. Binds the user to the guard and reuses the shared `UserStatsService($user)->getUserStats()`, so mobile and web can't diverge. Returns `payments` (earnings totals, by-year, by-band, bookings-by-year), `travel` (miles/hours/event totals + by-year), and `locations`.
- **Coordinate enrichment**: performance locations are matched against `venue_cache` (on the `full_address` string the web geocoder writes) and get `lat`/`lng` attached, so the mobile map renders markers without per-address client-side geocoding. Uncached locations keep null coords and still appear in the list. On real data, 67/80 locations resolved from cache.

## Tests

`tests/Feature/MobileStatsTest.php` — 4 passing: auth required; payment/travel/location blocks present with a known equal-split share; locations enriched from `venue_cache`; uncached locations null.

🤖 Generated with [Claude Code](https://claude.com/claude-code)