### PR TITLE
Fix sub added from booking lineup never joining the event

### DIFF
--- a/app/Http/Controllers/EventMemberController.php
+++ b/app/Http/Controllers/EventMemberController.php
@@ -111,6 +111,12 @@ class EventMemberController extends Controller
             }
         }
 
+        // Resolve user_id from email so the member record links to the registered
+        // user (their name resolves correctly, and re-adds restore rather than duplicate).
+        if (!$userId && !empty($validated['email'])) {
+            $userId = User::where('email', $validated['email'])->value('id');
+        }
+
         $data = [
             'band_id' => $bandId,
             'roster_member_id' => $validated['roster_member_id'] ?? null,
@@ -123,7 +129,7 @@ class EventMemberController extends Controller
             'band_role_id' => $validated['band_role_id'] ?? null,
             'attendance_status' => $validated['attendance_status'] ?? 'confirmed',
         ];
-        
+
         // If a soft-deleted record exists for this user/roster-member on this event, restore it
         $existing = EventMember::withTrashed()
             ->where('event_id', $event->id)

--- a/app/Http/Controllers/EventMemberController.php
+++ b/app/Http/Controllers/EventMemberController.php
@@ -69,6 +69,7 @@ class EventMemberController extends Controller
 
         $userId = $validated['user_id'] ?? null;
         $invitedNewUser = false;
+        $resolvedUserByEmail = false;
 
         // Handle substitute invitation if requested and email provided
         if ($validated['invite_substitute'] ?? false) {
@@ -97,6 +98,7 @@ class EventMemberController extends Controller
 
                 // If user exists, they'll be linked automatically by SubInvitationService
                 $existingUser = User::where('email', $validated['email'])->first();
+                $resolvedUserByEmail = true;
                 if ($existingUser) {
                     $userId = $existingUser->id;
                     $invitedNewUser = false;
@@ -113,7 +115,9 @@ class EventMemberController extends Controller
 
         // Resolve user_id from email so the member record links to the registered
         // user (their name resolves correctly, and re-adds restore rather than duplicate).
-        if (!$userId && !empty($validated['email'])) {
+        // Skip when the invite flow above already looked the email up, to avoid a
+        // duplicate query.
+        if (!$userId && !$resolvedUserByEmail && !empty($validated['email'])) {
             $userId = User::where('email', $validated['email'])->value('id');
         }
 

--- a/resources/js/Components/Event/Card/Footer.vue
+++ b/resources/js/Components/Event/Card/Footer.vue
@@ -25,6 +25,7 @@
       Setlist
     </a>
     <button
+      dusk="open-roster"
       :class="['flex items-center gap-1 text-sm font-medium', rosterColor]"
       @click="openRoster"
     >
@@ -128,6 +129,7 @@
                 <!-- Empty seat -->
                 <div v-else>
                   <button
+                    dusk="empty-seat-add-sub"
                     @click="openSubPicker(slot)"
                     :class="slot.isRequired ? 'text-red-500 dark:text-red-400 hover:text-red-700 dark:hover:text-red-300' : 'text-gray-400 dark:text-gray-500 hover:text-gray-600 dark:hover:text-gray-300'"
                     class="text-xs italic flex items-center gap-1"
@@ -224,6 +226,7 @@
     <ul v-else class="space-y-1 max-h-96 overflow-y-auto">
       <li v-for="option in subPickerOptions" :key="option.id">
         <button
+          dusk="sub-picker-option"
           @click="addSubToSlot(option)"
           class="w-full flex items-center gap-3 p-2 rounded-lg hover:bg-blue-50 dark:hover:bg-slate-700 text-left transition-colors"
         >

--- a/resources/js/Pages/Bookings/Components/EventEditor/RosterSection.vue
+++ b/resources/js/Pages/Bookings/Components/EventEditor/RosterSection.vue
@@ -35,6 +35,7 @@
           Event Lineup ({{ eventMembers.length }})
         </h4>
         <button
+          dusk="lineup-add-sub"
           @click="openAddMemberModal"
           class="px-3 py-1.5 bg-blue-600 text-white text-sm rounded-lg hover:bg-blue-700 transition-colors flex items-center gap-1"
         >
@@ -147,6 +148,7 @@
                       {{ slot.is_required ? 'Needs filling' : 'Empty' }}
                     </span>
                     <button
+                      dusk="empty-seat-add-sub"
                       @click="openAddMemberModal(slot)"
                       class="ml-auto px-2 py-1 text-xs bg-blue-600 text-white rounded hover:bg-blue-700 transition-colors flex items-center gap-1"
                     >
@@ -311,6 +313,7 @@
                       <button
                         v-for="(sub, index) in subs"
                         :key="sub.id"
+                        dusk="sub-list-option"
                         @click="addFromCallList(sub)"
                         class="w-full flex items-center justify-between p-2 bg-white dark:bg-slate-600 rounded hover:bg-blue-50 dark:hover:bg-slate-500 transition-colors text-left"
                       >

--- a/routes/events.php
+++ b/routes/events.php
@@ -36,8 +36,12 @@ Route::middleware(['auth', 'verified'])->group(function () {
         Route::delete('/attachments/{attachment}', [EventAttachmentsController::class, 'destroy'])->name('events.attachments.destroy');
 
         // Event members (absences and substitutes)
-        Route::get('/{event}/members', [EventMembersController::class, 'index'])->name('events.members.index');
-        Route::post('/{eventId}/members', [EventMembersController::class, 'store'])->name('events.members.store');
+        // NOTE: GET/POST /events/{event}/members are intentionally NOT defined here.
+        // They are owned by EventMemberController (the roster-aware controller) in
+        // routes/rosters.php. Defining them here too created a route collision where
+        // this file (loaded first) won the POST, and its store() early-returned on
+        // invite_substitute without ever creating the event_member — so subs invited
+        // from the booking lineup were emailed but never added. See EventMemberStoreTest.
         Route::post('/{event}/members/initialize', [EventMembersController::class, 'initializeFromBand'])->name('events.members.initialize');
         Route::patch('/{event}/members/{user}/status', [EventMembersController::class, 'updateStatus'])->name('events.members.updateStatus');
         Route::post('/{event}/members/substitutes', [EventMembersController::class, 'addSubstitute'])->name('events.members.addSubstitute');

--- a/tests/Browser/EventSubLineupTest.php
+++ b/tests/Browser/EventSubLineupTest.php
@@ -1,0 +1,295 @@
+<?php
+
+namespace Tests\Browser;
+
+use App\Models\Bands;
+use App\Models\BandRole;
+use App\Models\Bookings;
+use App\Models\Events;
+use App\Models\Roster;
+use App\Models\RosterSlot;
+use App\Models\SubstituteCallList;
+use App\Models\User;
+use Illuminate\Foundation\Testing\DatabaseMigrations;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\Hash;
+use Laravel\Dusk\Browser;
+use Spatie\Permission\Models\Role;
+use Spatie\Permission\PermissionRegistrar;
+use Tests\DuskTestCase;
+
+/**
+ * Browser coverage for adding a substitute to an event from the two UIs that
+ * both POST /events/{event}/members:
+ *
+ *   1. The booking lineup page  (RosterSection.vue — inline "Add Sub")
+ *   2. The dashboard event card (Footer.vue — "Roster" modal → empty seat)
+ *
+ * Regression guard: a duplicate route definition once made the lineup's
+ * invite_substitute=true POST hit a controller that emailed the sub but never
+ * created the event_member, so the lineup "did nothing" while the dashboard
+ * modal worked. These tests assert the sub actually lands in the lineup.
+ */
+class EventSubLineupTest extends DuskTestCase
+{
+    use DatabaseMigrations;
+
+    private User $owner;
+    private Bands $band;
+    private Bookings $booking;
+    private Events $event;
+    private Roster $roster;
+    private RosterSlot $slot;
+    private RosterSlot $bassSlot;
+    private BandRole $role;
+
+    /**
+     * Skip the parent's teardown migrate:rollback, which fails on this
+     * codebase's irreversible migration. The next test's migrate:fresh
+     * resets state cleanly. Matches EventTest.
+     */
+    protected function tearDown(): void
+    {
+        // Intentionally do nothing.
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Artisan::call('db:seed', ['--class' => 'EventTypeSeeder', '--force' => true]);
+        Artisan::call('db:seed', ['--class' => 'StatesTableSeeder', '--force' => true]);
+
+        $this->band = Bands::factory()->create(['name' => 'Sub Test Band']);
+
+        $this->owner = User::factory()->create([
+            'name' => 'Olive Owner',
+            'email' => 'sub-lineup-owner@test.local',
+            'password' => Hash::make('password'),
+        ]);
+        $this->band->owners()->create(['user_id' => $this->owner->id]);
+
+        app()[PermissionRegistrar::class]->forgetCachedPermissions();
+        $ownerRole = Role::where('name', 'band-owner')->where('guard_name', 'web')->first();
+        if ($ownerRole) {
+            setPermissionsTeamId($this->band->id);
+            $this->owner->assignRole($ownerRole);
+            setPermissionsTeamId(0);
+        }
+
+        $this->role = BandRole::firstOrCreate([
+            'band_id' => $this->band->id,
+            'name' => 'Guitar',
+        ]);
+
+        // A roster with one required, intentionally-empty slot ("Lead Guitar")
+        // so the lineup shows an empty seat to fill, plus a second slot that
+        // gets a pre-existing member — both the lineup and the dashboard roster
+        // dialog only render the slot grid once the event has >= 1 member.
+        $this->roster = Roster::factory()->create(['band_id' => $this->band->id]);
+        $this->slot = RosterSlot::create([
+            'roster_id' => $this->roster->id,
+            'band_role_id' => $this->role->id,
+            'name' => 'Lead Guitar',
+            'quantity' => 1,
+            'is_required' => true,
+        ]);
+        // Shared filler slot — each event seats one member here so the slot grid
+        // renders, leaving Lead Guitar as the single empty seat to fill. Created
+        // once (not per event) so it doesn't pollute other events' lineups.
+        $this->bassSlot = RosterSlot::create([
+            'roster_id' => $this->roster->id,
+            'band_role_id' => $this->role->id,
+            'name' => 'Bass',
+            'quantity' => 1,
+            'is_required' => false,
+        ]);
+
+        // A custom (non-roster) substitute on the band's call list — this is the
+        // path that sends invite_substitute=true and was the regressed flow.
+        SubstituteCallList::create([
+            'band_id' => $this->band->id,
+            'instrument' => 'Guitar',
+            'band_role_id' => $this->role->id,
+            'custom_name' => 'Sidney Sub',
+            'custom_email' => 'sidney-sub@test.local',
+            'custom_phone' => '555-0100',
+            'priority' => 1,
+        ]);
+
+        $this->booking = Bookings::factory()->create([
+            'band_id' => $this->band->id,
+            'name' => 'Sub Test Booking',
+        ]);
+
+        $this->event = $this->makeRosterEvent($this->booking, 'Sub Test Event');
+    }
+
+    /**
+     * Create an event on the shared roster with an empty "Lead Guitar" seat and
+     * one filler member (in a Bass slot) so the slot grid renders. The empty
+     * Lead Guitar seat is what the tests click to add a sub.
+     */
+    private function makeRosterEvent(Bookings $booking, string $title): Events
+    {
+        $event = Events::factory()->create([
+            'eventable_type' => Bookings::class,
+            'eventable_id' => $booking->id,
+            'title' => $title,
+            'roster_id' => $this->roster->id,
+            // Future date so the event appears in the dashboard's upcoming window.
+            'date' => now()->addDays(30)->toDateString(),
+        ]);
+
+        \App\Models\EventMember::create([
+            'event_id' => $event->id,
+            'band_id' => $this->band->id,
+            'slot_id' => $this->bassSlot->id,
+            'band_role_id' => $this->role->id,
+            'name' => 'Benny Bass',
+            'attendance_status' => 'confirmed',
+        ]);
+
+        return $event;
+    }
+
+    /**
+     * Drive the lineup "Add Sub" flow for $event: open the empty Lead Guitar
+     * seat, pick the call-list sub, accept the invite alert.
+     */
+    private function addCallListSubViaLineup(Browser $browser, Events $event): void
+    {
+        $url = route('Booking Lineup', [
+            'band' => $this->band->id,
+            'booking' => $event->eventable_id,
+        ], false);
+
+        $browser->visit($url)
+            ->waitForText($event->title, 10)
+            ->waitForText('Lead Guitar', 10)
+            ->waitFor('@empty-seat-add-sub', 10)
+            ->click('@empty-seat-add-sub')
+            ->waitForText('Add Sub', 5)
+            ->waitFor('@sub-list-option', 5)
+            ->click('@sub-list-option')
+            // A custom call-list sub is also invited, which raises a JS alert.
+            ->waitForDialog(5)
+            ->acceptDialog()
+            ->waitForText('Event Lineup (2)', 10)
+            ->assertSee('Sidney Sub');
+    }
+
+    /**
+     * Lineup page: clicking the inline "Add Sub" on an empty seat and picking a
+     * call-list sub adds them to the lineup (and persists the event_member).
+     */
+    public function test_adding_a_sub_from_the_booking_lineup_adds_them_to_the_event(): void
+    {
+        $url = route('Booking Lineup', ['band' => $this->band->id, 'booking' => $this->booking->id], false);
+
+        $this->browse(function (Browser $browser) use ($url) {
+            $browser->loginAs($this->owner)
+                ->visit($url)
+                ->waitForText('Sub Test Event', 10)
+                // Click the inline "Add Sub" on the empty Lead Guitar seat — the
+                // exact flow that was reported as doing nothing.
+                ->waitForText('Lead Guitar', 10)
+                ->waitFor('@empty-seat-add-sub', 10)
+                ->click('@empty-seat-add-sub')
+                ->waitForText('Add Sub', 5)
+                // Pick the call-list sub from the Sub List tab
+                ->waitFor('@sub-list-option', 5)
+                ->click('@sub-list-option')
+                // A custom call-list sub is also invited, which raises a JS alert.
+                ->waitForDialog(5)
+                ->assertDialogOpened('Invitation sent to sidney-sub@test.local! They\'ll be added to the band as a substitute once they create an account.')
+                ->acceptDialog()
+                // The modal closes and the sub now appears in the lineup count + row.
+                ->waitForText('Event Lineup (2)', 10)
+                ->assertSee('Sidney Sub');
+        });
+
+        // Added to the Lead Guitar seat, so it carries that slot_id.
+        $this->assertDatabaseHas('event_members', [
+            'event_id' => $this->event->id,
+            'name' => 'Sidney Sub',
+            'email' => 'sidney-sub@test.local',
+            'slot_id' => $this->slot->id,
+        ]);
+    }
+
+    /**
+     * Reusing the SAME call-list sub on a DIFFERENT event must add them to that
+     * event too — not just send another invitation. This is the second symptom
+     * of the route-collision bug: the sub was already invited from event A, so
+     * reusing on event B looked like it did nothing.
+     */
+    public function test_reusing_a_sub_on_a_different_event_adds_them_to_that_event(): void
+    {
+        // A second, separate booking + event sharing the band, roster and call list.
+        $secondBooking = Bookings::factory()->create([
+            'band_id' => $this->band->id,
+            'name' => 'Second Booking',
+        ]);
+        $secondEvent = $this->makeRosterEvent($secondBooking, 'Second Event');
+
+        $this->browse(function (Browser $browser) use ($secondEvent) {
+            $browser->loginAs($this->owner);
+
+            // First use: add the call-list sub to the original event.
+            $this->addCallListSubViaLineup($browser, $this->event);
+
+            // Reuse: add the same call-list sub to a different event.
+            $this->addCallListSubViaLineup($browser, $secondEvent);
+        });
+
+        // The sub lands on BOTH events.
+        $this->assertDatabaseHas('event_members', [
+            'event_id' => $this->event->id,
+            'name' => 'Sidney Sub',
+            'email' => 'sidney-sub@test.local',
+            'slot_id' => $this->slot->id,
+        ]);
+        $this->assertDatabaseHas('event_members', [
+            'event_id' => $secondEvent->id,
+            'name' => 'Sidney Sub',
+            'email' => 'sidney-sub@test.local',
+        ]);
+    }
+
+    /**
+     * Dashboard event card: opening the "Roster" modal, clicking an empty seat,
+     * and picking a sub adds them to the event lineup.
+     */
+    public function test_adding_a_sub_from_the_dashboard_roster_modal_adds_them_to_the_event(): void
+    {
+        $this->browse(function (Browser $browser) {
+            $browser->loginAs($this->owner)
+                ->visit('/dashboard')
+                ->waitFor('#event_' . $this->event->id, 10)
+                ->within('#event_' . $this->event->id, function (Browser $card) {
+                    $card->waitFor('@open-roster', 10)
+                        ->click('@open-roster');
+                })
+                // Roster dialog (teleported to body) shows the empty seat
+                ->waitForText('Lead Guitar', 10)
+                ->waitFor('@empty-seat-add-sub', 10)
+                ->click('@empty-seat-add-sub')
+                // Sub Picker dialog
+                ->waitForText('Add Sub', 5)
+                ->waitFor('@sub-picker-option', 5)
+                ->click('@sub-picker-option')
+                // Sub picker closes; the roster dialog seat now shows the sub.
+                // (Footer.addSubToSlot does not invite, so there is no alert.)
+                ->waitForText('Sidney Sub', 10)
+                ->assertSee('Sidney Sub');
+        });
+
+        $this->assertDatabaseHas('event_members', [
+            'event_id' => $this->event->id,
+            'name' => 'Sidney Sub',
+            'email' => 'sidney-sub@test.local',
+            'slot_id' => $this->slot->id,
+        ]);
+    }
+}

--- a/tests/Feature/EventMemberStoreTest.php
+++ b/tests/Feature/EventMemberStoreTest.php
@@ -216,4 +216,44 @@ class EventMemberStoreTest extends TestCase
 
         Mail::assertNothingSent();
     }
+
+    /**
+     * Inviting a substitute (invite_substitute=true with a valid email) must BOTH
+     * send the invitation AND add them to the event lineup.
+     *
+     * Regression: POST /events/{id}/members collided between two route definitions.
+     * The early-returning EventMembersController::store won the dispatch, so a sub
+     * invited from the booking lineup ("Add Sub" on an empty seat) was emailed but
+     * never created as an event_member — the lineup looked like nothing happened,
+     * while the dashboard modal (which never sends invite_substitute) worked.
+     */
+    public function test_invite_substitute_with_email_also_adds_member_to_lineup(): void
+    {
+        Mail::fake();
+
+        $response = $this->actingAs($this->owner)
+            ->postJson("/events/{$this->event->id}/members", [
+                'name' => 'Invited Sub',
+                'email' => 'invited-sub@example.com',
+                'invite_substitute' => true,
+                'attendance_status' => 'confirmed',
+                'slot_id' => $this->slot->id,
+            ]);
+
+        $response->assertStatus(201);
+
+        // The invitation record is created...
+        $this->assertDatabaseHas('event_subs', [
+            'event_id' => $this->event->id,
+        ]);
+
+        // ...AND the member is actually added to the event lineup, in the slot.
+        $this->assertDatabaseHas('event_members', [
+            'event_id' => $this->event->id,
+            'name' => 'Invited Sub',
+            'email' => 'invited-sub@example.com',
+            'slot_id' => $this->slot->id,
+            'band_role_id' => $this->role->id,
+        ]);
+    }
 }

--- a/tests/Feature/EventMemberStoreTest.php
+++ b/tests/Feature/EventMemberStoreTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Feature;
 
+use App\Mail\SubInvitation;
 use App\Models\BandOwners;
 use App\Models\BandRole;
 use App\Models\Bands;
@@ -242,10 +243,13 @@ class EventMemberStoreTest extends TestCase
 
         $response->assertStatus(201);
 
-        // The invitation record is created...
+        // The invitation record is created and the invitation email is sent...
         $this->assertDatabaseHas('event_subs', [
             'event_id' => $this->event->id,
         ]);
+        Mail::assertSent(SubInvitation::class, function (SubInvitation $mail) {
+            return $mail->hasTo('invited-sub@example.com');
+        });
 
         // ...AND the member is actually added to the event lineup, in the slot.
         $this->assertDatabaseHas('event_members', [


### PR DESCRIPTION
## Problem

Adding a substitute from the **booking lineup** page's inline "Add Sub" button sent the invitation email/notification but **never added the sub to the lineup** — it looked like nothing happened. The **dashboard roster modal** added the sub immediately. The same failure occurred when **reusing a sub on a different event**.

## Root cause

A route collision. `POST /events/{event}/members` was defined twice, with the same route name, by two controllers:

| File (load order) | Route | Controller |
|---|---|---|
| `routes/events.php` (first) | `POST /{eventId}/members` | `EventMembersController@store` |
| `routes/rosters.php` (second) | `POST /{event}/members` | `EventMemberController@store` |

`events.php` loads first, so the URL dispatched to `EventMembersController@store`, whose invite branch **early-returns after sending the invitation without creating the `event_member`**:

```php
if ($inviteSub) {
    $subInvitationService->inviteSubToEvent(...);
    return response()->json(['message' => 'Substitute invited'], 201); // never adds the member
}
```

The lineup is the only caller that sends `invite_substitute=true` (for custom call-list subs), so only it hit the early return. The dashboard modal never sets that flag, so it worked.

## Fix

- **Remove the duplicate `GET`/`POST /events/{event}/members` routes** from `routes/events.php` so both verbs resolve to the roster-aware `EventMemberController`, which creates the member **and** sends the invite. The non-colliding plural routes (`initialize`, `{user}/status`, `substitutes/*`) stay.
- **Port `email → user_id` resolution** into `EventMemberController::store` so adding/re-adding a registered user by email links and restores correctly (that logic only existed on the now-removed controller).

## Tests

- **Feature regression** (`EventMemberStoreTest`): `invite_substitute=true` with an email must both send the invite **and** create the slotted `event_member`.
- **Dusk** (`EventSubLineupTest`, none existed before): covers the lineup "Add Sub" flow, the dashboard roster modal flow, and **reusing a sub on a different event**. Adds `dusk=` selectors to `Footer.vue` and `RosterSection.vue` for stable targeting.

## Verification

- `EventMemberStoreTest`, `EventMemberSubInvitationTest`, `RosterMemberManagementTest`, `RosterFutureEventSyncEndpointsTest`, mobile `DashboardTest`/`AssignSubBandAccessTest`: all green.
- New Dusk suite: 3 tests pass (9 assertions, stable across reruns).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
