### PR TITLE
fix(bookings): restore amount_paid fast-path + payload guard (stranded from #469)

### DIFF
--- a/app/Models/Bookings.php
+++ b/app/Models/Bookings.php
@@ -288,7 +288,18 @@ class Bookings extends Model implements Contractable, GoogleCalenderable
             return number_format($rawValue / 100, 2, '.', '');
         }
 
-        // Otherwise, calculate it from the payments relationship
+        // If the payments relation is already loaded (e.g. show/store/update
+        // eager-load it), sum in memory to avoid a redundant aggregate query.
+        // Sum raw cents via getRawOriginal — the `amount` accessor is cast by
+        // Price to a formatted dollar string, which must not be summed.
+        if ($this->relationLoaded('payments')) {
+            $totalCents = $this->payments
+                ->where('status', 'paid')
+                ->sum(fn ($payment) => (int) $payment->getRawOriginal('amount'));
+            return number_format($totalCents / 100, 2, '.', '');
+        }
+
+        // Otherwise, calculate it from the payments relationship.
         $total = $this->payments()->where('status', 'paid')->sum('amount') / 100;
         return number_format($total, 2, '.', '');
     }

--- a/tests/Feature/Api/Mobile/MeBookingsTest.php
+++ b/tests/Feature/Api/Mobile/MeBookingsTest.php
@@ -308,6 +308,11 @@ class MeBookingsTest extends TestCase
 
         $paid = collect($response->json('bookings'))->firstWhere('name', 'Paid Gig');
         $this->assertSame('450.00', $paid['amount_paid']);
+
+        // The list must not serialize per-payment detail: amount_paid comes
+        // from the withSum aggregate, not an eager-loaded payments relation.
+        // Guards against reintroducing ->with('payments') on the list query.
+        $this->assertSame([], $paid['payments']);
     }
 
     public function test_index_does_not_run_per_booking_payment_query(): void


### PR DESCRIPTION
## Summary

#469 auto-merged at an earlier commit before two Copilot review fixes were applied. This restores them.

1. **Restore the `relationLoaded('payments')` fast-path** in `getAmountPaidAttribute`. `show`/`store`/`update` eager-load `payments` and then read `amount_paid` via the formatter — without this branch, the accessor runs a **redundant aggregate query** against `payments()` even though the rows are already in memory. Sums raw cents via `getRawOriginal` (the `amount` accessor is `Price`-cast to a formatted dollar string, so it must not be summed directly).

2. **Add a payload-guard assertion** that `/api/mobile/me/bookings` keeps `payments == []` in the response — guarding against anyone reintroducing `->with('payments')` on the list query (which `BookingFormatter` would serialize, enlarging the payload and exposing per-payment detail).

Both points were raised by Copilot on #469.

## Tests

26 tests pass across mobile bookings suites; the list-payload guard is now asserted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)