### PR TITLE
Clean up band invitations and Google Drive on member removal

### DIFF
--- a/app/Services/BandMemberRemovalService.php
+++ b/app/Services/BandMemberRemovalService.php
@@ -2,11 +2,14 @@
 
 namespace App\Services;
 
+use App\Models\BandSubInvitation;
 use App\Models\BandSubs;
 use App\Models\Bands;
 use App\Models\CalendarAccess;
 use App\Models\EventMember;
 use App\Models\EventSubs;
+use App\Models\GoogleDriveConnection;
+use App\Models\Invitations;
 use App\Models\RosterMember;
 use App\Models\User;
 use App\Models\userPermissions;
@@ -15,7 +18,10 @@ use Illuminate\Support\Facades\Log;
 
 class BandMemberRemovalService
 {
-    public function __construct(protected GoogleCalendarService $googleCalendarService) {}
+    public function __construct(
+        protected GoogleCalendarService $googleCalendarService,
+        protected GoogleDriveOAuthService $googleDriveOAuthService,
+    ) {}
 
     /**
      * Completely remove a user from a band, cleaning up all associated data.
@@ -31,6 +37,8 @@ class BandMemberRemovalService
             $this->removeFromRosters($band, $user);
             $this->removeBandSubRegistration($band, $user);
             $this->removePendingEventSubInvitations($band, $user);
+            $this->removePendingBandInvitations($band, $user);
+            $this->disconnectGoogleDrive($band, $user);
             $this->orphanMediaFiles($band, $user);
             $band->members()->where('user_id', $user->id)->delete();
             $band->owners()->where('user_id', $user->id)->delete();
@@ -140,6 +148,51 @@ class BandMemberRemovalService
             ->where('user_id', $user->id)
             ->where('pending', true)
             ->delete();
+    }
+
+    /**
+     * Remove pending band-level invitations for this user in this band.
+     * Covers both the band sub-invitation table (keyed by user_id) and the
+     * legacy member invitation table (keyed by email). Accepted band sub
+     * invitations are kept as historical records; only pending ones — which
+     * would otherwise let the removed user re-join the band — are deleted.
+     */
+    private function removePendingBandInvitations(Bands $band, User $user): void
+    {
+        BandSubInvitation::where('band_id', $band->id)
+            ->where('user_id', $user->id)
+            ->where('pending', true)
+            ->delete();
+
+        Invitations::where('band_id', $band->id)
+            ->where('email', $user->email)
+            ->where('pending', true)
+            ->delete();
+    }
+
+    /**
+     * Disconnect any Google Drive media-library connections this user set up
+     * for this band. Mirrors GoogleDriveController::disconnect: revoke the
+     * OAuth token with Google so their personal credentials can no longer
+     * sync into the band, then soft-delete the connection. Previously synced
+     * files are kept (they belong to the band, and MediaFile.drive_connection_id
+     * stays pointed at the soft-deleted row for provenance).
+     */
+    private function disconnectGoogleDrive(Bands $band, User $user): void
+    {
+        $connections = GoogleDriveConnection::where('band_id', $band->id)
+            ->where('user_id', $user->id)
+            ->get();
+
+        foreach ($connections as $connection) {
+            try {
+                $this->googleDriveOAuthService->revokeToken($connection);
+            } catch (\Exception $e) {
+                Log::warning("Could not revoke Google Drive token for user {$user->id} on connection {$connection->id}: {$e->getMessage()}");
+            }
+
+            $connection->delete();
+        }
     }
 
     /**

--- a/tests/Feature/Api/Mobile/BandMembersMobileTest.php
+++ b/tests/Feature/Api/Mobile/BandMembersMobileTest.php
@@ -5,8 +5,12 @@ namespace Tests\Feature\Api\Mobile;
 use App\Models\BandMembers;
 use App\Models\BandOwners;
 use App\Models\Bands;
+use App\Models\Events;
+use App\Models\EventMember;
+use App\Models\GoogleDriveConnection;
 use App\Models\User;
 use App\Services\GoogleCalendarService;
+use App\Services\GoogleDriveOAuthService;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Mockery;
 use Tests\TestCase;
@@ -32,10 +36,15 @@ class BandMembersMobileTest extends TestCase
         $this->artisan('db:seed', ['--class' => 'SubRolesPermissionsSeeder']);
         \setPermissionsTeamId(0);
 
-        // BandSettingsController injects BandMemberRemovalService which requires
-        // GoogleCalendarService. Mock it so CI doesn't need the credentials file.
+        // BandSettingsController injects BandMemberRemovalService, which depends on
+        // GoogleCalendarService and GoogleDriveOAuthService. Mock both so CI doesn't
+        // need real credentials or make network calls during removal.
         $mock = Mockery::mock(GoogleCalendarService::class);
         $this->app->instance(GoogleCalendarService::class, $mock);
+
+        $driveMock = Mockery::mock(GoogleDriveOAuthService::class);
+        $driveMock->shouldReceive('revokeToken')->andReturnTrue();
+        $this->app->instance(GoogleDriveOAuthService::class, $driveMock);
 
         $this->owner = User::factory()->create([
             'name' => 'Owner Person',
@@ -71,5 +80,45 @@ class BandMembersMobileTest extends TestCase
         $response->assertOk()
             ->assertJsonFragment(['name' => 'Owner Person', 'email' => 'owner@example.com', 'is_owner' => true])
             ->assertJsonFragment(['name' => 'Member Person', 'email' => 'member@example.com', 'is_owner' => false]);
+    }
+
+    public function test_remove_member_runs_full_cleanup_via_mobile_endpoint(): void
+    {
+        // Future event the member is on, and a Google Drive connection they set up —
+        // both should be cleaned when removed through the mobile endpoint.
+        $futureEvent = Events::factory()->forBand($this->band)->create(['date' => now()->addMonth()]);
+        EventMember::factory()->create([
+            'event_id' => $futureEvent->id,
+            'band_id'  => $this->band->id,
+            'user_id'  => $this->member->id,
+        ]);
+
+        $connection = GoogleDriveConnection::create([
+            'user_id'              => $this->member->id,
+            'band_id'              => $this->band->id,
+            'access_token'         => 'fake-access-token',
+            'refresh_token'        => 'fake-refresh-token',
+            'google_account_email' => $this->member->email,
+            'is_active'            => true,
+        ]);
+
+        $response = $this->withHeaders($this->asOwner())
+            ->deleteJson("/api/mobile/bands/{$this->band->id}/members/{$this->member->id}");
+
+        $response->assertNoContent();
+
+        // Member is gone from the band.
+        $this->assertDatabaseMissing('band_members', [
+            'band_id' => $this->band->id,
+            'user_id' => $this->member->id,
+        ]);
+
+        // Future event assignment removed and Drive connection disconnected.
+        $this->assertDatabaseMissing('event_members', [
+            'event_id'   => $futureEvent->id,
+            'user_id'    => $this->member->id,
+            'deleted_at' => null,
+        ]);
+        $this->assertSoftDeleted('google_drive_connections', ['id' => $connection->id]);
     }
 }

--- a/tests/Feature/BandsControllerTest.php
+++ b/tests/Feature/BandsControllerTest.php
@@ -13,6 +13,11 @@ use App\Models\RosterMember;
 use App\Models\BandCalendars;
 use App\Models\CalendarAccess;
 use App\Models\BandPaymentGroup;
+use App\Models\BandSubInvitation;
+use App\Models\Invitations;
+use App\Models\MediaFile;
+use App\Models\GoogleDriveConnection;
+use App\Services\GoogleDriveOAuthService;
 use Illuminate\Support\Str;
 use Google\Service\Calendar;
 use App\Services\CalendarService;
@@ -245,6 +250,72 @@ class BandsControllerTest extends TestCase
             'user_id'   => null,
             'is_active' => false,
         ]);
+    }
+
+    public function test_delete_member_removes_pending_band_invitations(): void
+    {
+        $this->mock(GoogleCalendarService::class)->shouldReceive('getCalendar', 'findAccess', 'revokeAccess')->andReturnNull();
+
+        // Pending band sub-invitation linked to the member (re-entry path).
+        $pendingSubInvite = BandSubInvitation::factory()->create([
+            'band_id' => $this->band->id,
+            'user_id' => $this->member->id,
+            'pending' => true,
+        ]);
+
+        // Accepted band sub-invitation should be kept as a historical record.
+        $acceptedSubInvite = BandSubInvitation::factory()->create([
+            'band_id'     => $this->band->id,
+            'user_id'     => $this->member->id,
+            'pending'     => false,
+            'accepted_at' => now()->subMonth(),
+        ]);
+
+        // Pending legacy member invitation keyed by the member's email.
+        $pendingInvite = Invitations::create([
+            'band_id'        => $this->band->id,
+            'email'          => $this->member->email,
+            'invite_type_id' => 1,
+            'pending'        => true,
+            'key'            => (string) Str::uuid(),
+        ]);
+
+        $this->actingAs($this->owner)
+            ->delete(route('bands.deleteMember', [$this->band, $this->member]));
+
+        $this->assertDatabaseMissing('band_sub_invitations', ['id' => $pendingSubInvite->id]);
+        $this->assertDatabaseHas('band_sub_invitations', ['id' => $acceptedSubInvite->id]);
+        $this->assertDatabaseMissing('invitations', ['id' => $pendingInvite->id]);
+    }
+
+    public function test_delete_member_disconnects_google_drive_but_keeps_synced_files(): void
+    {
+        $this->mock(GoogleCalendarService::class)->shouldReceive('getCalendar', 'findAccess', 'revokeAccess')->andReturnNull();
+        $this->mock(GoogleDriveOAuthService::class)->shouldReceive('revokeToken')->andReturnTrue();
+
+        $connection = GoogleDriveConnection::create([
+            'user_id'              => $this->member->id,
+            'band_id'              => $this->band->id,
+            'access_token'         => 'fake-access-token',
+            'refresh_token'        => 'fake-refresh-token',
+            'google_account_email' => $this->member->email,
+            'is_active'            => true,
+        ]);
+
+        // A file already synced into the band library through that connection.
+        $mediaFile = MediaFile::factory()->create([
+            'band_id'              => $this->band->id,
+            'drive_connection_id'  => $connection->id,
+        ]);
+
+        $this->actingAs($this->owner)
+            ->delete(route('bands.deleteMember', [$this->band, $this->member]));
+
+        // Connection is soft-deleted so it no longer syncs.
+        $this->assertSoftDeleted('google_drive_connections', ['id' => $connection->id]);
+
+        // Previously synced file is kept (it belongs to the band).
+        $this->assertDatabaseHas('media_files', ['id' => $mediaFile->id]);
     }
 
     public function test_delete_owner_performs_full_cleanup(): void


### PR DESCRIPTION
## Summary

Extends `BandMemberRemovalService::removeFromBand()` to close two future-facing access paths that survived removal. Builds on the existing removal cleanup (calendar ACL, permissions/roles, payment groups, future events, rosters, subs, media), keeping the same principle: **future access is cleaned, past-event stats (pay/mileage) are preserved.**

### New cleanup

- **Pending band invitations** — deletes pending `band_sub_invitations` (by `user_id`) and pending legacy `invitations` (by email). Both were re-entry tokens a removed user could use to re-join. Accepted invitations are kept as historical records.
- **Google Drive connections** — a `google_drive_connections` row is per user+band and holds the user's encrypted OAuth tokens; the media-library sync runs every ~6h. After removal it kept syncing the removed user's Drive into the band. Now mirrors `GoogleDriveController::disconnect`: revoke the OAuth token with Google, then soft-delete the connection. Previously synced files are kept (they belong to the band).

`GoogleDriveOAuthService` is injected into the service constructor for the token revocation.

## Tests

- `BandsControllerTest::test_delete_member_removes_pending_band_invitations`
- `BandsControllerTest::test_delete_member_disconnects_google_drive_but_keeps_synced_files`
- `BandMembersMobileTest::test_remove_member_runs_full_cleanup_via_mobile_endpoint` — end-to-end coverage for the mobile removal endpoint, which previously had none.

All removal-related suites green (web + mobile + account deletion): **17 passed (55 assertions)**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)