### PR TITLE
Mileage invalidation: subquery filter + clarify moved_at doc

### DIFF
--- a/app/Http/Controllers/Api/Mobile/AuthController.php
+++ b/app/Http/Controllers/Api/Mobile/AuthController.php
@@ -128,7 +128,8 @@ class AuthController extends Controller
             'email_notifications' => 'required|boolean',
             // Optional: when the user moved. Drives mileage-cache invalidation —
             // only events on/after this date recompute against the new address.
-            // Omitted (or address unchanged) → defaults to today in the service.
+            // Only consulted when the address actually changed; if omitted in
+            // that case the service defaults the boundary to today.
             'moved_at'            => 'nullable|date',
         ]);
 

--- a/app/Services/MileageService.php
+++ b/app/Services/MileageService.php
@@ -33,9 +33,11 @@ class MileageService
         // Filter by event date with a subquery so the database does the work in
         // one statement — avoids pulling every matching event id into memory and
         // building a giant WHERE IN list. A no-match simply deletes 0 rows.
+        // events.date is a DATE column, so a plain where keeps the predicate
+        // sargable (whereDate would wrap it in DATE() and defeat any index).
         return EventDistanceForMembers::where('user_id', $userId)
             ->whereIn('event_id', Events::query()
-                ->whereDate('date', '>=', $moveDay)
+                ->where('date', '>=', $moveDay)
                 ->select('id'))
             ->delete();
     }

--- a/app/Services/MileageService.php
+++ b/app/Services/MileageService.php
@@ -30,16 +30,13 @@ class MileageService
         $userId  = is_object($user) ? $user->id : $user;
         $moveDay = ($movedAt ? Carbon::parse($movedAt) : Carbon::now())->toDateString();
 
-        $eventIds = Events::query()
-            ->whereDate('date', '>=', $moveDay)
-            ->pluck('id');
-
-        if ($eventIds->isEmpty()) {
-            return 0;
-        }
-
+        // Filter by event date with a subquery so the database does the work in
+        // one statement — avoids pulling every matching event id into memory and
+        // building a giant WHERE IN list. A no-match simply deletes 0 rows.
         return EventDistanceForMembers::where('user_id', $userId)
-            ->whereIn('event_id', $eventIds)
+            ->whereIn('event_id', Events::query()
+                ->whereDate('date', '>=', $moveDay)
+                ->select('id'))
             ->delete();
     }
     public function handle($events, ?Bands $band = null)


### PR DESCRIPTION
Follow-up to #453 (which merged before these review fixes landed). Applies the two Copilot review comments from that PR.

## Changes

- **`MileageService::invalidateFromMoveDate`** — filter events by date with a subquery instead of `pluck`-ing all matching ids into memory and building a large `WHERE IN` list. MySQL does the work in one statement; a no-match deletes 0 rows, so the explicit empty-check is gone.
- **`AuthController` doc** — clarify that `moved_at` is only consulted when the address actually changed (the service isn't called otherwise), defaulting the boundary to today when omitted in that case.

No behavior change — purely a performance/clarity polish. The 5 existing tests in `AccountMoveMileageInvalidationTest` still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)