### PR TITLE
fix(calendar): guard additional_data->public against missing key (fixes TTS-BAND-ZJ)

### DIFF
--- a/app/Jobs/ProcessEventCreated.php
+++ b/app/Jobs/ProcessEventCreated.php
@@ -46,7 +46,7 @@ class ProcessEventCreated implements ShouldQueue, ShouldBeUniqueUntilProcessing
                 $this->event->storeGoogleEventId($this->event->getGoogleCalendar(), $event->id);
             }
 
-            if ($this->event->additional_data && $this->event->additional_data->public && $this->shouldSyncToPublicCalendar())
+            if ($this->event->additional_data && !empty($this->event->additional_data->public) && $this->shouldSyncToPublicCalendar())
             {
                 Log::info('Event is public and eligible, writing to public calendar for event ID: ' . $this->event->id);
                 $publicEvent = $this->event->writeToGoogleCalendar($this->event->getPublicGoogleCalendar());

--- a/app/Jobs/ProcessEventDeleted.php
+++ b/app/Jobs/ProcessEventDeleted.php
@@ -31,7 +31,7 @@ class ProcessEventDeleted
                 Log::info('Deleted event from calendar in observer for event ID: ' . $this->event->id);
             }
             
-            if($this->event->additional_data && $this->event->additional_data->public)
+            if($this->event->additional_data && !empty($this->event->additional_data->public))
             {
                 Log::info('Event is public, deleting from public calendar for event ID: ' . $this->event->id);
                 $publicCalendar = $this->event->getPublicGoogleCalendar();

--- a/tests/Feature/ProcessEventCreatedTest.php
+++ b/tests/Feature/ProcessEventCreatedTest.php
@@ -50,4 +50,36 @@ class ProcessEventCreatedTest extends TestCase
             'google_eventable_type' => Events::class,
         ]);
     }
+
+    public function test_handle_does_not_crash_when_additional_data_lacks_public_key(): void
+    {
+        // TTS-BAND-ZJ: additional_data is a valid object but has no `public`
+        // key. Reading ->public directly raises "Undefined property:
+        // stdClass::$public" under PHP 8. The job must treat a missing key as
+        // not-public, not crash.
+        $band = Bands::factory()->create();
+        $booking = Bookings::factory()->create(['band_id' => $band->id]);
+        $event = Events::factory()->create([
+            'eventable_type' => Bookings::class,
+            'eventable_id'   => $booking->id,
+        ]);
+
+        // Well-formed JSON object without a `public` key.
+        DB::table('events')->where('id', $event->id)
+            ->update(['additional_data' => json_encode(['times' => []])]);
+
+        Log::spy();
+
+        (new ProcessEventCreated($event))->handle();
+
+        Log::shouldNotHaveReceived('error', [Mockery::on(
+            fn ($message) => is_string($message)
+                && str_contains($message, 'Undefined property: stdClass::$public')
+        )]);
+
+        $this->assertDatabaseMissing('google_events', [
+            'google_eventable_id'   => $event->id,
+            'google_eventable_type' => Events::class,
+        ]);
+    }
 }


### PR DESCRIPTION
## Summary

`ProcessEventCreated` and `ProcessEventDeleted` read `$event->additional_data->public` directly. `additional_data` is normalized to a `stdClass` on read, but the object frequently has **no `public` key** — so the access raised `Undefined property: stdClass::$public` under PHP 8. The job's catch block swallowed it as `Failed to create event in calendar: ...`, firing **103 times** (TTS-BAND-ZJ, last seen ~21h ago).

The truthiness check `&& $additional_data->public` guards against `null` but not against the property being **absent**.

## Fix

Guard both reads with `!empty(...)`, matching the pattern already used in `ProcessEventUpdated::syncPublicCalendar` (`!empty($this->event->additional_data->public)`). A missing key is now treated as not-public instead of crashing.

Two sites changed:
- `ProcessEventCreated.php:49`
- `ProcessEventDeleted.php:34`

(`ProcessEventUpdated` and `EventsController` already use `!empty`/`isset` and were correct.)

## Tests

Added a regression test in `ProcessEventCreatedTest` for `additional_data` that is a valid object lacking the `public` key, alongside the existing double-encoded-string case (TTS-BAND-11E). 11 calendar-job tests pass.

Fixes TTS-BAND-ZJ

🤖 Generated with [Claude Code](https://claude.com/claude-code)