### PR TITLE
refactor(bookings): use withSum for amount_paid (follow-up to #468)

### DIFF
--- a/app/Http/Controllers/Api/Mobile/BookingsController.php
+++ b/app/Http/Controllers/Api/Mobile/BookingsController.php
@@ -43,7 +43,9 @@ class BookingsController extends Controller
      */
     public function index(BookingIndexRequest $request, Bands $band): JsonResponse
     {
-        $query = $band->bookings()->with(['contacts', 'band', 'events', 'payments']);
+        $query = $band->bookings()
+            ->with(['contacts', 'band', 'events'])
+            ->withSum(['payments as payment_total_cents' => fn ($q) => $q->where('status', 'paid')], 'amount');
 
         if ($request->filled('status')) {
             $query->where('status', $request->input('status'));
@@ -96,7 +98,12 @@ class BookingsController extends Controller
         $bandIds = $user->bands()->pluck('id');
 
         $query = Bookings::query()
-            ->with(['band', 'contacts', 'events', 'payments'])
+            ->with(['band', 'contacts', 'events'])
+            // Aggregate paid payments into payment_total_cents (raw cents) so the
+            // amount_paid accessor uses its fast-path instead of one sum() query
+            // per booking (N+1), without serializing the full payments relation
+            // into the list response.
+            ->withSum(['payments as payment_total_cents' => fn ($q) => $q->where('status', 'paid')], 'amount')
             ->whereIn('band_id', $bandIds);
 
         if ($request->filled('status')) {

--- a/app/Models/Bookings.php
+++ b/app/Models/Bookings.php
@@ -288,18 +288,7 @@ class Bookings extends Model implements Contractable, GoogleCalenderable
             return number_format($rawValue / 100, 2, '.', '');
         }
 
-        // If the payments relation is already loaded (e.g. eager-loaded by a
-        // list endpoint), sum in PHP to avoid an aggregate query per booking
-        // (N+1). Sum raw cents via getRawOriginal — the `amount` accessor is
-        // cast by Price to a formatted dollar string, which must not be summed.
-        // Otherwise fall back to a single aggregate query (also in raw cents).
-        if ($this->relationLoaded('payments')) {
-            $totalCents = $this->payments
-                ->where('status', 'paid')
-                ->sum(fn ($payment) => (int) $payment->getRawOriginal('amount'));
-            return number_format($totalCents / 100, 2, '.', '');
-        }
-
+        // Otherwise, calculate it from the payments relationship
         $total = $this->payments()->where('status', 'paid')->sum('amount') / 100;
         return number_format($total, 2, '.', '');
     }

--- a/tests/Feature/Api/Mobile/MeBookingsTest.php
+++ b/tests/Feature/Api/Mobile/MeBookingsTest.php
@@ -273,11 +273,11 @@ class MeBookingsTest extends TestCase
         $response->assertJsonValidationErrors('from');
     }
 
-    public function test_amount_paid_is_correct_with_eager_loaded_payments(): void
+    public function test_amount_paid_is_correct_with_aggregated_payments(): void
     {
-        // Guards the eager-loaded amount_paid path: payments.amount is cast by
-        // Price to a formatted dollar string, so the loaded-relation sum must
-        // use raw cents (getRawOriginal), not the accessor.
+        // amount_paid is fed by the withSum('payment_total_cents') aggregate
+        // (paid-only, raw cents). Guards that the aggregate matches a manual
+        // sum and that pending payments are excluded.
         $user = User::factory()->create();
         $band = Bands::create([
             'name' => 'Band', 'site_name' => 'b-' . uniqid(), 'is_personal' => false,
@@ -342,7 +342,7 @@ class MeBookingsTest extends TestCase
             ->count();
         DB::disableQueryLog();
 
-        // With payments eager-loaded, the per-booking sum() queries are gone.
+        // With the withSum aggregate, the per-booking sum() queries are gone.
         $this->assertSame(0, $paymentAggregates,
             "Expected no per-booking payment sum() queries, found {$paymentAggregates}");
     }


### PR DESCRIPTION
## Summary

Follow-up to #468 (TTS-BAND-113). That PR fixed the `amount_paid` N+1 by **eager-loading the `payments` relation** — but `BookingFormatter::format()` serializes a loaded `payments` relation into the response. So the `/api/mobile` bookings **list** payloads grew and started exposing full per-payment detail (id, amount, date, type, status) that the list did not previously include.

Copilot flagged this on #468, but the PR auto-merged before the change could be applied — hence this follow-up.

## Change

Swap eager-load → a **paid-only `withSum`** aggregate on both list endpoints:

```php
->withSum(['payments as payment_total_cents' => fn ($q) => $q->where('status', 'paid')], 'amount')
```

`amount_paid` already has a fast-path for the `payment_total_cents` attribute, so this:
- keeps the N+1 fixed (one aggregate in the main query, no per-booking sum),
- **leaves the list response shape unchanged** (no `payments` array serialized),
- lets me remove the now-unused `relationLoaded('payments')` branch from the accessor.

## Tests

Existing regression tests carry over (renamed to reflect the aggregate path). The N+1 assertion (no per-booking `sum(amount)` query) is unchanged and still passes; verified it fails without the aggregate. 32 tests pass across mobile bookings + finance suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)