### PR TITLE
Invalidate user mileage cache from a user-supplied move date

### DIFF
--- a/app/Http/Controllers/Api/Mobile/AuthController.php
+++ b/app/Http/Controllers/Api/Mobile/AuthController.php
@@ -9,6 +9,7 @@ use App\Models\Country;
 use App\Models\State;
 use App\Models\User;
 use App\Services\AccountDeletionService;
+use App\Services\MileageService;
 use App\Services\Mobile\TokenService;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
@@ -20,6 +21,7 @@ class AuthController extends Controller
 {
     public function __construct(
         private readonly TokenService $tokenService,
+        private readonly MileageService $mileageService,
     ) {}
 
     public function token(TokenRequest $request): JsonResponse
@@ -124,7 +126,22 @@ class AuthController extends Controller
             // Match the band-settings address fields (ZIP+4 / international).
             'zip'                 => 'nullable|string|max:20',
             'email_notifications' => 'required|boolean',
+            // Optional: when the user moved. Drives mileage-cache invalidation —
+            // only events on/after this date recompute against the new address.
+            // Omitted (or address unchanged) → defaults to today in the service.
+            'moved_at'            => 'nullable|date',
         ]);
+
+        // Snapshot the address before mutating so we can tell whether it actually
+        // changed. Only a real change invalidates mileage; touching name/email/etc.
+        // must not nuke the user's cached distances.
+        $addressBefore = [
+            $user->Address1,
+            $user->Address2,
+            $user->City,
+            $user->StateID,
+            $user->Zip,
+        ];
 
         $user->name               = $data['name'];
         $user->email              = $data['email'];
@@ -141,6 +158,19 @@ class AuthController extends Controller
         }
 
         $user->save();
+
+        $addressAfter = [
+            $user->Address1,
+            $user->Address2,
+            $user->City,
+            $user->StateID,
+            $user->Zip,
+        ];
+
+        if ($addressBefore !== $addressAfter) {
+            // moved_at defaults to today inside the service when null.
+            $this->mileageService->invalidateFromMoveDate($user, $data['moved_at'] ?? null);
+        }
 
         return response()->json(['account' => $this->tokenService->formatAccount($user)]);
     }

--- a/app/Services/MileageService.php
+++ b/app/Services/MileageService.php
@@ -3,13 +3,45 @@
 namespace App\Services;
 use App\Models\State;
 use App\Models\Bands;
+use App\Models\Events;
 use App\Models\Bookings;
+use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Auth;
 use App\Models\EventDistanceForMembers;
 
 class MileageService
 {
     protected array $stateCache = [];
+
+    /**
+     * Invalidate a user's cached mileage for events on or after a move date.
+     *
+     * When a user moves, only events from the move date onward were (or will be)
+     * driven from the new address — past events stay locked to the mileage that
+     * was correct when they happened. We delete the affected EventDistanceForMembers
+     * rows so MileageService recomputes them, against the new origin, on next view.
+     *
+     * @param  \App\Models\User|int  $user  The user (or user id) whose cache to invalidate.
+     * @param  mixed     $movedAt   Move date; anything Carbon can parse. Defaults to today.
+     * @return int  Number of cached rows invalidated.
+     */
+    public function invalidateFromMoveDate($user, $movedAt = null): int
+    {
+        $userId  = is_object($user) ? $user->id : $user;
+        $moveDay = ($movedAt ? Carbon::parse($movedAt) : Carbon::now())->toDateString();
+
+        $eventIds = Events::query()
+            ->whereDate('date', '>=', $moveDay)
+            ->pluck('id');
+
+        if ($eventIds->isEmpty()) {
+            return 0;
+        }
+
+        return EventDistanceForMembers::where('user_id', $userId)
+            ->whereIn('event_id', $eventIds)
+            ->delete();
+    }
     public function handle($events, ?Bands $band = null)
     {
         $user = Auth::user();

--- a/tests/Feature/Api/Mobile/AccountMoveMileageInvalidationTest.php
+++ b/tests/Feature/Api/Mobile/AccountMoveMileageInvalidationTest.php
@@ -1,0 +1,129 @@
+<?php
+
+namespace Tests\Feature\Api\Mobile;
+
+use App\Models\Events;
+use App\Models\User;
+use App\Models\EventDistanceForMembers;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+/**
+ * When a user moves, only their cached mileage for events on/after the move date
+ * should be invalidated — past events keep the mileage that was correct then.
+ * The move date is supplied by the user (defaulting to today) since the system
+ * stores only the current address and can't otherwise know when they moved.
+ */
+class AccountMoveMileageInvalidationTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /** Seed a cached mileage row for the given user + event date. */
+    private function seedMileage(User $user, string $date): EventDistanceForMembers
+    {
+        $event = Events::factory()->create(['date' => $date]);
+
+        return EventDistanceForMembers::create([
+            'user_id'  => $user->id,
+            'event_id' => $event->id,
+            'miles'    => 42.0,
+            'minutes'  => 50,
+        ]);
+    }
+
+    private function patchAddress(User $user, array $overrides = []): \Illuminate\Testing\TestResponse
+    {
+        $token = $user->createToken('test')->plainTextToken;
+
+        return $this->withToken($token)->patchJson('/api/mobile/account', array_merge([
+            'name'                => $user->name,
+            'email'               => $user->email,
+            'address1'            => '500 New Place',
+            'city'                => 'Baton Rouge',
+            'state_id'            => 12,
+            'zip'                 => '70802',
+            'email_notifications' => true,
+        ], $overrides));
+    }
+
+    public function test_only_events_on_or_after_move_date_are_invalidated(): void
+    {
+        $user = User::factory()->create([
+            'Address1' => '1 Old St', 'City' => 'Old Town', 'StateID' => '5', 'Zip' => '00001',
+        ]);
+
+        $before = $this->seedMileage($user, '2026-01-10'); // before move
+        $onDay  = $this->seedMileage($user, '2026-03-01'); // exactly on move date
+        $after  = $this->seedMileage($user, '2026-05-20'); // after move
+
+        $this->patchAddress($user, ['moved_at' => '2026-03-01'])->assertOk();
+
+        // Past event keeps its locked-in mileage.
+        $this->assertDatabaseHas('event_distance_for_members', ['id' => $before->id]);
+        // On/after the move date are invalidated so they recompute on next view.
+        $this->assertDatabaseMissing('event_distance_for_members', ['id' => $onDay->id]);
+        $this->assertDatabaseMissing('event_distance_for_members', ['id' => $after->id]);
+    }
+
+    public function test_move_date_defaults_to_today_when_omitted(): void
+    {
+        $user = User::factory()->create([
+            'Address1' => '1 Old St', 'City' => 'Old Town', 'StateID' => '5', 'Zip' => '00001',
+        ]);
+
+        $past   = $this->seedMileage($user, now()->subMonth()->toDateString());
+        $future = $this->seedMileage($user, now()->addMonth()->toDateString());
+
+        // No moved_at → defaults to today: only today-or-later recompute.
+        $this->patchAddress($user, ['moved_at' => null])->assertOk();
+
+        $this->assertDatabaseHas('event_distance_for_members', ['id' => $past->id]);
+        $this->assertDatabaseMissing('event_distance_for_members', ['id' => $future->id]);
+    }
+
+    public function test_unchanged_address_does_not_invalidate_any_mileage(): void
+    {
+        $user = User::factory()->create([
+            'Address1' => '500 New Place', 'Address2' => null, 'City' => 'Baton Rouge',
+            'StateID' => '12', 'Zip' => '70802',
+        ]);
+
+        $future = $this->seedMileage($user, now()->addMonth()->toDateString());
+
+        // Re-submit the SAME address (only the name differs) — mileage must survive.
+        $this->patchAddress($user, ['name' => 'Renamed Person', 'moved_at' => '2026-01-01'])
+            ->assertOk();
+
+        $this->assertDatabaseHas('event_distance_for_members', ['id' => $future->id]);
+    }
+
+    public function test_only_the_moving_users_mileage_is_invalidated(): void
+    {
+        $mover = User::factory()->create([
+            'Address1' => '1 Old St', 'City' => 'Old Town', 'StateID' => '5', 'Zip' => '00001',
+        ]);
+        $other = User::factory()->create();
+
+        $event = Events::factory()->create(['date' => now()->addMonth()->toDateString()]);
+        $moverRow = EventDistanceForMembers::create([
+            'user_id' => $mover->id, 'event_id' => $event->id, 'miles' => 10, 'minutes' => 20,
+        ]);
+        $otherRow = EventDistanceForMembers::create([
+            'user_id' => $other->id, 'event_id' => $event->id, 'miles' => 10, 'minutes' => 20,
+        ]);
+
+        $this->patchAddress($mover, ['moved_at' => now()->toDateString()])->assertOk();
+
+        $this->assertDatabaseMissing('event_distance_for_members', ['id' => $moverRow->id]);
+        $this->assertDatabaseHas('event_distance_for_members', ['id' => $otherRow->id]);
+    }
+
+    public function test_invalid_move_date_is_rejected(): void
+    {
+        $user = User::factory()->create();
+
+        $this->patchAddress($user, ['moved_at' => 'not-a-date'])
+            ->assertUnprocessable()
+            ->assertJsonValidationErrors(['moved_at']);
+    }
+}


### PR DESCRIPTION
## Problem

A sub (Wes) corrected his address after noticing his mileage was wrong, but the stats kept showing the **old** mileage. `MileageService` only recomputed a cached distance when the *event's* `updated_at` changed — it never reacted to the user's **address** (the origin) changing. So updating an address left every cached `EventDistanceForMembers` row stale.

## Why a user-supplied move date

The `users` table stores only the *current* address — no history, no move date. So the system can't know **when** a move happened, and it shouldn't blindly recompute everything: mileage for a past gig should reflect where the user lived *at the time of that event* (that's locked-in reimbursement). The fix puts the boundary in the user's hands.

## What changed

- `MileageService::invalidateFromMoveDate($user, $movedAt)` — deletes the user's cached mileage rows for events dated **on/after** the move date (defaults to today). Past events keep their original mileage; affected events recompute against the new origin on next view.
- `AuthController::updateAccount` (mobile `PATCH /api/mobile/account`) — accepts an optional `moved_at` (`nullable|date`), snapshots the address before/after the save, and **only invalidates when the address actually changed**. Editing name/email/etc. never disturbs cached mileage.

## Tests

`tests/Feature/Api/Mobile/AccountMoveMileageInvalidationTest.php` — 5 cases:
- only events on/after the move date are invalidated (boundary inclusive)
- move date defaults to today when omitted
- unchanged address is a no-op
- only the moving user's rows are touched
- invalid `moved_at` is rejected (422)

All green. The mobile-side prompt ("When did you move?", with explanation + an address autocomplete) ships separately in the Flutter repo and already targets this `moved_at` contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)