### PR TITLE
Fix: sub stats hidden by join-date gate (the actual Wes bug)

### DIFF
--- a/app/Services/UserStatsService.php
+++ b/app/Services/UserStatsService.php
@@ -100,15 +100,11 @@ class UserStatsService
             // Use cached join date
             $joinDate = $bandJoinDates[$band->id];
 
-            // Get all bookings for this band after the user joined.
-            // date column was removed from bookings (moved to events); use created_at as a proxy.
-            // Eager load payouts to avoid N+1 queries.
             // For sub-only users, scope to bookings that contain at least one
             // event they were assigned to (mirrors getTravelStats scoping).
             $allowedEventIds = $this->getAllowedEventIds($band->id);
 
             $bookingsQuery = \App\Models\Bookings::where('band_id', $band->id)
-                ->where('created_at', '>=', $joinDate)
                 ->whereIn('status', ['confirmed', 'pending'])
                 ->with([
                     'payout.adjustments',
@@ -119,7 +115,17 @@ class UserStatsService
                 ->orderBy('created_at', 'desc');
 
             if ($allowedEventIds !== null) {
+                // Sub: their per-event assignment list already defines the exact
+                // scope. The join-date gate must NOT apply — a sub has no
+                // continuous tenure, and band_subs.created_at is just when they
+                // were first invited, which can post-date bookings they were
+                // later assigned to. Gating on it silently drops those gigs.
                 $bookingsQuery->whereHas('events', fn ($q) => $q->whereIn('events.id', $allowedEventIds));
+            } else {
+                // Owner/member: credit only bookings created on or after they
+                // joined the band. created_at is a proxy since bookings no
+                // longer carry a date column (moved to events).
+                $bookingsQuery->where('created_at', '>=', $joinDate);
             }
 
             $bookings = $bookingsQuery->get();
@@ -504,11 +510,15 @@ class UserStatsService
                     $query->where('user_id', $this->user->id);
                 },
             ])
-            ->where('date', '>=', $joinDate)
             ->where('date', '<=', Carbon::now());
 
             if ($allowedEventIds !== null) {
+                // Sub: scope by their assigned events, not by join date (see
+                // getPaymentStats — band_subs.created_at can post-date the gig).
                 $bandEventsQuery->whereIn('events.id', $allowedEventIds);
+            } else {
+                // Owner/member: only events on or after they joined the band.
+                $bandEventsQuery->where('date', '>=', $joinDate);
             }
 
             $bandEvents = $bandEventsQuery->get();
@@ -658,28 +668,32 @@ class UserStatsService
                 },
             ];
 
-            // Get events from bookings for this band after join date
+            // Get events from bookings for this band. Subs are scoped by their
+            // assigned events (no join-date gate — see getPaymentStats);
+            // owners/members are gated to events on or after they joined.
             $bookingEventsQuery = Events::whereHasMorph('eventable', [\App\Models\Bookings::class], function ($query) use ($band) {
                 $query->where('band_id', $band->id);
             })
             ->with($withClause)
-            ->where('date', '>=', $joinDate)
             ->where('date', '<=', Carbon::now());
 
             if ($allowedEventIds !== null) {
                 $bookingEventsQuery->whereIn('events.id', $allowedEventIds);
+            } else {
+                $bookingEventsQuery->where('date', '>=', $joinDate);
             }
 
-            // Get events from legacy band_events for this band after join date
+            // Get events from legacy band_events for this band (same scoping rules).
             $bandEventEventsQuery = Events::whereHasMorph('eventable', [\App\Models\BandEvents::class], function ($query) use ($band) {
                 $query->where('band_id', $band->id);
             })
             ->with($withClause)
-            ->where('date', '>=', $joinDate)
             ->where('date', '<=', Carbon::now());
 
             if ($allowedEventIds !== null) {
                 $bandEventEventsQuery->whereIn('events.id', $allowedEventIds);
+            } else {
+                $bandEventEventsQuery->where('date', '>=', $joinDate);
             }
 
             $bandEvents = $bookingEventsQuery->get()->concat($bandEventEventsQuery->get())

--- a/tests/Unit/Services/UserStatsServiceTest.php
+++ b/tests/Unit/Services/UserStatsServiceTest.php
@@ -601,6 +601,112 @@ class UserStatsServiceTest extends TestCase
             'Sub user should receive their flow-configured payout share');
     }
 
+    public function test_sub_user_sees_stats_for_gig_booked_before_their_sub_pivot()
+    {
+        // THE WES BUG, real timeline: a band books a future gig long before a
+        // sub is brought in for it.
+        //   - booking created 2 years ago  (bookings.created_at)
+        //   - sub invited/accepted 1 year ago  (band_subs / event_subs)
+        //   - performance is 1 year in the future  (events.date)
+        // Subs are invited per-event, so band_subs.created_at routinely
+        // post-dates the booking by years. The join-date gate keyed payment
+        // stats off bookings.created_at >= join_date, so a booking that
+        // predates the sub pivot (2yr-old booking vs 1yr-old pivot) was
+        // silently dropped even though the gig is future and the sub is on it.
+        $owner = User::factory()->create();
+        DB::table('band_owners')->insert([
+            'user_id'    => $owner->id,
+            'band_id'    => $this->band->id,
+            'created_at' => Carbon::now()->subYears(3),
+            'updated_at' => Carbon::now()->subYears(3),
+        ]);
+
+        // Booking created 2 years ago for a gig that performs 1 year from now.
+        $booking = Bookings::factory()->create([
+            'band_id'    => $this->band->id,
+            'price'      => 1000,
+            'status'     => 'confirmed',
+            'created_at' => Carbon::now()->subYears(2),
+        ]);
+        $event = Events::factory()->create([
+            'eventable_type' => 'App\\Models\\Bookings',
+            'eventable_id'   => $booking->id,
+            'date'           => Carbon::now()->addYear(), // future performance
+        ]);
+
+        // Wes's band_subs pivot is created 1 year ago — AFTER the booking
+        // (2yr) but BEFORE the gig (next year): the exact gap that broke him.
+        DB::table('band_subs')->insert([
+            'user_id'    => $this->user->id,
+            'band_id'    => $this->band->id,
+            'created_at' => Carbon::now()->subYear(),
+            'updated_at' => Carbon::now()->subYear(),
+        ]);
+
+        \App\Models\EventMember::factory()->create([
+            'event_id'          => $event->id,
+            'band_id'           => $this->band->id,
+            'user_id'           => $owner->id,
+            'roster_member_id'  => null,
+            'attendance_status' => 'confirmed',
+        ]);
+        \App\Models\EventMember::factory()->create([
+            'event_id'          => $event->id,
+            'band_id'           => $this->band->id,
+            'user_id'           => $this->user->id,
+            'roster_member_id'  => null,
+            'attendance_status' => 'confirmed',
+        ]);
+
+        // Accepted sub assignment, dated 1 year ago (with the pivot).
+        DB::table('event_subs')->insert([
+            'event_id'       => $event->id,
+            'band_id'        => $this->band->id,
+            'user_id'        => $this->user->id,
+            'invitation_key' => \Illuminate\Support\Str::uuid(),
+            'pending'        => false,
+            'accepted_at'    => Carbon::now()->subYear(),
+            'created_at'     => Carbon::now()->subYear(),
+            'updated_at'     => Carbon::now()->subYear(),
+        ]);
+
+        BandPayoutConfig::create([
+            'band_id'      => $this->band->id,
+            'name'         => 'Sub-inclusive config',
+            'is_active'    => true,
+            'flow_diagram' => [
+                'nodes' => [
+                    ['id' => 'income-1', 'type' => 'income', 'data' => []],
+                    ['id' => 'group-1', 'type' => 'payoutGroup', 'data' => [
+                        'sourceType' => 'roster', 'distributionMode' => 'equal_split',
+                        'incomingAllocationType' => 'remainder', 'incomingAllocationValue' => 0,
+                        'rosterConfig' => ['memberTypeFilter' => 'all'],
+                    ]],
+                ],
+                'edges' => [['id' => 'e1', 'source' => 'income-1', 'target' => 'group-1']],
+            ],
+        ]);
+
+        $service = new UserStatsService($this->user);
+        $stats   = $service->getUserStats();
+
+        // The booking predates his sub pivot but he was assigned the gig —
+        // it MUST appear. The performance is in the future, so it counts as
+        // UPCOMING (projected), not earned — earned booking_count stays 0.
+        $this->assertEquals(1, $stats['payments']['upcoming_booking_count'],
+            'Sub gig whose booking predates the band_subs pivot must still appear as upcoming');
+        $this->assertEquals('500.00', $stats['payments']['upcoming_earnings'],
+            'Sub should be credited their projected share for a future gig booked before their sub pivot');
+        // Earned totals stay zero — the gig hasn't happened yet.
+        $this->assertEquals('0.00', $stats['payments']['total_earnings'],
+            'A future gig must not count as earned');
+
+        // It must NOT yet count toward travel — the performance is in the
+        // future, so no miles have been driven. (date <= now() still applies.)
+        $this->assertEquals(0, $stats['travel']['event_count'],
+            'A future gig should not count toward travel stats yet');
+    }
+
     public function test_sub_user_assigned_via_event_members_sees_payment_stats()
     {
         // Sub added directly to event_members (no event_subs row) — the path


### PR DESCRIPTION
## Summary

Follow-up to #449. That PR stopped excluding sub-only users from the band loop, but Wes — who owns/plays in his own band **and** subs for another — still saw **no stats from the subbed band**. The real culprit was the **join-date gate**, not band scoping.

### Root cause (the real timeline)

A band books a future gig long before a sub is brought in for it:

| Event | When | Column |
|-------|------|--------|
| Booking created | 2025 | `bookings.created_at` |
| Sub invited & accepted | 2026 | `band_subs.created_at`, `event_subs.created_at` |
| Performance | 2027 | `events.date` |

`getPaymentStats` gated bookings on `created_at >= the user's join date`, where a sub's join date is `band_subs.created_at`. Subs are invited **per-event**, so that pivot routinely post-dates the booking by **years**. Result: `2025 >= 2026` is false → the booking is silently dropped, even though the gig is upcoming and the sub is explicitly assigned to it. `getTravelStats` / `getEventLocations` had the same gate on `events.date`.

For owners/members the gate is correct (continuous tenure from their pivot). For a sub it's simply wrong — a sub has no tenure.

## Fix

When `getAllowedEventIds()` returns a non-null list (i.e. the user is a sub on that band), that explicit per-event allow-list **is** the authoritative scope — so skip the join-date gate entirely for subs. Owners/members keep the gate unchanged. Applied consistently across all three stat sections (payments, travel, locations).

## Test plan

- [x] Regression test mirrors the exact timeline: booking created 2 years ago, sub pivot 1 year ago, performance 1 year in the **future**.
- [x] Verified it **fails on pre-fix code** (0 bookings — Wes's symptom) and **passes with the fix** ($500 share, 1 booking).
- [x] Tightened travel assertion: a future gig counts toward payment stats (projected earnings) but **not** travel (no miles driven yet — `date <= now()` still applies).
- [x] All 18 `UserStatsServiceTest` cases pass.
- [ ] Manual: log in as Wes, hit `/api/mobile/me/stats` — confirm the subbed band's future gig and earnings now appear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)