### PR TITLE
feat(payouts): delete payout config (mobile API)

### DIFF
--- a/app/Http/Controllers/Api/Mobile/PayoutFlowController.php
+++ b/app/Http/Controllers/Api/Mobile/PayoutFlowController.php
@@ -129,6 +129,18 @@ class PayoutFlowController extends Controller
     }
 
     /**
+     * DELETE /api/mobile/bands/{band}/payout-flow/configs/{configId}
+     * Delete a config (owner-only). The mobile UI blocks deleting the active
+     * config; there is intentionally no server-side active-guard (mirrors web).
+     */
+    public function destroyConfig(Bands $band, int $configId): JsonResponse
+    {
+        $this->findConfig($band->id, $configId)->delete();
+
+        return response()->json(null, 204);
+    }
+
+    /**
      * POST /api/mobile/bands/{band}/payout-flow/preview
      * Preview a payout calculation for a flow + test amount (no persistence).
      */

--- a/routes/api.php
+++ b/routes/api.php
@@ -272,6 +272,7 @@ Route::prefix('mobile')->group(function () {
         Route::middleware('owner')->group(function () {
             Route::post('/bands/{band}/payout-flow/configs', [App\Http\Controllers\Api\Mobile\PayoutFlowController::class, 'createConfig'])->name('mobile.payout-flow.configs.create');
             Route::patch('/bands/{band}/payout-flow/configs/{configId}', [App\Http\Controllers\Api\Mobile\PayoutFlowController::class, 'updateConfig'])->name('mobile.payout-flow.configs.update');
+            Route::delete('/bands/{band}/payout-flow/configs/{configId}', [App\Http\Controllers\Api\Mobile\PayoutFlowController::class, 'destroyConfig'])->name('mobile.payout-flow.configs.destroy');
         });
 
         // ── Rehearsals (read) ──────────────────────────────────────────

--- a/tests/Feature/Api/Mobile/PayoutFlowMobileTest.php
+++ b/tests/Feature/Api/Mobile/PayoutFlowMobileTest.php
@@ -297,4 +297,43 @@ class PayoutFlowMobileTest extends TestCase
                 'name' => 'X', 'template' => 'blank',
             ])->assertForbidden();
     }
+
+    public function test_owner_can_delete_config(): void
+    {
+        $config = BandPayoutConfig::create([
+            'band_id' => $this->band->id,
+            'name' => 'To delete',
+            'is_active' => false,
+            'flow_diagram' => ['nodes' => [['id' => 'income-1', 'type' => 'income', 'data' => ['amount' => 0]]], 'edges' => []],
+        ]);
+
+        $this->withHeaders($this->headers($this->ownerToken))
+            ->deleteJson("/api/mobile/bands/{$this->band->id}/payout-flow/configs/{$config->id}")
+            ->assertNoContent();
+
+        $this->assertDatabaseMissing('band_payout_configs', ['id' => $config->id]);
+    }
+
+    public function test_delete_unknown_config_returns_404(): void
+    {
+        $this->withHeaders($this->headers($this->ownerToken))
+            ->deleteJson("/api/mobile/bands/{$this->band->id}/payout-flow/configs/999999")
+            ->assertNotFound();
+    }
+
+    public function test_non_owner_cannot_delete_config(): void
+    {
+        $config = BandPayoutConfig::create([
+            'band_id' => $this->band->id,
+            'name' => 'Keep',
+            'is_active' => false,
+            'flow_diagram' => ['nodes' => [['id' => 'income-1', 'type' => 'income', 'data' => ['amount' => 0]]], 'edges' => []],
+        ]);
+
+        $this->withHeaders($this->headers($this->memberToken))
+            ->deleteJson("/api/mobile/bands/{$this->band->id}/payout-flow/configs/{$config->id}")
+            ->assertForbidden();
+
+        $this->assertDatabaseHas('band_payout_configs', ['id' => $config->id]);
+    }
 }


### PR DESCRIPTION
**Draft** — staging auto-deploys on merge; un-draft when ready.

Adds `DELETE /api/mobile/bands/{band}/payout-flow/configs/{configId}` → `destroyConfig` (owner-gated): find-or-404, delete, 204.

No server-side active-config guard — the **mobile UI** blocks deleting the active config (only offers Delete for inactive ones). This mirrors web's `deletePayoutConfig`, which also has no guard.

## Tests
`PayoutFlow` suite green, incl.:
- owner deletes → 204, row gone from DB
- unknown id → 404
- non-owner → 403, config untouched

Pairs with the mobile delete UI (TTS-App).

🤖 Generated with [Claude Code](https://claude.com/claude-code)