### PR TITLE
fix(bookings): source date/venue_name from events table (fixes TTS-BAND-14V, TTS-BAND-14T)

### DIFF
--- a/app/Http/Controllers/QuestionnairesController.php
+++ b/app/Http/Controllers/QuestionnairesController.php
@@ -150,7 +150,7 @@ class QuestionnairesController extends Controller
             'booking' => [
                 'id' => $i->booking->id,
                 'name' => $i->booking->name,
-                'date' => $i->booking->start_date?->format('M j, Y'),
+                'date' => $i->booking->event_dates,
             ],
             'fields' => $i->fields->map(fn ($f) => [
                 'id' => $f->id,
@@ -177,7 +177,7 @@ class QuestionnairesController extends Controller
             ->map(fn ($b) => [
                 'id' => $b->id,
                 'name' => $b->name,
-                'date' => $b->start_date?->format('M j, Y'),
+                'date' => $b->event_dates,
                 'already_sent' => in_array($b->id, $bookingIdsAlreadySent, true),
                 'contacts' => $b->contacts->map(fn ($c) => [
                     'id' => $c->id,

--- a/app/Http/Controllers/QuestionnairesController.php
+++ b/app/Http/Controllers/QuestionnairesController.php
@@ -128,7 +128,8 @@ class QuestionnairesController extends Controller
         $rawInstances = $questionnaire->instances()
             ->with([
                 'recipientContact:id,name',
-                'booking:id,name,date,band_id',
+                'booking:id,name,band_id',
+                'booking.events:id,eventable_id,eventable_type,date,venue_name',
                 'fields' => fn ($q) => $q->orderBy('position'),
                 'responses',
             ])
@@ -149,7 +150,7 @@ class QuestionnairesController extends Controller
             'booking' => [
                 'id' => $i->booking->id,
                 'name' => $i->booking->name,
-                'date' => $i->booking->date?->format('M j, Y'),
+                'date' => $i->booking->start_date?->format('M j, Y'),
             ],
             'fields' => $i->fields->map(fn ($f) => [
                 'id' => $f->id,
@@ -170,13 +171,13 @@ class QuestionnairesController extends Controller
             ->all();
 
         $bookings = $band->bookings()
-            ->with(['contacts:id,name'])
-            ->whereDate('date', '>=', today())
-            ->get(['id', 'name', 'date', 'band_id'])
+            ->with(['contacts:id,name', 'events:id,eventable_id,eventable_type,date,venue_name'])
+            ->whereHas('events', fn ($q) => $q->whereDate('date', '>=', today()))
+            ->get(['id', 'name', 'band_id'])
             ->map(fn ($b) => [
                 'id' => $b->id,
                 'name' => $b->name,
-                'date' => $b->date?->format('M j, Y'),
+                'date' => $b->start_date?->format('M j, Y'),
                 'already_sent' => in_array($b->id, $bookingIdsAlreadySent, true),
                 'contacts' => $b->contacts->map(fn ($c) => [
                     'id' => $c->id,

--- a/app/Http/Controllers/RehearsalController.php
+++ b/app/Http/Controllers/RehearsalController.php
@@ -65,7 +65,7 @@ class RehearsalController extends Controller
                 'events.title',
                 'events.date',
                 'bookings.name as booking_name',
-                'bookings.venue_name',
+                'events.venue_name',
                 'events.notes'
             ])
             ->get();
@@ -211,7 +211,7 @@ class RehearsalController extends Controller
                 'events.title',
                 'events.date',
                 'bookings.name as booking_name',
-                'bookings.venue_name',
+                'events.venue_name',
                 'events.notes'
             ])
             ->get();
@@ -395,7 +395,7 @@ class RehearsalController extends Controller
                 'events.title',
                 'events.date',
                 'bookings.name as booking_name',
-                'bookings.venue_name',
+                'events.venue_name',
                 'events.notes'
             ])
             ->get();
@@ -443,7 +443,7 @@ class RehearsalController extends Controller
                 'events.title',
                 'events.date',
                 'bookings.name as booking_name',
-                'bookings.venue_name',
+                'events.venue_name',
                 'events.notes'
             ])
             ->get();

--- a/app/Models/Bookings.php
+++ b/app/Models/Bookings.php
@@ -234,6 +234,25 @@ class Bookings extends Model implements Contractable, GoogleCalenderable
         return 'Multiple venues';
     }
 
+    /**
+     * Comma-separated list of the booking's event dates, de-duplicated and
+     * sorted chronologically (e.g. "Jun 12, 2026, Jun 14, 2026"). A booking
+     * can span multiple events on different dates, so a single date column
+     * no longer captures it. Returns null when the booking has no events.
+     */
+    public function getEventDatesAttribute(): ?string
+    {
+        $dates = $this->events
+            ->pluck('date')
+            ->filter()
+            ->sortBy(fn ($d) => $d->timestamp)
+            ->map(fn ($d) => $d->format('M j, Y'))
+            ->unique()
+            ->values();
+
+        return $dates->isEmpty() ? null : $dates->implode(', ');
+    }
+
     public function getTotalDurationAttribute(): float
     {
         $events = $this->events;

--- a/tests/Feature/Questionnaires/ShowQuestionnaireTest.php
+++ b/tests/Feature/Questionnaires/ShowQuestionnaireTest.php
@@ -1,0 +1,136 @@
+<?php
+
+namespace Tests\Feature\Questionnaires;
+
+use App\Models\Bands;
+use App\Models\Bookings;
+use App\Models\Contacts;
+use App\Models\Events;
+use App\Models\QuestionnaireInstances;
+use App\Models\Questionnaires;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+/**
+ * Covers QuestionnairesController::show, the Inertia "Questionnaires/Show"
+ * page. The booking date displayed here is derived from the related events
+ * (the `bookings` table has no `date`/`venue_name` columns), and a booking
+ * can span multiple events on different dates — so the date is rendered as a
+ * comma-separated list. Regression coverage for TTS-BAND-14T.
+ */
+class ShowQuestionnaireTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private Bands $band;
+    private User $owner;
+    private Questionnaires $template;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->band = Bands::factory()->create();
+        $this->owner = User::factory()->create();
+        $this->band->owners()->create(['user_id' => $this->owner->id]);
+        $this->template = Questionnaires::factory()->create(['band_id' => $this->band->id]);
+    }
+
+    private function bookingWithEvents(array $dates): Bookings
+    {
+        $booking = Bookings::factory()->create(['band_id' => $this->band->id]);
+        foreach ($dates as $date) {
+            Events::factory()->create([
+                'eventable_type' => Bookings::class,
+                'eventable_id' => $booking->id,
+                'date' => $date,
+            ]);
+        }
+        return $booking;
+    }
+
+    private function instanceFor(Bookings $booking): QuestionnaireInstances
+    {
+        $contact = Contacts::factory()->create(['band_id' => $this->band->id, 'can_login' => true]);
+        $booking->contacts()->attach($contact, ['is_primary' => true]);
+
+        return QuestionnaireInstances::factory()->create([
+            'questionnaire_id' => $this->template->id,
+            'booking_id' => $booking->id,
+            'recipient_contact_id' => $contact->id,
+            'sent_by_user_id' => $this->owner->id,
+        ]);
+    }
+
+    public function test_show_renders_single_event_booking_date(): void
+    {
+        $booking = $this->bookingWithEvents(['2026-07-04']);
+        $this->instanceFor($booking);
+
+        $response = $this->actingAs($this->owner)
+            ->get(route('questionnaires.show', [$this->band, $this->template]));
+
+        $response->assertOk();
+        $response->assertInertia(fn ($a) => $a
+            ->component('Questionnaires/Show')
+            ->where('instances.0.booking.date', 'Jul 4, 2026'));
+    }
+
+    public function test_show_renders_multi_event_booking_dates_comma_separated(): void
+    {
+        // Created out of chronological order to prove the accessor sorts.
+        $booking = $this->bookingWithEvents(['2026-07-06', '2026-07-04', '2026-07-05']);
+        $this->instanceFor($booking);
+
+        $response = $this->actingAs($this->owner)
+            ->get(route('questionnaires.show', [$this->band, $this->template]));
+
+        $response->assertOk();
+        $response->assertInertia(fn ($a) => $a
+            ->where('instances.0.booking.date', 'Jul 4, 2026, Jul 5, 2026, Jul 6, 2026'));
+    }
+
+    public function test_show_dedupes_events_sharing_a_date(): void
+    {
+        $booking = $this->bookingWithEvents(['2026-07-04', '2026-07-04']);
+        $this->instanceFor($booking);
+
+        $response = $this->actingAs($this->owner)
+            ->get(route('questionnaires.show', [$this->band, $this->template]));
+
+        $response->assertOk();
+        $response->assertInertia(fn ($a) => $a
+            ->where('instances.0.booking.date', 'Jul 4, 2026'));
+    }
+
+    public function test_show_handles_booking_with_no_events(): void
+    {
+        $booking = Bookings::factory()->create(['band_id' => $this->band->id]);
+        $this->instanceFor($booking);
+
+        $response = $this->actingAs($this->owner)
+            ->get(route('questionnaires.show', [$this->band, $this->template]));
+
+        $response->assertOk();
+        $response->assertInertia(fn ($a) => $a
+            ->where('instances.0.booking.date', null));
+    }
+
+    public function test_send_list_only_includes_bookings_with_upcoming_events(): void
+    {
+        $upcoming = $this->bookingWithEvents([now()->addWeek()->toDateString()]);
+        $past = $this->bookingWithEvents([now()->subWeek()->toDateString()]);
+        $eventless = Bookings::factory()->create(['band_id' => $this->band->id]);
+
+        $response = $this->actingAs($this->owner)
+            ->get(route('questionnaires.show', [$this->band, $this->template]));
+
+        $response->assertOk();
+        $response->assertInertia(function ($a) use ($upcoming, $past, $eventless) {
+            $ids = collect($a->toArray()['props']['bookings'])->pluck('id');
+            $this->assertTrue($ids->contains($upcoming->id), 'upcoming booking should be listed');
+            $this->assertFalse($ids->contains($past->id), 'past-only booking should be excluded');
+            $this->assertFalse($ids->contains($eventless->id), 'event-less booking should be excluded');
+        });
+    }
+}


### PR DESCRIPTION
## Summary

Two production 500s in Sentry traced to the same root cause: the `bookings` table no longer has `date` or `venue_name` columns — they live on the related `events` table — but several controllers still referenced them directly, throwing `QueryException`.

- **TTS-BAND-14V** (7 events) — `GET /api/rehearsal/{id}` selected `bookings.venue_name`
- **TTS-BAND-14T** (2 events) — `/bands/{band}/questionnaires/{q}` eager-loaded/filtered `bookings.date`

## Changes

**`RehearsalController`** — `bookings.venue_name` → `events.venue_name` in 4 identical join queries (only one had fired in Sentry; the other three were the same latent bug). The join already pulls `events.date`.

**`QuestionnairesController::show`** — re-sourced the date from the related events, eager-loaded `events` to avoid N+1, and scoped upcoming bookings via `whereHas('events', date >= today)` (preserving the old upcoming-only filter). Fixed a third latent spot (the send-to booking list) that hadn't surfaced because `show` threw earlier.

**Multi-event handling** — a questionnaire is tied to a `booking_id`, and a booking can span multiple events on different dates. Added `Bookings::event_dates` accessor returning a de-duplicated, chronologically-sorted, comma-separated list (e.g. `Jul 4, 2026, Jul 5, 2026`). Event-less bookings render `null`.

## Tests

New `ShowQuestionnaireTest` (the `show` page had zero coverage, which is how the 500 reached production): single-event, multi-event (sorted), duplicate-date, event-less, and the upcoming-only send-list filter.

`94 questionnaire + 8 rehearsal tests pass.`

Fixes TTS-BAND-14V
Fixes TTS-BAND-14T

🤖 Generated with [Claude Code](https://claude.com/claude-code)