### PR TITLE
Mobile API: event media upload (chunked, client-shared)

### DIFF
--- a/app/Http/Controllers/Api/Mobile/MediaController.php
+++ b/app/Http/Controllers/Api/Mobile/MediaController.php
@@ -261,6 +261,25 @@ class MediaController extends Controller
         }
     }
 
+    // ── Chunked upload (status) ────────────────────────────────────────────────
+
+    public function uploadStatus(Bands $band, string $uploadId): JsonResponse
+    {
+        $upload = ChunkedUpload::where('upload_id', $uploadId)
+            ->where('user_id', Auth::id())
+            ->firstOrFail();
+
+        return response()->json([
+            'upload_id'       => $upload->upload_id,
+            'filename'        => $upload->filename,
+            'filesize'        => $upload->filesize,
+            'mime_type'       => $upload->mime_type,
+            'total_chunks'    => $upload->total_chunks,
+            'chunks_uploaded' => $upload->chunks_uploaded,
+            'status'          => $upload->status,
+        ]);
+    }
+
     // ── Helpers ────────────────────────────────────────────────────────────────
 
     private function formatFile(MediaFile $m, bool $detailed = false): array

--- a/app/Http/Controllers/Api/Mobile/MediaController.php
+++ b/app/Http/Controllers/Api/Mobile/MediaController.php
@@ -192,6 +192,7 @@ class MediaController extends Controller
             'event_id'     => $validated['event_id'] ?? null,
             'total_chunks' => $validated['total_chunks'],
             'user_id'      => Auth::id(),
+            'band_id'      => $band->id,
             'status'       => 'initiated',
         ]);
 
@@ -204,9 +205,7 @@ class MediaController extends Controller
     {
         $validated = $request->validated();
 
-        $upload = ChunkedUpload::where('upload_id', $uploadId)
-            ->where('user_id', Auth::id())
-            ->firstOrFail();
+        $upload = $this->findUploadForBand($uploadId, $band);
 
         if ($validated['chunk_index'] >= $upload->total_chunks) {
             return response()->json(['error' => 'Invalid chunk index.'], 400);
@@ -234,9 +233,7 @@ class MediaController extends Controller
 
     public function uploadComplete(Request $request, Bands $band, string $uploadId): JsonResponse
     {
-        $upload = ChunkedUpload::where('upload_id', $uploadId)
-            ->where('user_id', Auth::id())
-            ->firstOrFail();
+        $upload = $this->findUploadForBand($uploadId, $band);
 
         if ($upload->chunks_uploaded !== $upload->total_chunks) {
             return response()->json([
@@ -265,9 +262,7 @@ class MediaController extends Controller
 
     public function uploadStatus(Bands $band, string $uploadId): JsonResponse
     {
-        $upload = ChunkedUpload::where('upload_id', $uploadId)
-            ->where('user_id', Auth::id())
-            ->firstOrFail();
+        $upload = $this->findUploadForBand($uploadId, $band);
 
         return response()->json([
             'upload_id'       => $upload->upload_id,
@@ -281,6 +276,21 @@ class MediaController extends Controller
     }
 
     // ── Helpers ────────────────────────────────────────────────────────────────
+
+    /**
+     * Resolve a chunked upload for the current user, scoped to the band in the
+     * route. Band-stamped uploads (new rows) must match the band exactly; legacy
+     * rows with a null band_id remain reachable so in-flight uploads don't break.
+     */
+    private function findUploadForBand(string $uploadId, Bands $band): ChunkedUpload
+    {
+        return ChunkedUpload::where('upload_id', $uploadId)
+            ->where('user_id', Auth::id())
+            ->where(function ($q) use ($band) {
+                $q->whereNull('band_id')->orWhere('band_id', $band->id);
+            })
+            ->firstOrFail();
+    }
 
     private function formatFile(MediaFile $m, bool $detailed = false): array
     {

--- a/app/Models/ChunkedUpload.php
+++ b/app/Models/ChunkedUpload.php
@@ -11,6 +11,7 @@ class ChunkedUpload extends Model
     protected $fillable = [
         'upload_id',
         'user_id',
+        'band_id',
         'filename',
         'filesize',
         'mime_type',

--- a/app/Services/Mobile/EventDataService.php
+++ b/app/Services/Mobile/EventDataService.php
@@ -7,12 +7,18 @@ use App\Models\Bookings;
 use App\Models\EventAttachment;
 use App\Models\EventMember;
 use App\Models\Events;
+use App\Models\MediaFile;
 use App\Models\RosterSlot;
+use App\Services\MediaLibraryService;
 use Illuminate\Http\Request;
 use Illuminate\Support\Collection;
 
 class EventDataService
 {
+    public function __construct(private readonly MediaLibraryService $mediaService)
+    {
+    }
+
     /**
      * Compute 'none' | 'red' | 'yellow' | 'green' roster status from a flat
      * collection of member arrays (each must have is_filled / is_sub keys).
@@ -324,6 +330,11 @@ class EventDataService
 
         $attachments = $event->attachments->map(fn ($a) => $this->formatAttachment($a))->values()->toArray();
 
+        $media = $this->mediaService->getEventMedia($event)
+            ->map(fn ($m) => $this->formatMedia($m))
+            ->values()
+            ->toArray();
+
         return [
             'id'              => $event->id,
             'key'             => $event->key,
@@ -344,6 +355,7 @@ class EventDataService
             'members'         => $members,
             'contacts'        => $contacts,
             'attachments'     => $attachments,
+            'media'           => $media,
             ...$additionalData,
         ];
     }
@@ -359,6 +371,25 @@ class EventDataService
             'mime_type' => $attachment->mime_type,
             'file_size' => $attachment->file_size,
             'url'       => $attachment->url,
+        ];
+    }
+
+    /**
+     * Format a media-library file to its API shape.
+     */
+    public function formatMedia(MediaFile $m): array
+    {
+        return [
+            'id'             => $m->id,
+            'filename'       => $m->filename,
+            'title'          => $m->title,
+            'media_type'     => $m->media_type,
+            'mime_type'      => $m->mime_type,
+            'file_size'      => $m->file_size,
+            'formatted_size' => $m->formatted_size,
+            'folder_path'    => $m->folder_path,
+            'thumbnail_url'  => $m->thumbnail_url,
+            'created_at'     => $m->created_at?->toIso8601String(),
         ];
     }
 

--- a/app/Services/Mobile/EventDataService.php
+++ b/app/Services/Mobile/EventDataService.php
@@ -383,6 +383,7 @@ class EventDataService
             'id'             => $m->id,
             'filename'       => $m->filename,
             'title'          => $m->title,
+            'description'    => $m->description,
             'media_type'     => $m->media_type,
             'mime_type'      => $m->mime_type,
             'file_size'      => $m->file_size,

--- a/app/Services/Mobile/MediaUploadService.php
+++ b/app/Services/Mobile/MediaUploadService.php
@@ -5,6 +5,7 @@ namespace App\Services\Mobile;
 use App\Models\Bands;
 use App\Models\BandStorageQuota;
 use App\Models\ChunkedUpload;
+use App\Models\Events;
 use App\Models\MediaFile;
 use App\Services\MediaLibraryService;
 use Illuminate\Support\Facades\Auth;
@@ -86,6 +87,33 @@ class MediaUploadService
             ['quota_limit' => 5368709120, 'quota_used' => 0]
         );
         $quota->increment('quota_used', $upload->filesize);
+
+        // Resolve (and lazily create) the event's client-shared folder, reusing the
+        // same idempotent rule the web controllers use. The mobile client only ever
+        // sends event_id — folder path logic stays server-side.
+        if ($upload->event_id) {
+            $event = Events::find($upload->event_id);
+            if ($event) {
+                try {
+                    if ($event->enable_portal_media_access && !$event->media_folder_path) {
+                        $folderPath = $this->mediaService->createEventFolder($event);
+                        $event->update(['media_folder_path' => $folderPath]);
+                    }
+                    if ($event->media_folder_path && !$mediaFile->folder_path) {
+                        $mediaFile->update(['folder_path' => $event->media_folder_path]);
+                    }
+                } catch (\Exception $e) {
+                    // Non-fatal: the MediaFile is already valid and will still be
+                    // associated below. Match the thumbnail-generation stance and
+                    // leave folder_path null rather than aborting the upload.
+                    \Log::warning('Mobile upload: event folder creation failed', [
+                        'media_id' => $mediaFile->id,
+                        'event_id' => $event->id,
+                        'error'    => $e->getMessage(),
+                    ]);
+                }
+            }
+        }
 
         $this->mediaService->createAssociations($mediaFile, null, $upload->event_id);
 

--- a/app/Services/Mobile/MediaUploadService.php
+++ b/app/Services/Mobile/MediaUploadService.php
@@ -91,9 +91,17 @@ class MediaUploadService
         // Resolve (and lazily create) the event's client-shared folder, reusing the
         // same idempotent rule the web controllers use. The mobile client only ever
         // sends event_id — folder path logic stays server-side.
+        //
+        // Tenant guard: only honour event_id when the event actually belongs to the
+        // uploading band. A client could otherwise pass an event_id from another
+        // band and have the media associated with — and folder-pathed from — a
+        // foreign event. When the event doesn't belong to $band we fall through to
+        // a plain no-event upload (no folder, no association to the foreign event).
+        $eventId = null;
         if ($upload->event_id) {
             $event = Events::find($upload->event_id);
-            if ($event) {
+            if ($event && $event->eventable?->band_id === $band->id) {
+                $eventId = $event->id;
                 try {
                     if ($event->enable_portal_media_access && !$event->media_folder_path) {
                         $folderPath = $this->mediaService->createEventFolder($event);
@@ -115,7 +123,7 @@ class MediaUploadService
             }
         }
 
-        $this->mediaService->createAssociations($mediaFile, null, $upload->event_id);
+        $this->mediaService->createAssociations($mediaFile, null, $eventId);
 
         if (in_array($mediaType, ['image', 'video'])) {
             try {

--- a/database/factories/BandsFactory.php
+++ b/database/factories/BandsFactory.php
@@ -28,7 +28,7 @@ class BandsFactory extends Factory
         $band = $this->faker->company();
         return [
             'name' => $band,
-            'site_name' => Str::slug($band, '_')
+            'site_name' => Str::slug($band, '_') . '_' . uniqid()
         ];
     }
 

--- a/database/migrations/2026_06_23_000000_add_band_id_to_chunked_uploads_table.php
+++ b/database/migrations/2026_06_23_000000_add_band_id_to_chunked_uploads_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('chunked_uploads', function (Blueprint $table) {
+            $table->foreignId('band_id')->nullable()->after('user_id')->constrained('bands')->onDelete('cascade');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('chunked_uploads', function (Blueprint $table) {
+            $table->dropForeign(['band_id']);
+            $table->dropColumn('band_id');
+        });
+    }
+};

--- a/routes/api.php
+++ b/routes/api.php
@@ -298,6 +298,7 @@ Route::prefix('mobile')->group(function () {
         // ── Media (write) ──────────────────────────────────────────────
         Route::prefix('bands/{band}')->middleware('mobile.band:write:media')->group(function () {
             Route::delete('/media/{media}', [App\Http\Controllers\Api\Mobile\MediaController::class, 'destroy'])->name('mobile.media.destroy');
+            Route::get('/media/upload/{uploadId}', [App\Http\Controllers\Api\Mobile\MediaController::class, 'uploadStatus'])->name('mobile.media.upload.status');
             Route::post('/media/upload/initiate', [App\Http\Controllers\Api\Mobile\MediaController::class, 'uploadInitiate'])->name('mobile.media.upload.initiate');
             Route::post('/media/upload/{uploadId}/chunk', [App\Http\Controllers\Api\Mobile\MediaController::class, 'uploadChunk'])->name('mobile.media.upload.chunk');
             Route::post('/media/upload/{uploadId}/complete', [App\Http\Controllers\Api\Mobile\MediaController::class, 'uploadComplete'])->name('mobile.media.upload.complete');

--- a/tests/Feature/Api/Mobile/EventMediaUploadTest.php
+++ b/tests/Feature/Api/Mobile/EventMediaUploadTest.php
@@ -18,7 +18,7 @@ class EventMediaUploadTest extends TestCase
 {
     use RefreshDatabase;
 
-    private function setup_band_event(): array
+    private function createUserWithBandAndEvent(): array
     {
         $user = User::factory()->create();
         $band = Bands::factory()->create();
@@ -36,15 +36,13 @@ class EventMediaUploadTest extends TestCase
             'enable_portal_media_access' => true,
         ]);
 
-        $token = $user->createToken('test-device')->plainTextToken;
-
-        return compact('user', 'band', 'booking', 'event', 'token');
+        return compact('user', 'band', 'booking', 'event');
     }
 
     public function test_completing_event_upload_creates_folder_and_associates_media(): void
     {
         Storage::fake('s3');
-        ['user' => $user, 'band' => $band, 'event' => $event] = $this->setup_band_event();
+        ['user' => $user, 'band' => $band, 'event' => $event] = $this->createUserWithBandAndEvent();
 
         $upload = ChunkedUpload::factory()->create([
             'user_id'        => $user->id,
@@ -84,7 +82,7 @@ class EventMediaUploadTest extends TestCase
     public function test_second_event_upload_reuses_existing_folder(): void
     {
         Storage::fake('s3');
-        ['user' => $user, 'band' => $band, 'event' => $event] = $this->setup_band_event();
+        ['user' => $user, 'band' => $band, 'event' => $event] = $this->createUserWithBandAndEvent();
         $event->update(['media_folder_path' => '2026/07/test-gig']);
 
         $upload = ChunkedUpload::factory()->create([
@@ -111,7 +109,7 @@ class EventMediaUploadTest extends TestCase
     public function test_folder_creation_failure_does_not_abort_upload(): void
     {
         Storage::fake('s3');
-        ['user' => $user, 'band' => $band, 'event' => $event] = $this->setup_band_event();
+        ['user' => $user, 'band' => $band, 'event' => $event] = $this->createUserWithBandAndEvent();
 
         // Force the (lazy) event-folder creation to blow up. The upload has
         // already been merged, stored on S3, and persisted by this point, so a
@@ -156,7 +154,7 @@ class EventMediaUploadTest extends TestCase
     public function test_event_detail_returns_associated_media(): void
     {
         Storage::fake('s3');
-        ['user' => $user, 'band' => $band, 'event' => $event] = $this->setup_band_event();
+        ['user' => $user, 'band' => $band, 'event' => $event] = $this->createUserWithBandAndEvent();
         $event->update(['media_folder_path' => '2026/07/test-gig']);
 
         $media = \App\Models\MediaFile::factory()->create([
@@ -173,7 +171,7 @@ class EventMediaUploadTest extends TestCase
             ->getJson("/api/mobile/events/{$event->key}");
 
         $response->assertStatus(200)
-            ->assertJsonStructure(['event' => ['media' => [['id', 'filename', 'media_type', 'mime_type', 'file_size', 'formatted_size', 'thumbnail_url', 'created_at']]]]);
+            ->assertJsonStructure(['event' => ['media' => [['id', 'filename', 'title', 'description', 'media_type', 'mime_type', 'file_size', 'formatted_size', 'thumbnail_url', 'created_at']]]]);
 
         $ids = collect($response->json('event.media'))->pluck('id');
         $this->assertTrue($ids->contains($media->id), 'event media should include the file in the folder');
@@ -181,7 +179,7 @@ class EventMediaUploadTest extends TestCase
 
     public function test_upload_status_returns_progress(): void
     {
-        ['user' => $user, 'band' => $band] = $this->setup_band_event();
+        ['user' => $user, 'band' => $band] = $this->createUserWithBandAndEvent();
 
         $upload = ChunkedUpload::factory()->create([
             'user_id'         => $user->id,
@@ -200,5 +198,88 @@ class EventMediaUploadTest extends TestCase
             'chunks_uploaded' => 2,
             'status'          => 'uploading',
         ]);
+    }
+
+    // ── Tenant isolation (security) ─────────────────────────────────────────
+
+    public function test_cross_band_event_id_is_not_associated_and_creates_no_folder(): void
+    {
+        Storage::fake('s3');
+
+        // Band A (the uploading band) and Band B (owns the foreign event).
+        ['user' => $user, 'band' => $bandA] = $this->createUserWithBandAndEvent();
+        ['event' => $foreignEvent] = $this->createUserWithBandAndEvent();
+
+        // Sanity: the foreign event belongs to a different band than band A.
+        $this->assertNotSame($bandA->id, $foreignEvent->eventable->band_id);
+
+        // Upload under band A, but pointing at band B's event_id.
+        $upload = ChunkedUpload::factory()->create([
+            'user_id'         => $user->id,
+            'band_id'         => $bandA->id,
+            'total_chunks'    => 1,
+            'chunks_uploaded' => 1,
+            'mime_type'       => 'image/jpeg',
+            'filename'        => 'cross.jpg',
+            'folder_path'     => null,
+            'event_id'        => $foreignEvent->id,
+        ]);
+        Storage::disk('local')->put("chunks/{$upload->upload_id}/0", 'chunkdata');
+
+        $response = $this->actingAs($user)
+            ->withHeaders(['X-Band-ID' => $bandA->id])
+            ->postJson(
+                "/api/mobile/bands/{$bandA->id}/media/upload/{$upload->upload_id}/complete"
+            );
+
+        // The upload itself still succeeds — it is just treated as a no-event upload.
+        $response->assertStatus(200);
+
+        $mediaId = $response->json('media.id');
+
+        // No cross-tenant association to the foreign event.
+        $this->assertDatabaseMissing('media_associations', [
+            'media_file_id'   => $mediaId,
+            'associable_type' => 'App\\Models\\Events',
+            'associable_id'   => $foreignEvent->id,
+        ]);
+
+        // The foreign event's folder path was not touched.
+        $foreignEvent->refresh();
+        $this->assertNull($foreignEvent->media_folder_path);
+    }
+
+    public function test_upload_status_is_scoped_to_the_initiating_band(): void
+    {
+        // One user owns BOTH bands so the failure is specifically the band_id
+        // guard, not a band-access failure.
+        $user = User::factory()->create();
+
+        $bandA = Bands::factory()->create();
+        $bandA->owners()->create(['user_id' => $user->id]);
+
+        $bandB = Bands::factory()->create();
+        $bandB->owners()->create(['user_id' => $user->id]);
+
+        // Initiate the upload under band A.
+        $upload = ChunkedUpload::factory()->create([
+            'user_id'         => $user->id,
+            'band_id'         => $bandA->id,
+            'total_chunks'    => 4,
+            'chunks_uploaded' => 2,
+            'status'          => 'uploading',
+        ]);
+
+        // Same-band status still works.
+        $this->actingAs($user)
+            ->withHeaders(['X-Band-ID' => $bandA->id])
+            ->getJson("/api/mobile/bands/{$bandA->id}/media/upload/{$upload->upload_id}")
+            ->assertStatus(200);
+
+        // Querying the same upload under band B must 404 — the upload is not band B's.
+        $this->actingAs($user)
+            ->withHeaders(['X-Band-ID' => $bandB->id])
+            ->getJson("/api/mobile/bands/{$bandB->id}/media/upload/{$upload->upload_id}")
+            ->assertStatus(404);
     }
 }

--- a/tests/Feature/Api/Mobile/EventMediaUploadTest.php
+++ b/tests/Feature/Api/Mobile/EventMediaUploadTest.php
@@ -1,0 +1,155 @@
+<?php
+
+namespace Tests\Feature\Api\Mobile;
+
+use App\Models\Bands;
+use App\Models\Bookings;
+use App\Models\ChunkedUpload;
+use App\Models\EventTypes;
+use App\Models\Events;
+use App\Models\User;
+use App\Services\MediaLibraryService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Storage;
+use Mockery;
+use Tests\TestCase;
+
+class EventMediaUploadTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function setup_band_event(): array
+    {
+        $user = User::factory()->create();
+        $band = Bands::factory()->create();
+        $band->owners()->create(['user_id' => $user->id]);
+
+        $eventType = EventTypes::factory()->create();
+        $booking = Bookings::factory()->create(['band_id' => $band->id]);
+        $event = Events::factory()->create([
+            'eventable_id'               => $booking->id,
+            'eventable_type'             => 'App\\Models\\Bookings',
+            'event_type_id'              => $eventType->id,
+            'date'                       => now()->addDays(7)->format('Y-m-d'),
+            'title'                      => 'Test Gig',
+            'media_folder_path'          => null,
+            'enable_portal_media_access' => true,
+        ]);
+
+        $token = $user->createToken('test-device')->plainTextToken;
+
+        return compact('user', 'band', 'booking', 'event', 'token');
+    }
+
+    public function test_completing_event_upload_creates_folder_and_associates_media(): void
+    {
+        Storage::fake('s3');
+        ['user' => $user, 'band' => $band, 'event' => $event] = $this->setup_band_event();
+
+        $upload = ChunkedUpload::factory()->create([
+            'user_id'        => $user->id,
+            'total_chunks'   => 1,
+            'chunks_uploaded'=> 1,
+            'mime_type'      => 'image/jpeg',
+            'filename'       => 'shot.jpg',
+            'folder_path'    => null,
+            'event_id'       => $event->id,
+        ]);
+
+        Storage::disk('local')->put("chunks/{$upload->upload_id}/0", 'chunkdata');
+
+        $response = $this->actingAs($user)
+            ->withHeaders(['X-Band-ID' => $band->id])
+            ->postJson(
+                "/api/mobile/bands/{$band->id}/media/upload/{$upload->upload_id}/complete"
+            );
+
+        $response->assertStatus(200)->assertJsonStructure(['media' => ['id', 'folder_path']]);
+
+        $event->refresh();
+        $this->assertNotNull($event->media_folder_path, 'event folder should be created');
+
+        $mediaId = $response->json('media.id');
+        $this->assertDatabaseHas('media_files', [
+            'id'          => $mediaId,
+            'folder_path' => $event->media_folder_path,
+        ]);
+        $this->assertDatabaseHas('media_associations', [
+            'media_file_id'   => $mediaId,
+            'associable_type' => 'App\\Models\\Events',
+            'associable_id'   => $event->id,
+        ]);
+    }
+
+    public function test_second_event_upload_reuses_existing_folder(): void
+    {
+        Storage::fake('s3');
+        ['user' => $user, 'band' => $band, 'event' => $event] = $this->setup_band_event();
+        $event->update(['media_folder_path' => '2026/07/test-gig']);
+
+        $upload = ChunkedUpload::factory()->create([
+            'user_id'        => $user->id,
+            'total_chunks'   => 1,
+            'chunks_uploaded'=> 1,
+            'mime_type'      => 'image/jpeg',
+            'filename'       => 'shot2.jpg',
+            'folder_path'    => null,
+            'event_id'       => $event->id,
+        ]);
+        Storage::disk('local')->put("chunks/{$upload->upload_id}/0", 'chunkdata');
+
+        $this->actingAs($user)
+            ->withHeaders(['X-Band-ID' => $band->id])
+            ->postJson(
+                "/api/mobile/bands/{$band->id}/media/upload/{$upload->upload_id}/complete"
+            )->assertStatus(200);
+
+        $event->refresh();
+        $this->assertEquals('2026/07/test-gig', $event->media_folder_path);
+    }
+
+    public function test_folder_creation_failure_does_not_abort_upload(): void
+    {
+        Storage::fake('s3');
+        ['user' => $user, 'band' => $band, 'event' => $event] = $this->setup_band_event();
+
+        // Force the (lazy) event-folder creation to blow up. The upload has
+        // already been merged, stored on S3, and persisted by this point, so a
+        // folder failure must be non-fatal: the media stays valid + associated.
+        $mock = Mockery::mock(MediaLibraryService::class)->makePartial();
+        $mock->shouldReceive('createEventFolder')
+            ->andThrow(new \RuntimeException('boom'));
+        $this->app->instance(MediaLibraryService::class, $mock);
+
+        $upload = ChunkedUpload::factory()->create([
+            'user_id'        => $user->id,
+            'total_chunks'   => 1,
+            'chunks_uploaded'=> 1,
+            'mime_type'      => 'image/jpeg',
+            'filename'       => 'shot3.jpg',
+            'folder_path'    => null,
+            'event_id'       => $event->id,
+        ]);
+        Storage::disk('local')->put("chunks/{$upload->upload_id}/0", 'chunkdata');
+
+        $response = $this->actingAs($user)
+            ->withHeaders(['X-Band-ID' => $band->id])
+            ->postJson(
+                "/api/mobile/bands/{$band->id}/media/upload/{$upload->upload_id}/complete"
+            );
+
+        $response->assertStatus(200);
+
+        // Upload still completes; the event folder simply stays unset.
+        $event->refresh();
+        $this->assertNull($event->media_folder_path);
+
+        $mediaId = $response->json('media.id');
+        $this->assertDatabaseHas('media_files', ['id' => $mediaId]);
+        $this->assertDatabaseHas('media_associations', [
+            'media_file_id'   => $mediaId,
+            'associable_type' => 'App\\Models\\Events',
+            'associable_id'   => $event->id,
+        ]);
+    }
+}

--- a/tests/Feature/Api/Mobile/EventMediaUploadTest.php
+++ b/tests/Feature/Api/Mobile/EventMediaUploadTest.php
@@ -178,4 +178,27 @@ class EventMediaUploadTest extends TestCase
         $ids = collect($response->json('event.media'))->pluck('id');
         $this->assertTrue($ids->contains($media->id), 'event media should include the file in the folder');
     }
+
+    public function test_upload_status_returns_progress(): void
+    {
+        ['user' => $user, 'band' => $band] = $this->setup_band_event();
+
+        $upload = ChunkedUpload::factory()->create([
+            'user_id'         => $user->id,
+            'total_chunks'    => 4,
+            'chunks_uploaded' => 2,
+            'status'          => 'uploading',
+        ]);
+
+        $response = $this->actingAs($user)
+            ->withHeaders(['X-Band-ID' => $band->id])
+            ->getJson("/api/mobile/bands/{$band->id}/media/upload/{$upload->upload_id}");
+
+        $response->assertStatus(200)->assertJson([
+            'upload_id'       => $upload->upload_id,
+            'total_chunks'    => 4,
+            'chunks_uploaded' => 2,
+            'status'          => 'uploading',
+        ]);
+    }
 }

--- a/tests/Feature/Api/Mobile/EventMediaUploadTest.php
+++ b/tests/Feature/Api/Mobile/EventMediaUploadTest.php
@@ -152,4 +152,30 @@ class EventMediaUploadTest extends TestCase
             'associable_id'   => $event->id,
         ]);
     }
+
+    public function test_event_detail_returns_associated_media(): void
+    {
+        Storage::fake('s3');
+        ['user' => $user, 'band' => $band, 'event' => $event] = $this->setup_band_event();
+        $event->update(['media_folder_path' => '2026/07/test-gig']);
+
+        $media = \App\Models\MediaFile::factory()->create([
+            'band_id'     => $band->id,
+            'user_id'     => $user->id,
+            'folder_path' => '2026/07/test-gig',
+            'filename'    => 'live.jpg',
+            'media_type'  => 'image',
+            'mime_type'   => 'image/jpeg',
+        ]);
+
+        $response = $this->actingAs($user)
+            ->withHeaders(['X-Band-ID' => $band->id])
+            ->getJson("/api/mobile/events/{$event->key}");
+
+        $response->assertStatus(200)
+            ->assertJsonStructure(['event' => ['media' => [['id', 'filename', 'media_type', 'mime_type', 'file_size', 'formatted_size', 'thumbnail_url', 'created_at']]]]);
+
+        $ids = collect($response->json('event.media'))->pluck('id');
+        $this->assertTrue($ids->contains($media->id), 'event media should include the file in the folder');
+    }
 }


### PR DESCRIPTION
## Summary

Backend support for the mobile app to upload media to a specific event via the existing chunked-upload pipeline, with web parity for client sharing.

- **Event folder auto-create on upload** — when a mobile chunked upload references an `event_id`, `MediaUploadService::complete()` now lazily creates the event's client-shared folder by reusing `MediaLibraryService::createEventFolder()` (same idempotent guard as the web controllers: only when `enable_portal_media_access` and no folder yet) and sets the uploaded `MediaFile.folder_path`. Wrapped in a non-fatal try/catch so a folder-creation failure can't orphan an already-stored S3 file.
- **Event media in detail response** — `EventDataService::formatForShow()` now returns a `media[]` array (alongside the separate band-internal `attachments`), resolved via the existing `MediaLibraryService::getEventMedia()` query, using the same field shape as `MediaController::formatFile()`.
- **Upload status endpoint** — `GET /api/mobile/bands/{band}/media/upload/{uploadId}` (`MediaController::uploadStatus`) returns chunk progress so the mobile client can resume interrupted uploads. Scoped to the authenticated user.

No new event-media query or path/slug logic was written — existing services are reused throughout.

## Test Plan

- [x] `php artisan test tests/Feature/Api/Mobile` — 274 passed (935 assertions), sequential
- [x] New `tests/Feature/Api/Mobile/EventMediaUploadTest.php` covers: folder created + media associated on event upload; folder reused on second upload; folder-creation failure does not abort upload; event detail returns associated media; upload status returns progress
- [ ] Merge before the mobile (tts_bandmate) PR — the Flutter client depends on this contract

🤖 Generated with [Claude Code](https://claude.com/claude-code)