### PR TITLE
fix(stripe): use toArray() so checkout session metadata survives (fixes TTS-BAND-2W)

### DIFF
--- a/app/Http/Controllers/StripeWebhookController.php
+++ b/app/Http/Controllers/StripeWebhookController.php
@@ -142,7 +142,10 @@ class StripeWebhookController extends Controller
                 // Check if this is a contact payment (has booking_id in metadata)
                 if (isset($session->metadata->booking_id)) {
                     $paymentService = app(ContactPaymentService::class);
-                    $paymentService->processSuccessfulPayment((array) $session);
+                    // Use Stripe's recursive toArray(): a plain (array) cast on a
+                    // StripeObject does not recurse and mangles protected keys, so
+                    // the nested `metadata` would be lost and the payment skipped.
+                    $paymentService->processSuccessfulPayment($session->toArray());
                     Log::info('Contact payment processed via checkout session', [
                         'session_id' => $session->id,
                         'booking_id' => $session->metadata->booking_id,

--- a/tests/Unit/StripeWebhookControllerTest.php
+++ b/tests/Unit/StripeWebhookControllerTest.php
@@ -116,6 +116,52 @@ class StripeWebhookControllerTest extends TestCase
         $this->assertEquals(200, $response->getStatusCode());
     }
 
+    public function testCheckoutSessionCompletedRecordsContactPayment()
+    {
+        // Regression for TTS-BAND-2W: a checkout.session.completed event with
+        // valid metadata must record a payment against the booking. The bug was
+        // a (array) cast on the Stripe Session that dropped the nested metadata,
+        // causing "Missing metadata in checkout session" and no payment.
+        Queue::fake();
+
+        $booking = Bookings::factory()->create();
+        $contact = Contacts::factory()->create(['band_id' => $booking->band_id]);
+        $booking->contacts()->attach($contact, [
+            'role' => 'client',
+            'is_primary' => true,
+            'notes' => '',
+        ]);
+
+        // A real StripeObject (not a stdClass) so the toArray()-vs-(array)
+        // distinction is actually exercised — metadata is a nested StripeObject.
+        $stripeEvent = new Event();
+        $stripeEvent->type = 'checkout.session.completed';
+        $stripeEvent->data = new \stdClass();
+        $stripeEvent->data->object = \Stripe\Checkout\Session::constructFrom([
+            'id' => 'cs_live_test_2w',
+            'payment_intent' => 'pi_test_2w',
+            'metadata' => [
+                'booking_id' => (string) $booking->id,
+                'contact_id' => (string) $contact->id,
+                'payment_amount' => '450000', // cents
+            ],
+        ]);
+
+        $request = new Request([], [], [], [], [], ['CONTENT_TYPE' => 'application/json'], json_encode($stripeEvent));
+
+        $response = $this->controller->index($request);
+
+        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertDatabaseHas('payments', [
+            'payable_id' => $booking->id,
+            'payable_type' => Bookings::class,
+            'payer_type' => Contacts::class,
+            'payer_id' => $contact->id,
+            'payment_type' => 'portal',
+            'status' => 'paid',
+        ]);
+    }
+
     public function testInvalidStripeSignature()
     {
         Config::set('services.stripe.webhook_secret', 'test_secret');


### PR DESCRIPTION
## Summary

The `checkout.session.completed` webhook passed `(array) $session` to `ContactPaymentService::processSuccessfulPayment`. A plain PHP `(array)` cast on a `\Stripe\Checkout\Session` **does not recurse** and mangles the protected-property keys — so the nested `metadata` (`booking_id`, `contact_id`, `payment_amount`) was **dropped entirely**. The service then logged `"Missing metadata in checkout session"` and returned without recording the payment on this path.

## Impact — noisy error log, NOT lost payments (verified)

TTS-BAND-2W fired 23 times / 7 users. However, **no payments were actually lost.** Stripe fires *both* `checkout.session.completed` (this buggy path → logged the error, recorded nothing) and `payment_intent.succeeded` (a separate handler that hand-builds the metadata array correctly → recorded the payment). The successful path caught every payment.

Verified against production: booking 589 — the session captured in the TTS-BAND-2W Sentry event — has its `portal` payment recorded despite the error being logged for it.

So this fix:
- **Stops the false `Missing metadata` errors** on the `checkout.session.completed` path.
- **Removes the accidental reliance** on `payment_intent.succeeded` as the only working path — making checkout-session handling correct in its own right.

No data backfill needed.

## Root cause (verified empirically)

```php
$arr = (array) $stripeSession;
$arr['metadata'];          // Undefined array key — metadata is gone
$session->toArray()['metadata']['booking_id']; // '589' ✅ (recursive)
```

`(array)` on a `StripeObject` exposes protected props under mangled `\0*\0key` names, not clean keys. `toArray()` is Stripe's recursive converter.

## Fix

Replace `(array) $session` with `$session->toArray()`. The `payment_intent.succeeded` branch was already correct.

## Tests

Added a regression test in `StripeWebhookControllerTest` driving a real `checkout.session.completed` event (with a genuine `\Stripe\Checkout\Session`) through the controller and asserting a `portal` payment is recorded. **Verified it fails on the old `(array)` cast and passes with `toArray()`.** Also added `RefreshDatabase` to the class (per Copilot review) — it was the only DB-touching Unit test without it. 15 payment-related tests pass.

Fixes TTS-BAND-2W

🤖 Generated with [Claude Code](https://claude.com/claude-code)