### PR TITLE
Split user stats earnings into earned vs. upcoming

### DIFF
--- a/app/Services/UserStatsService.php
+++ b/app/Services/UserStatsService.php
@@ -59,6 +59,12 @@ class UserStatsService
         $yearEarnings = [];
         $bookingsByYear = [];
         $totalBookingCount = 0;
+        $upcomingEarnings = 0;
+        $upcomingBookingCount = 0;
+
+        // A gig is "earned" once its date has passed. Gigs dated today or in the
+        // future (and bookings with no events yet, so no date) are still upcoming.
+        $today = Carbon::now()->startOfDay();
 
         // Get all bands the user owns or is a member of
         // Eager load counts and payout configs to avoid N+1 queries in payout calculations
@@ -112,21 +118,34 @@ class UserStatsService
                 ->get();
 
             $bandTotal = 0;
+            $bandBookingCount = 0;
 
             foreach ($bookings as $booking) {
                 // Calculate user's share of this booking
                 $userShare = $this->calculateUserShareFromBooking($band, $booking, $userBandStatus[$band->id] ?? []);
 
                 if ($userShare > 0) {
-                    $bandTotal += $userShare;
-                    $totalBookingCount++;
+                    // A gig counts as earned only once its date has passed. Future
+                    // gigs (and bookings with no date yet) are projected, not earned.
+                    $isUpcoming = $booking->start_date === null
+                        || $booking->start_date->gte($today);
 
-                    // Add to year earnings
                     $year = $booking->start_date?->year;
-                    if (!isset($yearEarnings[$year])) {
-                        $yearEarnings[$year] = 0;
+
+                    if ($isUpcoming) {
+                        $upcomingEarnings += $userShare;
+                        $upcomingBookingCount++;
+                    } else {
+                        $bandTotal += $userShare;
+                        $bandBookingCount++;
+                        $totalBookingCount++;
+
+                        // Add to year earnings (earned gigs only)
+                        if (!isset($yearEarnings[$year])) {
+                            $yearEarnings[$year] = 0;
+                        }
+                        $yearEarnings[$year] += $userShare;
                     }
-                    $yearEarnings[$year] += $userShare;
 
                     // Add detailed booking info to year grouping
                     if (!isset($bookingsByYear[$year])) {
@@ -143,6 +162,7 @@ class UserStatsService
                         'venue_address' => $primary?->venue_address ?? '',
                         'date' => $booking->start_date?->format('Y-m-d'),
                         'status' => $booking->status,
+                        'is_upcoming' => $isUpcoming,
                         'total_price' => number_format(floatval($booking->price), 2, '.', ''),
                         'user_share' => number_format($userShare / 100, 2, '.', ''),
                     ];
@@ -154,7 +174,8 @@ class UserStatsService
                     'band_id' => $band->id,
                     'band_name' => $band->name,
                     'total' => number_format($bandTotal / 100, 2, '.', ''),
-                    'booking_count' => $bookings->count(),
+                    // Earned bookings only, to stay consistent with the earned total above.
+                    'booking_count' => $bandBookingCount,
                 ];
             }
         }
@@ -174,18 +195,28 @@ class UserStatsService
         // Format bookings by year - sort years descending and bookings by date descending
         $formattedBookingsByYear = collect($bookingsByYear)
             ->map(function ($bookings, $year) {
+                $earned = collect($bookings)->where('is_upcoming', false);
+                $upcoming = collect($bookings)->where('is_upcoming', true);
+
                 return [
                     'year' => $year,
                     'bookings' => collect($bookings)->sortByDesc('date')->values()->toArray(),
+                    // Earned share only, to match the headline total.
                     'year_total' => number_format(
-                        collect($bookings)->sum(function ($b) {
-                            return floatval($b['user_share']);
-                        }),
+                        $earned->sum(fn ($b) => floatval($b['user_share'])),
                         2,
                         '.',
                         ''
                     ),
-                    'booking_count' => count($bookings),
+                    // Projected share from gigs in this year that haven't happened yet.
+                    'upcoming_total' => number_format(
+                        $upcoming->sum(fn ($b) => floatval($b['user_share'])),
+                        2,
+                        '.',
+                        ''
+                    ),
+                    'booking_count' => $earned->count(),
+                    'upcoming_booking_count' => $upcoming->count(),
                 ];
             })
             ->sortByDesc('year')
@@ -196,9 +227,12 @@ class UserStatsService
 
         return [
             'total_earnings' => number_format($totalEarnings / 100, 2, '.', ''),
+            // Projected earnings from gigs that haven't happened yet.
+            'upcoming_earnings' => number_format($upcomingEarnings / 100, 2, '.', ''),
             'by_year' => $byYear,
             'by_band' => array_values($bandEarnings),
             'booking_count' => $totalBookingCount,
+            'upcoming_booking_count' => $upcomingBookingCount,
             'bookings_by_year' => $formattedBookingsByYear,
         ];
     }

--- a/app/Services/UserStatsService.php
+++ b/app/Services/UserStatsService.php
@@ -152,7 +152,11 @@ class UserStatsService
                         $bookingsByYear[$year] = [];
                     }
 
-                    $primary = $booking->events()->orderBy('date')->orderBy('id')->first();
+                    // Use the eager-loaded events collection (sorted in memory)
+                    // rather than re-querying, which would be an N+1 per booking.
+                    $primary = $booking->events
+                        ->sortBy([['date', 'asc'], ['id', 'asc']])
+                        ->first();
                     $bookingsByYear[$year][] = [
                         'id' => $booking->id,
                         'booking_name' => $booking->name,

--- a/resources/js/Pages/UserStats/Index.vue
+++ b/resources/js/Pages/UserStats/Index.vue
@@ -744,7 +744,11 @@ export default {
       if (!date) {
         return 'TBD'
       }
-      return new Date(date).toLocaleDateString('en-US', {
+      // Parse the Y-m-d string as a LOCAL date. `new Date('2025-06-15')` is
+      // interpreted as UTC midnight, which renders as the previous day for
+      // users west of UTC; building from explicit parts avoids that shift.
+      const [year, month, day] = date.split('-').map(Number)
+      return new Date(year, month - 1, day).toLocaleDateString('en-US', {
         year: 'numeric',
         month: 'short',
         day: 'numeric'

--- a/resources/js/Pages/UserStats/Index.vue
+++ b/resources/js/Pages/UserStats/Index.vue
@@ -61,7 +61,14 @@
                       ${{ formatNumber(stats.payments.total_earnings) }}
                     </dd>
                     <dd class="text-xs text-gray-500 dark:text-gray-400">
-                      {{ stats.payments.booking_count }} bookings
+                      {{ stats.payments.booking_count }} {{ stats.payments.booking_count === 1 ? 'gig' : 'gigs' }} played
+                    </dd>
+                    <dd
+                      v-if="stats.payments.upcoming_booking_count > 0"
+                      class="mt-1 text-xs text-gray-500 dark:text-gray-400"
+                    >
+                      <span class="font-medium text-gray-700 dark:text-gray-300">${{ formatNumber(stats.payments.upcoming_earnings) }}</span>
+                      upcoming ({{ stats.payments.upcoming_booking_count }} {{ stats.payments.upcoming_booking_count === 1 ? 'gig' : 'gigs' }})
                     </dd>
                   </dl>
                 </div>
@@ -214,12 +221,21 @@
                       {{ yearData.year }}
                     </span>
                     <span class="text-sm text-gray-500 dark:text-gray-400">
-                      {{ yearData.booking_count }} {{ yearData.booking_count === 1 ? 'booking' : 'bookings' }}
+                      {{ yearData.booking_count }} {{ yearData.booking_count === 1 ? 'gig' : 'gigs' }} played
+                      <template v-if="yearData.upcoming_booking_count > 0">
+                        · {{ yearData.upcoming_booking_count }} upcoming
+                      </template>
                     </span>
                   </div>
                   <div class="text-right">
                     <div class="text-lg font-semibold text-green-600 dark:text-green-400">
                       ${{ formatNumber(yearData.year_total) }}
+                    </div>
+                    <div
+                      v-if="yearData.upcoming_booking_count > 0"
+                      class="text-xs text-gray-500 dark:text-gray-400"
+                    >
+                      +${{ formatNumber(yearData.upcoming_total) }} upcoming
                     </div>
                   </div>
                 </button>
@@ -240,7 +256,13 @@
                       :sortable="true"
                     >
                       <template #body="slotProps">
-                        {{ formatDate(slotProps.data.date) }}
+                        <div>{{ formatDate(slotProps.data.date) }}</div>
+                        <span
+                          v-if="slotProps.data.is_upcoming"
+                          class="inline-block mt-0.5 px-1.5 py-0.5 rounded text-[10px] font-medium bg-amber-100 text-amber-800 dark:bg-amber-900 dark:text-amber-200"
+                        >
+                          Upcoming
+                        </span>
                       </template>
                     </Column>
                     <Column

--- a/resources/js/Pages/UserStats/Index.vue
+++ b/resources/js/Pages/UserStats/Index.vue
@@ -535,7 +535,7 @@
 
         <!-- Empty State -->
         <div
-          v-if="stats.payments.booking_count === 0 && stats.travel.event_count === 0"
+          v-if="stats.payments.booking_count === 0 && stats.payments.upcoming_booking_count === 0 && stats.travel.event_count === 0"
           class="bg-white dark:bg-gray-800 overflow-hidden shadow-sm rounded-lg"
         >
           <div class="p-12 text-center">

--- a/resources/js/Pages/UserStats/Index.vue
+++ b/resources/js/Pages/UserStats/Index.vue
@@ -218,7 +218,7 @@
                       />
                     </svg>
                     <span class="text-lg font-semibold text-gray-900 dark:text-white">
-                      {{ yearData.year }}
+                      {{ yearData.year || 'TBD' }}
                     </span>
                     <span class="text-sm text-gray-500 dark:text-gray-400">
                       {{ yearData.booking_count }} {{ yearData.booking_count === 1 ? 'gig' : 'gigs' }} played
@@ -370,7 +370,7 @@
                       />
                     </svg>
                     <span class="text-lg font-semibold text-gray-900 dark:text-white">
-                      {{ yearData.year }}
+                      {{ yearData.year || 'TBD' }}
                     </span>
                     <span class="text-sm text-gray-500 dark:text-gray-400">
                       {{ yearData.event_count }} {{ yearData.event_count === 1 ? 'event' : 'events' }}
@@ -739,6 +739,11 @@ export default {
     },
 
     formatDate(date) {
+      // Bookings with no events yet have a null date (treated as upcoming);
+      // show a placeholder rather than the epoch (Jan 1, 1970).
+      if (!date) {
+        return 'TBD'
+      }
       return new Date(date).toLocaleDateString('en-US', {
         year: 'numeric',
         month: 'short',

--- a/tests/Feature/MobileStatsTest.php
+++ b/tests/Feature/MobileStatsTest.php
@@ -68,7 +68,7 @@ class MobileStatsTest extends TestCase
         $response->assertOk();
         $response->assertJsonStructure([
             'stats' => [
-                'payments' => ['total_earnings', 'booking_count', 'by_year', 'by_band', 'bookings_by_year'],
+                'payments' => ['total_earnings', 'booking_count', 'upcoming_earnings', 'upcoming_booking_count', 'by_year', 'by_band', 'bookings_by_year'],
                 'travel'   => ['total_miles', 'total_minutes', 'total_hours', 'event_count', 'by_year'],
                 'locations',
             ],
@@ -77,6 +77,35 @@ class MobileStatsTest extends TestCase
         // Equal split of a $2000 booking between two members → $1000 share.
         $response->assertJsonPath('stats.payments.booking_count', 1);
         $response->assertJsonPath('stats.payments.total_earnings', '1000.00');
+    }
+
+    public function test_future_gigs_are_reported_as_upcoming_not_earned(): void
+    {
+        // Past gig → earned.
+        $this->seedConfirmedBookingWithVenue('The Ruins', '123 Main St, Lafayette, LA 70508, USA');
+
+        // Future gig → upcoming, not counted toward earnings.
+        $futureBooking = Bookings::factory()->create([
+            'band_id' => $this->band->id,
+            'price'   => 4000,
+            'status'  => 'confirmed',
+        ]);
+        Events::factory()->create([
+            'eventable_type' => 'App\\Models\\Bookings',
+            'eventable_id'   => $futureBooking->id,
+            'date'           => Carbon::now()->addMonth(),
+        ]);
+
+        Sanctum::actingAs($this->user);
+
+        $response = $this->getJson('/api/mobile/me/stats')->assertOk();
+
+        // Earned: only the past $2000 gig, split two ways → $1000.
+        $response->assertJsonPath('stats.payments.total_earnings', '1000.00');
+        $response->assertJsonPath('stats.payments.booking_count', 1);
+        // Upcoming: the future $4000 gig, split two ways → $2000.
+        $response->assertJsonPath('stats.payments.upcoming_earnings', '2000.00');
+        $response->assertJsonPath('stats.payments.upcoming_booking_count', 1);
     }
 
     public function test_locations_are_enriched_with_cached_coordinates(): void

--- a/tests/Feature/MobileStatsTest.php
+++ b/tests/Feature/MobileStatsTest.php
@@ -23,6 +23,10 @@ class MobileStatsTest extends TestCase
     {
         parent::setUp();
 
+        // Pin the clock so the earned-vs-upcoming split (gig date vs "today") is
+        // deterministic regardless of when/where the suite runs.
+        Carbon::setTestNow(Carbon::create(2025, 6, 15, 12, 0, 0));
+
         $this->user = User::factory()->create();
         $this->band = Bands::factory()->create();
 
@@ -31,6 +35,13 @@ class MobileStatsTest extends TestCase
             ['user_id' => $this->user->id, 'band_id' => $this->band->id, 'created_at' => Carbon::now()->subYears(2), 'updated_at' => Carbon::now()->subYears(2)],
             ['user_id' => User::factory()->create()->id, 'band_id' => $this->band->id, 'created_at' => Carbon::now()->subYears(2), 'updated_at' => Carbon::now()->subYears(2)],
         ]);
+    }
+
+    protected function tearDown(): void
+    {
+        Carbon::setTestNow();
+
+        parent::tearDown();
     }
 
     private function seedConfirmedBookingWithVenue(string $venueName, string $venueAddress): Events

--- a/tests/Unit/Services/UserStatsServiceTest.php
+++ b/tests/Unit/Services/UserStatsServiceTest.php
@@ -242,12 +242,18 @@ class UserStatsServiceTest extends TestCase
             'status' => 'confirmed',
         ]);
 
-        // Create booking AFTER join date (should count)
-        Bookings::factory()->create([
+        // Create booking AFTER join date (should count). Give it a past event date
+        // so it lands in earned earnings rather than upcoming.
+        $afterBooking = Bookings::factory()->create([
             'band_id' => $this->band->id,
             'price' => 2000,
             'created_at' => $joinDate->copy()->addDays(10),
             'status' => 'confirmed',
+        ]);
+        Events::factory()->create([
+            'eventable_type' => 'App\\Models\\Bookings',
+            'eventable_id' => $afterBooking->id,
+            'date' => Carbon::now()->subDays(5),
         ]);
 
         $service = new UserStatsService($this->user);
@@ -269,17 +275,28 @@ class UserStatsServiceTest extends TestCase
             'updated_at' => $joinDate,
         ]);
 
-        // Create bookings with different statuses
-        Bookings::factory()->create([
+        // Create bookings with different statuses. Give the countable ones a past
+        // event date so they land in earned earnings rather than upcoming.
+        $confirmed = Bookings::factory()->create([
             'band_id' => $this->band->id,
             'price' => 1000,
             'status' => 'confirmed',
         ]);
+        Events::factory()->create([
+            'eventable_type' => 'App\\Models\\Bookings',
+            'eventable_id' => $confirmed->id,
+            'date' => Carbon::now()->subDays(5),
+        ]);
 
-        Bookings::factory()->create([
+        $pending = Bookings::factory()->create([
             'band_id' => $this->band->id,
             'price' => 1000,
             'status' => 'pending',
+        ]);
+        Events::factory()->create([
+            'eventable_type' => 'App\\Models\\Bookings',
+            'eventable_id' => $pending->id,
+            'date' => Carbon::now()->subDays(5),
         ]);
 
         Bookings::factory()->create([
@@ -375,17 +392,28 @@ class UserStatsServiceTest extends TestCase
             'updated_at' => Carbon::now()->subYear(),
         ]);
 
-        // Create bookings for both bands
-        Bookings::factory()->create([
+        // Create bookings for both bands, each with a past event date so they
+        // count as earned rather than upcoming.
+        $booking1 = Bookings::factory()->create([
             'band_id' => $this->band->id,
             'price' => 4000, // $2000 per member (2 members)
             'status' => 'confirmed',
         ]);
+        Events::factory()->create([
+            'eventable_type' => 'App\\Models\\Bookings',
+            'eventable_id' => $booking1->id,
+            'date' => Carbon::now()->subDays(5),
+        ]);
 
-        Bookings::factory()->create([
+        $booking2 = Bookings::factory()->create([
             'band_id' => $band2->id,
             'price' => 3000, // $3000 (only member)
             'status' => 'confirmed',
+        ]);
+        Events::factory()->create([
+            'eventable_type' => 'App\\Models\\Bookings',
+            'eventable_id' => $booking2->id,
+            'date' => Carbon::now()->subDays(5),
         ]);
 
         $service = new UserStatsService($this->user);
@@ -559,5 +587,105 @@ class UserStatsServiceTest extends TestCase
         // Future events should not be counted in travel stats
         $this->assertEquals(0, $stats['travel']['total_miles']);
         $this->assertEquals(0, $stats['travel']['total_minutes']);
+    }
+
+
+    public function test_it_separates_earned_from_upcoming_earnings()
+    {
+        DB::table('band_members')->insert([
+            'user_id' => $this->user->id,
+            'band_id' => $this->band->id,
+            'created_at' => Carbon::now()->subYears(2),
+            'updated_at' => Carbon::now()->subYears(2),
+        ]);
+
+        // Past gig -> earned
+        $pastBooking = Bookings::factory()->create([
+            'band_id' => $this->band->id,
+            'price' => 1000,
+            'status' => 'confirmed',
+        ]);
+        Events::factory()->create([
+            'eventable_type' => 'App\\Models\\Bookings',
+            'eventable_id' => $pastBooking->id,
+            'date' => Carbon::now()->subDays(10),
+        ]);
+
+        // Future gig -> upcoming
+        $futureBooking = Bookings::factory()->create([
+            'band_id' => $this->band->id,
+            'price' => 3000,
+            'status' => 'confirmed',
+        ]);
+        Events::factory()->create([
+            'eventable_type' => 'App\\Models\\Bookings',
+            'eventable_id' => $futureBooking->id,
+            'date' => Carbon::now()->addDays(10),
+        ]);
+
+        $service = new UserStatsService($this->user);
+        $stats = $service->getUserStats();
+
+        // Only the sole member, so the user keeps the full price of each gig.
+        $this->assertEquals('1000.00', $stats['payments']['total_earnings']);
+        $this->assertEquals(1, $stats['payments']['booking_count']);
+        $this->assertEquals('3000.00', $stats['payments']['upcoming_earnings']);
+        $this->assertEquals(1, $stats['payments']['upcoming_booking_count']);
+    }
+
+
+    public function test_a_gig_dated_today_counts_as_upcoming()
+    {
+        DB::table('band_members')->insert([
+            'user_id' => $this->user->id,
+            'band_id' => $this->band->id,
+            'created_at' => Carbon::now()->subYear(),
+            'updated_at' => Carbon::now()->subYear(),
+        ]);
+
+        $booking = Bookings::factory()->create([
+            'band_id' => $this->band->id,
+            'price' => 2000,
+            'status' => 'confirmed',
+        ]);
+        Events::factory()->create([
+            'eventable_type' => 'App\\Models\\Bookings',
+            'eventable_id' => $booking->id,
+            'date' => Carbon::now(), // today
+        ]);
+
+        $service = new UserStatsService($this->user);
+        $stats = $service->getUserStats();
+
+        $this->assertEquals('0.00', $stats['payments']['total_earnings']);
+        $this->assertEquals(0, $stats['payments']['booking_count']);
+        $this->assertEquals('2000.00', $stats['payments']['upcoming_earnings']);
+        $this->assertEquals(1, $stats['payments']['upcoming_booking_count']);
+    }
+
+
+    public function test_a_booking_with_no_events_counts_as_upcoming()
+    {
+        DB::table('band_members')->insert([
+            'user_id' => $this->user->id,
+            'band_id' => $this->band->id,
+            'created_at' => Carbon::now()->subYear(),
+            'updated_at' => Carbon::now()->subYear(),
+        ]);
+
+        // No events attached -> null gig date -> treated as upcoming.
+        Bookings::factory()->create([
+            'band_id' => $this->band->id,
+            'price' => 1500,
+            'status' => 'confirmed',
+        ]);
+
+        $service = new UserStatsService($this->user);
+        $stats = $service->getUserStats();
+
+        $this->assertEquals('0.00', $stats['payments']['total_earnings']);
+        $this->assertEquals(0, $stats['payments']['booking_count']);
+        $this->assertEquals('1500.00', $stats['payments']['upcoming_earnings']);
+        $this->assertEquals(1, $stats['payments']['upcoming_booking_count']);
     }
 }

--- a/tests/Unit/Services/UserStatsServiceTest.php
+++ b/tests/Unit/Services/UserStatsServiceTest.php
@@ -26,8 +26,21 @@ class UserStatsServiceTest extends TestCase
     {
         parent::setUp();
 
+        // Pin the clock so earned-vs-upcoming classification (which compares gig
+        // dates against "today") is deterministic and never flips when the suite
+        // runs across midnight or in a different timezone. Mid-day, mid-month,
+        // mid-year keeps all relative date math clear of any boundary.
+        Carbon::setTestNow(Carbon::create(2025, 6, 15, 12, 0, 0));
+
         $this->user = User::factory()->create();
         $this->band = Bands::factory()->create();
+    }
+
+    protected function tearDown(): void
+    {
+        Carbon::setTestNow();
+
+        parent::tearDown();
     }
 
     public function test_it_calculates_user_join_date_from_band_owner_pivot()


### PR DESCRIPTION
## Problem

User stats (web `/stats` and the mobile `/api/mobile/me/stats` endpoint) summed **every** confirmed/pending booking into a user's revenue, regardless of whether the gig had actually happened. Future bookings inflated the earnings figure, so the number didn't reflect what a user had actually earned.

## Change

Classify each booking by its gig date in the shared `UserStatsService`:

- A gig counts as **earned** only once its date has passed (`start_date < today`).
- Gigs dated **today**, **future** gigs, and bookings with **no events yet** (null date) are reported separately as **upcoming**.

`total_earnings` / `booking_count` / `by_year` / `by_band` now reflect **earned gigs only**, preserving their existing meaning so nothing downstream breaks. New fields are additive:

- top level: `upcoming_earnings`, `upcoming_booking_count`
- per year: `upcoming_total`, `upcoming_booking_count`
- per booking row: `is_upcoming`

Because `UserStatsService` feeds both the web page and the mobile endpoint (which passes `getUserStats()` straight through), both surfaces get the split from this one change. The web `/stats` page is updated to show the upcoming figure and badge upcoming rows. The companion mobile UI lives in the TTS-App repo.

## Tests

- `UserStatsServiceTest` — added coverage for the earned/upcoming split, today-counts-as-upcoming, and null-date-counts-as-upcoming. Updated three existing tests that had implicitly relied on the count-everything behavior (now attach past-dated events).
- `MobileStatsTest` — asserts the new fields appear in the endpoint response and that a future gig reports as `upcoming_earnings`, not `total_earnings`.

All 21 tests pass (72 assertions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)