### PR TITLE
Fix: web roster endpoint overwrites non-user members

### DIFF
--- a/app/Http/Controllers/RosterMemberController.php
+++ b/app/Http/Controllers/RosterMemberController.php
@@ -14,23 +14,35 @@ class RosterMemberController extends Controller
      */
     public function store(StoreRosterMemberRequest $request, Roster $roster)
     {
-        $member = RosterMember::withTrashed()->updateOrCreate(
-            [
+        $attributes = [
+            'slot_id' => $request->slot_id,
+            'name' => $request->name,
+            'email' => $request->email,
+            'phone' => $request->phone,
+            'role' => $request->role,
+            'band_role_id' => $request->band_role_id,
+            'notes' => $request->notes,
+            'is_active' => $request->boolean('is_active', true),
+            'deleted_at' => null, // Restore if soft-deleted
+        ];
+
+        if ($request->filled('user_id')) {
+            // A real user maps to one row per roster — upsert (and restore a
+            // soft-deleted row) on (roster_id, user_id).
+            $member = RosterMember::withTrashed()->updateOrCreate(
+                ['roster_id' => $roster->id, 'user_id' => $request->user_id],
+                $attributes,
+            );
+        } else {
+            // Custom (non-user) people have no natural key, so each add is a
+            // new row. updateOrCreate on a NULL user_id would collapse them all
+            // onto one record.
+            $member = RosterMember::create([
                 'roster_id' => $roster->id,
-                'user_id' => $request->user_id,
-            ],
-            [
-                'slot_id' => $request->slot_id,
-                'name' => $request->name,
-                'email' => $request->email,
-                'phone' => $request->phone,
-                'role' => $request->role,
-                'band_role_id' => $request->band_role_id,
-                'notes' => $request->notes,
-                'is_active' => $request->boolean('is_active', true),
-                'deleted_at' => null, // Restore if soft-deleted
-            ]
-        );
+                'user_id' => null,
+                ...$attributes,
+            ]);
+        }
 
         return response()->json([
             'message' => 'Member added to roster successfully',

--- a/tests/Feature/RosterMemberManagementTest.php
+++ b/tests/Feature/RosterMemberManagementTest.php
@@ -86,6 +86,31 @@ class RosterMemberManagementTest extends TestCase
     }
 
     #[Test]
+    public function owner_can_add_multiple_non_user_members_to_roster()
+    {
+        // Non-user members have no natural key, so each add must create a
+        // distinct row — updateOrCreate on (roster_id, user_id=null) would
+        // collapse them all onto one record.
+        foreach (['Guest Bassist', 'Guest Drummer', 'Guest Vocalist'] as $name) {
+            $this->actingAs($this->owner)
+                ->postJson("/rosters/{$this->roster->id}/members", ['name' => $name])
+                ->assertStatus(201);
+        }
+
+        $this->assertEquals(3, RosterMember::where('roster_id', $this->roster->id)
+            ->whereNull('user_id')
+            ->count());
+
+        foreach (['Guest Bassist', 'Guest Drummer', 'Guest Vocalist'] as $name) {
+            $this->assertDatabaseHas('roster_members', [
+                'roster_id' => $this->roster->id,
+                'user_id' => null,
+                'name' => $name,
+            ]);
+        }
+    }
+
+    #[Test]
     public function member_cannot_add_member_to_roster()
     {
         $newUser = User::factory()->create();


### PR DESCRIPTION
## Bug

`RosterMemberController::store` (web) keyed `updateOrCreate` on `(roster_id, user_id)`. For a non-user roster member (guest/sub, `user_id` is null), every add matched the same `(roster_id, NULL)` row and overwrote it — so a roster could only ever hold **one** non-user member when added via the web UI.

Surfaced by Copilot during review of #456. The mobile controller already handles this correctly.

## Fix

Mirror the mobile `RosterMembersController::store` pattern:
- Real user → `updateOrCreate` on `(roster_id, user_id)` (and restore soft-deleted), as before.
- Non-user → `create()` a new row (no natural key, so each add is distinct).

## Test

`owner_can_add_multiple_non_user_members_to_roster` — adds 3 guests, asserts 3 distinct rows. Existing `cannot_add_same_user_to_roster_twice` still passes (real-user upsert unchanged). Full `RosterMemberManagementTest` green (19 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)