### PR TITLE
Expose contact email/phone on mobile members + subs endpoints

### DIFF
--- a/app/Http/Controllers/Api/Mobile/BandSettingsController.php
+++ b/app/Http/Controllers/Api/Mobile/BandSettingsController.php
@@ -71,6 +71,7 @@ class BandSettingsController extends Controller
             return [
                 'id'          => $user->id,
                 'name'        => $user->name,
+                'email'       => $user->email,
                 'is_owner'    => $isOwner,
                 'permissions' => $perms,
             ];

--- a/app/Http/Controllers/Api/Mobile/BandSubsController.php
+++ b/app/Http/Controllers/Api/Mobile/BandSubsController.php
@@ -40,6 +40,7 @@ class BandSubsController extends Controller
                 'user_id' => $sub->user_id,
                 'name' => $sub->user->name,
                 'email' => $sub->user->email,
+                'phone' => null,
                 'band_role_id' => null,
                 'role_name' => null,
             ])
@@ -57,6 +58,7 @@ class BandSubsController extends Controller
                 'user_id' => $inv->user_id,
                 'name' => $inv->display_name,
                 'email' => $inv->display_email,
+                'phone' => $inv->display_phone,
                 'band_role_id' => $inv->band_role_id,
                 'role_name' => $inv->role_name,
             ])

--- a/app/Models/BandSubInvitation.php
+++ b/app/Models/BandSubInvitation.php
@@ -92,7 +92,7 @@ class BandSubInvitation extends Model
      */
     public function getDisplayPhoneAttribute(): ?string
     {
-        if ($this->user_id && $this->user) {
+        if ($this->user_id !== null) {
             return null;
         }
         return $this->phone;

--- a/app/Models/BandSubInvitation.php
+++ b/app/Models/BandSubInvitation.php
@@ -87,6 +87,18 @@ class BandSubInvitation extends Model
     }
 
     /**
+     * Get display phone. Registered users have no phone on file (the users
+     * table has no phone column), so only email-only invitations carry one.
+     */
+    public function getDisplayPhoneAttribute(): ?string
+    {
+        if ($this->user_id && $this->user) {
+            return null;
+        }
+        return $this->phone;
+    }
+
+    /**
      * Get role/instrument name
      */
     public function getRoleNameAttribute(): ?string

--- a/tests/Feature/Api/Mobile/BandMembersMobileTest.php
+++ b/tests/Feature/Api/Mobile/BandMembersMobileTest.php
@@ -6,7 +6,9 @@ use App\Models\BandMembers;
 use App\Models\BandOwners;
 use App\Models\Bands;
 use App\Models\User;
+use App\Services\GoogleCalendarService;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Mockery;
 use Tests\TestCase;
 
 /**
@@ -29,6 +31,11 @@ class BandMembersMobileTest extends TestCase
 
         $this->artisan('db:seed', ['--class' => 'SubRolesPermissionsSeeder']);
         \setPermissionsTeamId(0);
+
+        // BandSettingsController injects BandMemberRemovalService which requires
+        // GoogleCalendarService. Mock it so CI doesn't need the credentials file.
+        $mock = Mockery::mock(GoogleCalendarService::class);
+        $this->app->instance(GoogleCalendarService::class, $mock);
 
         $this->owner = User::factory()->create([
             'name' => 'Owner Person',

--- a/tests/Feature/Api/Mobile/BandMembersMobileTest.php
+++ b/tests/Feature/Api/Mobile/BandMembersMobileTest.php
@@ -27,6 +27,7 @@ class BandMembersMobileTest extends TestCase
     {
         parent::setUp();
 
+        $this->artisan('db:seed', ['--class' => 'SubRolesPermissionsSeeder']);
         \setPermissionsTeamId(0);
 
         $this->owner = User::factory()->create([

--- a/tests/Feature/Api/Mobile/BandMembersMobileTest.php
+++ b/tests/Feature/Api/Mobile/BandMembersMobileTest.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Tests\Feature\Api\Mobile;
+
+use App\Models\BandMembers;
+use App\Models\BandOwners;
+use App\Models\Bands;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+/**
+ * Covers the mobile band members listing under /api/mobile/bands/{band}/members
+ * (BandSettingsController@members), specifically that each member carries an
+ * email so the mobile app can surface email/message/copy contact actions.
+ */
+class BandMembersMobileTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected User $owner;
+    protected User $member;
+    protected Bands $band;
+    protected string $ownerToken;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        \setPermissionsTeamId(0);
+
+        $this->owner = User::factory()->create([
+            'name' => 'Owner Person',
+            'email' => 'owner@example.com',
+        ]);
+        $this->member = User::factory()->create([
+            'name' => 'Member Person',
+            'email' => 'member@example.com',
+        ]);
+
+        $this->band = Bands::factory()->create();
+
+        BandOwners::create(['band_id' => $this->band->id, 'user_id' => $this->owner->id]);
+        BandMembers::create(['band_id' => $this->band->id, 'user_id' => $this->member->id]);
+
+        $this->ownerToken = $this->owner->createToken('test-device')->plainTextToken;
+    }
+
+    private function asOwner(): array
+    {
+        return [
+            'Authorization' => "Bearer {$this->ownerToken}",
+            'X-Band-ID' => $this->band->id,
+            'Accept' => 'application/json',
+        ];
+    }
+
+    public function test_members_listing_includes_email(): void
+    {
+        $response = $this->withHeaders($this->asOwner())
+            ->getJson("/api/mobile/bands/{$this->band->id}/members");
+
+        $response->assertOk()
+            ->assertJsonFragment(['name' => 'Owner Person', 'email' => 'owner@example.com', 'is_owner' => true])
+            ->assertJsonFragment(['name' => 'Member Person', 'email' => 'member@example.com', 'is_owner' => false]);
+    }
+}

--- a/tests/Feature/Api/Mobile/BandSubsMobileTest.php
+++ b/tests/Feature/Api/Mobile/BandSubsMobileTest.php
@@ -84,6 +84,7 @@ class BandSubsMobileTest extends TestCase
             'band_id' => $this->band->id,
             'email' => 'pending@example.com',
             'name' => 'Pending Sub',
+            'phone' => '555-987-6543',
             'pending' => true,
         ]);
 
@@ -92,8 +93,10 @@ class BandSubsMobileTest extends TestCase
 
         $response->assertOk()
             ->assertJsonCount(2, 'subs')
-            ->assertJsonFragment(['status' => 'active', 'email' => 'active@example.com'])
-            ->assertJsonFragment(['status' => 'pending', 'email' => 'pending@example.com']);
+            // Registered users have no phone on file → null.
+            ->assertJsonFragment(['status' => 'active', 'email' => 'active@example.com', 'phone' => null])
+            // Email-only invitations carry the phone captured at invite time.
+            ->assertJsonFragment(['status' => 'pending', 'email' => 'pending@example.com', 'phone' => '555-987-6543']);
     }
 
     public function test_member_cannot_list_subs(): void


### PR DESCRIPTION
## Summary

The mobile app's shared contact detail screen now offers email, phone, **Send Message** (SMS), and copy-to-clipboard actions. This PR fills the backend gaps so those actions actually have data to act on for **members** and **subs**.

- `mobile.bands.members` (`BandSettingsController@members`) now returns each user's `email`.
- `mobile.bands.subs` (`BandSubsController@index`) now returns `phone`.

## Data note

The `users` table has **no phone column** — registered users (band members, active subs) have an email but never a phone. Only **pending email-only sub invitations** carry a phone (captured at invite time). So:

- Active subs → `phone: null`.
- Pending invitations → `phone` from the invitation, via a new `BandSubInvitation::display_phone` accessor (returns null for registered-user invites, the stored phone otherwise).

## Tests

- New `BandMembersMobileTest` — members listing includes email.
- Extended `BandSubsMobileTest` — active sub `phone => null`, pending invitation `phone` present.
- `php artisan test` for both: **10 passed (33 assertions)**.

## Companion

Mobile (TTS-App) PR consumes these fields. Backend should land first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)