### PR TITLE
Fix: include sub-only users in payment stats

### DIFF
--- a/app/Services/UserStatsService.php
+++ b/app/Services/UserStatsService.php
@@ -233,11 +233,25 @@ class UserStatsService
             return null; // null = no restriction
         }
 
-        return DB::table('event_subs')
+        // Mirror UserEventsService::getSubEvents: union accepted event_subs
+        // invitations with event_members rows where roster_member_id is NULL
+        // (direct sub assignment without an invitation flow).
+        $fromInvitations = DB::table('event_subs')
             ->where('user_id', $this->user->id)
             ->where('band_id', $bandId)
+            ->where('pending', false)
             ->pluck('event_id')
-            ->toArray();
+            ->all();
+
+        $fromEventMembers = DB::table('event_members')
+            ->where('user_id', $this->user->id)
+            ->where('band_id', $bandId)
+            ->whereNull('roster_member_id')
+            ->whereNull('deleted_at')
+            ->pluck('event_id')
+            ->all();
+
+        return array_values(array_unique(array_merge($fromInvitations, $fromEventMembers)));
     }
 
     /**

--- a/app/Services/UserStatsService.php
+++ b/app/Services/UserStatsService.php
@@ -62,27 +62,26 @@ class UserStatsService
 
         // Get all bands the user owns, is a member of, or subs for — subs can
         // have a payout share when the band's flow config includes them.
-        // Eager load counts and payout configs to avoid N+1 queries.
-        $allBands = $this->getUserBands()
-            ->each(fn ($b) => $b->loadMissing(['activePayoutConfig']))
-            ->each(fn ($b) => $b->loadCount(['owners', 'members']));
-
-        // Track owner/member status separately — needed by the old (non-flow)
-        // equal-split payout path in calculateUserShareFromBooking.
-        $ownerBandIds  = DB::table('band_owners')->where('user_id', $this->user->id)->pluck('band_id')->flip();
-        $memberBandIds = DB::table('band_members')->where('user_id', $this->user->id)->pluck('band_id')->flip();
+        // Use collection-level load methods so both calls batch across all bands
+        // rather than firing per-model queries (N+1).
+        $allBands = $this->getUserBands();
+        $allBands->loadMissing(['activePayoutConfig']);
+        $allBands->loadCount(['owners', 'members']);
 
         // Pre-calculate user's membership status and join dates for each band to avoid N+1 queries
         $userBandStatus = [];
         $bandJoinDates = [];
 
         $bandIds = $allBands->pluck('id')->toArray();
+        // getBandPivots queries band_owners, band_members, and band_subs and
+        // caches the result — derive owner/member presence from the same rows
+        // rather than issuing two more pluck queries.
         $pivots = $this->getBandPivots($bandIds);
 
         foreach ($allBands as $band) {
             $userBandStatus[$band->id] = [
-                'is_owner'  => $ownerBandIds->has($band->id),
-                'is_member' => $memberBandIds->has($band->id),
+                'is_owner'  => $pivots['owners']->has($band->id),
+                'is_member' => $pivots['members']->has($band->id),
             ];
             $bandJoinDates[$band->id] = $this->getUserJoinDateFromPivots(
                 $pivots['owners']->get($band->id),

--- a/app/Services/UserStatsService.php
+++ b/app/Services/UserStatsService.php
@@ -60,19 +60,18 @@ class UserStatsService
         $bookingsByYear = [];
         $totalBookingCount = 0;
 
-        // Get all bands the user owns or is a member of
-        // Eager load counts and payout configs to avoid N+1 queries in payout calculations
-        $ownedBands = $this->user->bandOwner()
-            ->withCount(['owners', 'members'])
-            ->with('activePayoutConfig')
-            ->get();
-        $memberBands = $this->user->bandMember()
-            ->withCount(['owners', 'members'])
-            ->with('activePayoutConfig')
-            ->get();
+        // Get all bands the user owns, is a member of, or subs for — subs can
+        // have a payout share when the band's flow config includes them.
+        // Eager load counts and payout configs to avoid N+1 queries.
+        $allBands = $this->getUserBands()
+            ->each(fn ($b) => $b->loadMissing(['activePayoutConfig']))
+            ->each(fn ($b) => $b->loadCount(['owners', 'members']));
 
-        $allBands = $ownedBands->merge($memberBands)->unique('id');
-        
+        // Track owner/member status separately — needed by the old (non-flow)
+        // equal-split payout path in calculateUserShareFromBooking.
+        $ownerBandIds  = DB::table('band_owners')->where('user_id', $this->user->id)->pluck('band_id')->flip();
+        $memberBandIds = DB::table('band_members')->where('user_id', $this->user->id)->pluck('band_id')->flip();
+
         // Pre-calculate user's membership status and join dates for each band to avoid N+1 queries
         $userBandStatus = [];
         $bandJoinDates = [];
@@ -82,8 +81,8 @@ class UserStatsService
 
         foreach ($allBands as $band) {
             $userBandStatus[$band->id] = [
-                'is_owner' => $ownedBands->contains('id', $band->id),
-                'is_member' => $memberBands->contains('id', $band->id),
+                'is_owner'  => $ownerBandIds->has($band->id),
+                'is_member' => $memberBandIds->has($band->id),
             ];
             $bandJoinDates[$band->id] = $this->getUserJoinDateFromPivots(
                 $pivots['owners']->get($band->id),
@@ -98,18 +97,27 @@ class UserStatsService
 
             // Get all bookings for this band after the user joined.
             // date column was removed from bookings (moved to events); use created_at as a proxy.
-            // Eager load payouts to avoid N+1 queries
-            $bookings = \App\Models\Bookings::where('band_id', $band->id)
+            // Eager load payouts to avoid N+1 queries.
+            // For sub-only users, scope to bookings that contain at least one
+            // event they were assigned to (mirrors getTravelStats scoping).
+            $allowedEventIds = $this->getAllowedEventIds($band->id);
+
+            $bookingsQuery = \App\Models\Bookings::where('band_id', $band->id)
                 ->where('created_at', '>=', $joinDate)
-                ->whereIn('status', ['confirmed', 'pending']) // Only count confirmed and pending bookings
+                ->whereIn('status', ['confirmed', 'pending'])
                 ->with([
                     'payout.adjustments',
                     'events.eventMembers.bandRole',
                     'events.eventMembers.rosterMember.bandRole',
                     'events.eventMembers.rosterMember.user',
                 ])
-                ->orderBy('created_at', 'desc')
-                ->get();
+                ->orderBy('created_at', 'desc');
+
+            if ($allowedEventIds !== null) {
+                $bookingsQuery->whereHas('events', fn ($q) => $q->whereIn('events.id', $allowedEventIds));
+            }
+
+            $bookings = $bookingsQuery->get();
 
             $bandTotal = 0;
 

--- a/tests/Unit/Services/UserStatsServiceTest.php
+++ b/tests/Unit/Services/UserStatsServiceTest.php
@@ -560,6 +560,127 @@ class UserStatsServiceTest extends TestCase
             'Sub user should receive their flow-configured payout share');
     }
 
+    public function test_sub_user_assigned_via_event_members_sees_payment_stats()
+    {
+        // Sub added directly to event_members (no event_subs row) — the path
+        // UserEventsService treats as valid via roster_member_id NULL.
+        DB::table('band_subs')->insert([
+            'user_id'    => $this->user->id,
+            'band_id'    => $this->band->id,
+            'created_at' => Carbon::now()->subMonths(6),
+            'updated_at' => Carbon::now()->subMonths(6),
+        ]);
+
+        $booking = Bookings::factory()->create([
+            'band_id' => $this->band->id,
+            'price'   => 1000,
+            'status'  => 'confirmed',
+        ]);
+        $event = Events::factory()->create([
+            'eventable_type' => 'App\\Models\\Bookings',
+            'eventable_id'   => $booking->id,
+            'date'           => Carbon::now()->subDays(10),
+        ]);
+
+        // Direct event_members assignment — no event_subs row at all
+        \App\Models\EventMember::factory()->create([
+            'event_id'          => $event->id,
+            'band_id'           => $this->band->id,
+            'user_id'           => $this->user->id,
+            'roster_member_id'  => null,
+            'attendance_status' => 'attended',
+        ]);
+
+        $flowDiagram = [
+            'nodes' => [
+                ['id' => 'income-1', 'type' => 'income', 'data' => []],
+                [
+                    'id'   => 'group-1',
+                    'type' => 'payoutGroup',
+                    'data' => [
+                        'sourceType'              => 'roster',
+                        'distributionMode'        => 'equal_split',
+                        'incomingAllocationType'  => 'remainder',
+                        'incomingAllocationValue' => 0,
+                        'rosterConfig'            => ['memberTypeFilter' => 'all'],
+                    ],
+                ],
+            ],
+            'edges' => [['id' => 'e1', 'source' => 'income-1', 'target' => 'group-1']],
+        ];
+
+        BandPayoutConfig::create([
+            'band_id'      => $this->band->id,
+            'name'         => 'Sub-inclusive config',
+            'is_active'    => true,
+            'flow_diagram' => $flowDiagram,
+        ]);
+
+        $service = new UserStatsService($this->user);
+        $stats   = $service->getUserStats();
+
+        $this->assertEquals(1, $stats['payments']['booking_count'],
+            'Sub assigned via event_members (no event_subs) should have bookings counted');
+        $this->assertEquals('1000.00', $stats['payments']['total_earnings'],
+            'Sub assigned via event_members should receive their payout share');
+    }
+
+    public function test_sub_user_with_pending_invite_excluded_from_payment_stats()
+    {
+        // Pending event_subs invitation (pending=true) — should not count.
+        DB::table('band_subs')->insert([
+            'user_id'    => $this->user->id,
+            'band_id'    => $this->band->id,
+            'created_at' => Carbon::now()->subMonths(6),
+            'updated_at' => Carbon::now()->subMonths(6),
+        ]);
+
+        $booking = Bookings::factory()->create([
+            'band_id' => $this->band->id,
+            'price'   => 1000,
+            'status'  => 'confirmed',
+        ]);
+        $event = Events::factory()->create([
+            'eventable_type' => 'App\\Models\\Bookings',
+            'eventable_id'   => $booking->id,
+            'date'           => Carbon::now()->subDays(10),
+        ]);
+
+        DB::table('event_subs')->insert([
+            'event_id'       => $event->id,
+            'band_id'        => $this->band->id,
+            'user_id'        => $this->user->id,
+            'invitation_key' => \Illuminate\Support\Str::uuid(),
+            'pending'        => true,  // not accepted
+            'accepted_at'    => null,
+            'created_at'     => Carbon::now()->subDays(5),
+            'updated_at'     => Carbon::now()->subDays(5),
+        ]);
+
+        BandPayoutConfig::create([
+            'band_id'      => $this->band->id,
+            'name'         => 'Sub-inclusive config',
+            'is_active'    => true,
+            'flow_diagram' => [
+                'nodes' => [
+                    ['id' => 'income-1', 'type' => 'income', 'data' => []],
+                    ['id' => 'group-1', 'type' => 'payoutGroup', 'data' => [
+                        'sourceType' => 'roster', 'distributionMode' => 'equal_split',
+                        'incomingAllocationType' => 'remainder', 'incomingAllocationValue' => 0,
+                        'rosterConfig' => ['memberTypeFilter' => 'all'],
+                    ]],
+                ],
+                'edges' => [['id' => 'e1', 'source' => 'income-1', 'target' => 'group-1']],
+            ],
+        ]);
+
+        $service = new UserStatsService($this->user);
+        $stats   = $service->getUserStats();
+
+        $this->assertEquals(0, $stats['payments']['booking_count'],
+            'Pending (unaccepted) sub invite should not appear in payment stats');
+    }
+
     public function test_sub_user_sees_zero_payment_stats_when_excluded_from_flow()
     {
         // Same setup but flow config uses memberTypeFilter = 'members_only'.

--- a/tests/Unit/Services/UserStatsServiceTest.php
+++ b/tests/Unit/Services/UserStatsServiceTest.php
@@ -458,7 +458,184 @@ class UserStatsServiceTest extends TestCase
         $this->assertEquals(0, $userShare);
     }
 
-    
+    public function test_sub_user_sees_payment_stats_for_assigned_bookings()
+    {
+        // Wes scenario: sub-only on a band, assigned to one event in a booking,
+        // flow config gives subs an equal split of the distributable amount.
+        $owner = User::factory()->create();
+        DB::table('band_owners')->insert([
+            'user_id' => $owner->id,
+            'band_id' => $this->band->id,
+            'created_at' => Carbon::now()->subYear(),
+            'updated_at' => Carbon::now()->subYear(),
+        ]);
+
+        // Register Wes as a band sub only (not owner or member)
+        DB::table('band_subs')->insert([
+            'user_id' => $this->user->id,
+            'band_id' => $this->band->id,
+            'created_at' => Carbon::now()->subMonths(6),
+            'updated_at' => Carbon::now()->subMonths(6),
+        ]);
+
+        // Create a confirmed booking with one past event
+        $booking = Bookings::factory()->create([
+            'band_id' => $this->band->id,
+            'price' => 1000,
+            'status' => 'confirmed',
+        ]);
+        $event = Events::factory()->create([
+            'eventable_type' => 'App\\Models\\Bookings',
+            'eventable_id'   => $booking->id,
+            'date'           => Carbon::now()->subDays(10),
+        ]);
+
+        // Owner also on the event
+        \App\Models\EventMember::factory()->create([
+            'event_id'          => $event->id,
+            'band_id'           => $this->band->id,
+            'user_id'           => $owner->id,
+            'roster_member_id'  => null,
+            'attendance_status' => 'attended',
+        ]);
+
+        // Record Wes as attending the event (sub with no roster member)
+        \App\Models\EventMember::factory()->create([
+            'event_id'         => $event->id,
+            'band_id'          => $this->band->id,
+            'user_id'          => $this->user->id,
+            'roster_member_id' => null,
+            'attendance_status' => 'attended',
+        ]);
+
+        // Record the event as assigned to Wes in event_subs
+        DB::table('event_subs')->insert([
+            'event_id'       => $event->id,
+            'band_id'        => $this->band->id,
+            'user_id'        => $this->user->id,
+            'invitation_key' => \Illuminate\Support\Str::uuid(),
+            'pending'        => false,
+            'accepted_at'    => Carbon::now()->subDays(15),
+            'created_at'     => Carbon::now()->subDays(15),
+            'updated_at'     => Carbon::now()->subDays(15),
+        ]);
+
+        // Flow config: no band cut, one payoutGroup node distributing to all
+        // attendees including subs (memberTypeFilter = 'all').
+        $flowDiagram = [
+            'nodes' => [
+                ['id' => 'income-1', 'type' => 'income', 'data' => []],
+                [
+                    'id'   => 'group-1',
+                    'type' => 'payoutGroup',
+                    'data' => [
+                        'sourceType'              => 'roster',
+                        'distributionMode'        => 'equal_split',
+                        'incomingAllocationType'  => 'remainder',
+                        'incomingAllocationValue' => 0,
+                        'rosterConfig'            => ['memberTypeFilter' => 'all'],
+                    ],
+                ],
+            ],
+            'edges' => [
+                ['id' => 'e1', 'source' => 'income-1', 'target' => 'group-1'],
+            ],
+        ];
+
+        BandPayoutConfig::create([
+            'band_id'      => $this->band->id,
+            'name'         => 'Sub-inclusive config',
+            'is_active'    => true,
+            'flow_diagram' => $flowDiagram,
+        ]);
+
+        $service = new UserStatsService($this->user);
+        $stats   = $service->getUserStats();
+
+        // Wes attended 1 event out of 1 in the booking; he and the owner
+        // both attended, so each gets $500.
+        $this->assertEquals(1, $stats['payments']['booking_count'],
+            'Sub user should have bookings counted in payment stats');
+        $this->assertEquals('500.00', $stats['payments']['total_earnings'],
+            'Sub user should receive their flow-configured payout share');
+    }
+
+    public function test_sub_user_sees_zero_payment_stats_when_excluded_from_flow()
+    {
+        // Same setup but flow config uses memberTypeFilter = 'members_only'.
+        DB::table('band_subs')->insert([
+            'user_id'    => $this->user->id,
+            'band_id'    => $this->band->id,
+            'created_at' => Carbon::now()->subMonths(6),
+            'updated_at' => Carbon::now()->subMonths(6),
+        ]);
+
+        $booking = Bookings::factory()->create([
+            'band_id' => $this->band->id,
+            'price'   => 1000,
+            'status'  => 'confirmed',
+        ]);
+        $event = Events::factory()->create([
+            'eventable_type' => 'App\\Models\\Bookings',
+            'eventable_id'   => $booking->id,
+            'date'           => Carbon::now()->subDays(10),
+        ]);
+
+        \App\Models\EventMember::factory()->create([
+            'event_id'          => $event->id,
+            'band_id'           => $this->band->id,
+            'user_id'           => $this->user->id,
+            'roster_member_id'  => null,
+            'attendance_status' => 'attended',
+        ]);
+
+        DB::table('event_subs')->insert([
+            'event_id'       => $event->id,
+            'band_id'        => $this->band->id,
+            'user_id'        => $this->user->id,
+            'invitation_key' => \Illuminate\Support\Str::uuid(),
+            'pending'        => false,
+            'accepted_at'    => Carbon::now()->subDays(15),
+            'created_at'     => Carbon::now()->subDays(15),
+            'updated_at'     => Carbon::now()->subDays(15),
+        ]);
+
+        $flowDiagram = [
+            'nodes' => [
+                ['id' => 'income-1', 'type' => 'income', 'data' => []],
+                [
+                    'id'   => 'group-1',
+                    'type' => 'payoutGroup',
+                    'data' => [
+                        'sourceType'              => 'roster',
+                        'distributionMode'        => 'equal_split',
+                        'incomingAllocationType'  => 'remainder',
+                        'incomingAllocationValue' => 0,
+                        'rosterConfig'            => ['memberTypeFilter' => 'members_only'],
+                    ],
+                ],
+            ],
+            'edges' => [
+                ['id' => 'e1', 'source' => 'income-1', 'target' => 'group-1'],
+            ],
+        ];
+
+        BandPayoutConfig::create([
+            'band_id'      => $this->band->id,
+            'name'         => 'Members-only config',
+            'is_active'    => true,
+            'flow_diagram' => $flowDiagram,
+        ]);
+
+        $service = new UserStatsService($this->user);
+        $stats   = $service->getUserStats();
+
+        $this->assertEquals('0.00', $stats['payments']['total_earnings'],
+            'Sub excluded from flow config should receive $0');
+        $this->assertEquals(0, $stats['payments']['booking_count']);
+    }
+
+
     public function test_it_returns_empty_stats_when_user_not_in_any_bands()
     {
         $service = new UserStatsService($this->user);


### PR DESCRIPTION
## Summary

- `getPaymentStats()` in `UserStatsService` was scoping its band loop to `bandOwner()` + `bandMember()`, completely skipping bands where the user is a **sub only**. Sub-only users saw $0 earnings and 0 booking count even when the band's flow config granted them a payout share.
- Fixed by switching to `getUserBands()` (the same source `getTravelStats` and `getEventLocations` already use), querying owner/member IDs separately for the `is_owner`/`is_member` status map that the legacy payout path needs, and scoping booking queries for sub-only users to bookings that contain at least one of their assigned events (via the existing `getAllowedEventIds` gate).

## Test plan

- [ ] Two new tests in `UserStatsServiceTest`: sub user sees correct payout share when flow config includes subs (`memberTypeFilter = all`); sub user sees $0 when excluded (`memberTypeFilter = members_only`)
- [ ] All 15 stats service tests pass: `php artisan test tests/Unit/Services/UserStatsServiceTest.php`
- [ ] Manual: log in as Wes (user 40), hit `/api/mobile/me/stats` — verify booking count and earnings are non-zero and match what the web payout tab shows for his assigned bookings