### PR TITLE
fix(payouts): template edges need unique ids to render on web

### DIFF
--- a/app/Services/PayoutFlowService.php
+++ b/app/Services/PayoutFlowService.php
@@ -231,17 +231,24 @@ class PayoutFlowService
             'data' => ['cutType' => 'percentage', 'value' => 10, 'tierConfig' => null, 'deactivated' => false],
         ];
 
-        // Every edge gets a unique id derived from its endpoints + handle. Vue
-        // Flow on web silently drops edges that have no id, so omitting it makes
-        // template connections render on mobile but NOT on web.
-        $edge = fn (string $source, string $sourceHandle, string $target, string $targetHandle) => [
-            'id' => "edge-$source-$sourceHandle-$target-$targetHandle",
-            'source' => $source,
-            'target' => $target,
-            'sourceHandle' => $sourceHandle,
-            'targetHandle' => $targetHandle,
-            'type' => 'custom',
-        ];
+        // Every edge needs a unique id — Vue Flow on web silently drops edges
+        // that lack one, so omitting it makes template connections render on
+        // mobile but NOT on web. A monotonic counter guarantees uniqueness
+        // regardless of node-id/handle contents (a dash-joined descriptive id
+        // could in theory collide when segments themselves contain dashes).
+        $edgeSeq = 0;
+        $edge = function (string $source, string $sourceHandle, string $target, string $targetHandle) use (&$edgeSeq) {
+            $edgeSeq++;
+
+            return [
+                'id' => "tpl-edge-{$edgeSeq}",
+                'source' => $source,
+                'target' => $target,
+                'sourceHandle' => $sourceHandle,
+                'targetHandle' => $targetHandle,
+                'type' => 'custom',
+            ];
+        };
 
         return [
             'blank' => [

--- a/app/Services/PayoutFlowService.php
+++ b/app/Services/PayoutFlowService.php
@@ -231,6 +231,18 @@ class PayoutFlowService
             'data' => ['cutType' => 'percentage', 'value' => 10, 'tierConfig' => null, 'deactivated' => false],
         ];
 
+        // Every edge gets a unique id derived from its endpoints + handle. Vue
+        // Flow on web silently drops edges that have no id, so omitting it makes
+        // template connections render on mobile but NOT on web.
+        $edge = fn (string $source, string $sourceHandle, string $target, string $targetHandle) => [
+            'id' => "edge-$source-$sourceHandle-$target-$targetHandle",
+            'source' => $source,
+            'target' => $target,
+            'sourceHandle' => $sourceHandle,
+            'targetHandle' => $targetHandle,
+            'type' => 'custom',
+        ];
+
         return [
             'blank' => [
                 'name' => 'Blank',
@@ -245,11 +257,9 @@ class PayoutFlowService
                 'description' => 'Everyone splits the income evenly.',
                 'flowDiagram' => [
                     'nodes' => [$income(), $allMembersGroup('group-1')],
-                    'edges' => [[
-                        'source' => 'income-1', 'target' => 'group-1',
-                        'sourceHandle' => 'income-out', 'targetHandle' => 'payoutgroup-in',
-                        'type' => 'custom',
-                    ]],
+                    'edges' => [
+                        $edge('income-1', 'income-out', 'group-1', 'payoutgroup-in'),
+                    ],
                 ],
             ],
             'band_cut_equal' => [
@@ -258,16 +268,8 @@ class PayoutFlowService
                 'flowDiagram' => [
                     'nodes' => [$income(), $bandCut, $allMembersGroup('group-1')],
                     'edges' => [
-                        [
-                            'source' => 'income-1', 'target' => 'cut-1',
-                            'sourceHandle' => 'income-out', 'targetHandle' => 'bandcut-in',
-                            'type' => 'custom',
-                        ],
-                        [
-                            'source' => 'cut-1', 'target' => 'group-1',
-                            'sourceHandle' => 'bandcut-out', 'targetHandle' => 'payoutgroup-in',
-                            'type' => 'custom',
-                        ],
+                        $edge('income-1', 'income-out', 'cut-1', 'bandcut-in'),
+                        $edge('cut-1', 'bandcut-out', 'group-1', 'payoutgroup-in'),
                     ],
                 ],
             ],
@@ -317,21 +319,9 @@ class PayoutFlowService
                         ],
                     ],
                     'edges' => [
-                        [
-                            'source' => 'income-1', 'target' => 'cut-1',
-                            'sourceHandle' => 'income-out', 'targetHandle' => 'bandcut-in',
-                            'type' => 'custom',
-                        ],
-                        [
-                            'source' => 'cut-1', 'target' => 'group-subs',
-                            'sourceHandle' => 'bandcut-out', 'targetHandle' => 'payoutgroup-in',
-                            'type' => 'custom',
-                        ],
-                        [
-                            'source' => 'cut-1', 'target' => 'group-roster',
-                            'sourceHandle' => 'bandcut-out', 'targetHandle' => 'payoutgroup-in',
-                            'type' => 'custom',
-                        ],
+                        $edge('income-1', 'income-out', 'cut-1', 'bandcut-in'),
+                        $edge('cut-1', 'bandcut-out', 'group-subs', 'payoutgroup-in'),
+                        $edge('cut-1', 'bandcut-out', 'group-roster', 'payoutgroup-in'),
                     ],
                 ],
             ],

--- a/tests/Feature/Api/Mobile/PayoutFlowMobileTest.php
+++ b/tests/Feature/Api/Mobile/PayoutFlowMobileTest.php
@@ -202,6 +202,23 @@ class PayoutFlowMobileTest extends TestCase
 
             $errors = $service->collectFlowValidationErrors($flow['nodes'], $flow['edges']);
             $this->assertSame([], $errors, "template $key flow invalid: " . json_encode($errors));
+
+            // Every edge needs a unique, non-empty id and source/target handles —
+            // Vue Flow on web drops edges that lack an id, so without this the
+            // connections render on mobile but not on web.
+            $ids = [];
+            foreach ($flow['edges'] as $edge) {
+                $this->assertArrayHasKey('id', $edge, "template $key edge missing id");
+                $this->assertNotEmpty($edge['id'], "template $key edge has empty id");
+                $this->assertArrayHasKey('sourceHandle', $edge, "template $key edge missing sourceHandle");
+                $this->assertArrayHasKey('targetHandle', $edge, "template $key edge missing targetHandle");
+                $ids[] = $edge['id'];
+            }
+            $this->assertSame(
+                count($ids),
+                count(array_unique($ids)),
+                "template $key has duplicate edge ids",
+            );
         }
     }
 


### PR DESCRIPTION
## Problem
A payout config created from a starter template showed its connections **on mobile but not on web**. Root cause: the template `flow_diagram`s emitted edges with `{source, target, sourceHandle, targetHandle, type}` but **no `id`**. Vue Flow on web silently drops edges that lack an `id` (mobile's renderer is more lenient), so the connections never drew on web.

## Fix
Added an `$edge(source, sourceHandle, target, targetHandle)` helper in `PayoutFlowService::configTemplates()` that derives a unique `id` (`edge-{source}-{sourceHandle}-{target}-{targetHandle}`) for every edge, and replaced the six inline edge literals with it. The two fan-out edges in `roster_sub_pay` (both `cut-1 → payoutgroup-in`) stay unique because the id includes the target.

The template-validity test now asserts every edge has a unique, non-empty `id` plus source/target handles — so this can't regress.

## Note
Existing configs already created from templates (before this fix) still have id-less edges; this only fixes newly-created ones. If any were created on the deployed env, they'd need re-creating (or a one-off backfill) to render on web.

## Tests
Full `PayoutFlow` suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)