### PR TITLE
feat(mobile): dashboard past events + load-older endpoint

### DIFF
--- a/app/Http/Controllers/Api/Mobile/DashboardController.php
+++ b/app/Http/Controllers/Api/Mobile/DashboardController.php
@@ -7,10 +7,14 @@ use App\Services\Mobile\DashboardFormatter;
 use App\Services\UserEventsService;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
+use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Auth;
 
 class DashboardController extends Controller
 {
+    /** Days of past events to include in the initial dashboard payload. */
+    private const INITIAL_PAST_WINDOW_DAYS = 30;
+
     public function __construct(private readonly DashboardFormatter $formatter) {}
 
     public function index(Request $request): JsonResponse
@@ -23,7 +27,10 @@ class DashboardController extends Controller
         // firing login events.
         Auth::setUser($user);
 
-        $events         = (new UserEventsService())->getEvents();
+        // Mobile shows a calendar (not the web feed), so include the recent past.
+        $afterDate = Carbon::now()->subDays(self::INITIAL_PAST_WINDOW_DAYS);
+
+        $events         = (new UserEventsService())->getEvents($afterDate);
         $upcomingCharts = (new UserEventsService())->getUpcomingCharts();
 
         $collection = $events instanceof \Illuminate\Support\Collection
@@ -37,6 +44,34 @@ class DashboardController extends Controller
             'upcoming_charts' => $upcomingCharts instanceof \Illuminate\Support\Collection
                 ? $upcomingCharts->values()
                 : collect($upcomingCharts)->values(),
+        ]);
+    }
+
+    /**
+     * Load an older 30-day window of events for the calendar's lazy back-fetch.
+     * Mirrors the web DashboardController::loadOlderEvents pattern.
+     */
+    public function loadOlder(Request $request): JsonResponse
+    {
+        $beforeDateInput = $request->input('before_date');
+
+        if (! $beforeDateInput) {
+            return response()->json(['events' => []]);
+        }
+
+        Auth::setUser($request->user());
+
+        $beforeDate = Carbon::parse($beforeDateInput);
+        $afterDate  = $beforeDate->copy()->subDays(30);
+
+        $events = (new UserEventsService())->getEvents($afterDate, $beforeDate);
+
+        $collection = $events instanceof \Illuminate\Support\Collection
+            ? $events
+            : collect($events);
+
+        return response()->json([
+            'events' => $this->formatter->formatEvents($collection),
         ]);
     }
 }

--- a/routes/api.php
+++ b/routes/api.php
@@ -89,6 +89,7 @@ Route::prefix('mobile')->group(function () {
 
         // Dashboard
         Route::get('/dashboard', [App\Http\Controllers\Api\Mobile\DashboardController::class, 'index'])->name('mobile.dashboard');
+        Route::get('/dashboard/load-older', [App\Http\Controllers\Api\Mobile\DashboardController::class, 'loadOlder'])->name('mobile.dashboard.load-older');
 
         // Aggregating charts across all of the user's bands (band-agnostic).
         Route::get('/charts', [App\Http\Controllers\Api\Mobile\MusicController::class, 'chartsForUser'])->name('mobile.charts.for-user');

--- a/tests/Feature/Api/Mobile/DashboardTest.php
+++ b/tests/Feature/Api/Mobile/DashboardTest.php
@@ -155,4 +155,75 @@ class DashboardTest extends TestCase
             'sub-only user must see their assigned event on the mobile dashboard',
         );
     }
+
+    public function test_dashboard_includes_events_from_the_past_30_days(): void
+    {
+        $user = User::factory()->create();
+        $band = Bands::factory()->create();
+        $band->owners()->create(['user_id' => $user->id]);
+
+        $eventType = EventTypes::factory()->create();
+        $booking = Bookings::factory()->create(['band_id' => $band->id]);
+        Events::factory()->create([
+            'eventable_id'   => $booking->id,
+            'eventable_type' => 'App\\Models\\Bookings',
+            'event_type_id'  => $eventType->id,
+            'date'           => now()->subDays(10)->format('Y-m-d'),
+        ]);
+
+        $token = $user->createToken('test-device')->plainTextToken;
+
+        $response = $this->withToken($token)->getJson('/api/mobile/dashboard');
+
+        $response->assertOk();
+        $this->assertCount(1, $response->json('events'), 'expected the 10-day-old event in the past-30d window');
+    }
+
+    public function test_load_older_returns_events_in_the_requested_past_window(): void
+    {
+        $user = User::factory()->create();
+        $band = Bands::factory()->create();
+        $band->owners()->create(['user_id' => $user->id]);
+
+        $eventType = EventTypes::factory()->create();
+        $booking = Bookings::factory()->create(['band_id' => $band->id]);
+        // 45 days ago: outside the initial 30d window, inside the load-older window.
+        Events::factory()->create([
+            'eventable_id'   => $booking->id,
+            'eventable_type' => 'App\\Models\\Bookings',
+            'event_type_id'  => $eventType->id,
+            'date'           => now()->subDays(45)->format('Y-m-d'),
+        ]);
+
+        $token = $user->createToken('test-device')->plainTextToken;
+
+        // Initial dashboard (30d window) must NOT include the 45-day-old event.
+        $initial = $this->withToken($token)->getJson('/api/mobile/dashboard');
+        $initial->assertOk();
+        $this->assertCount(0, $initial->json('events'));
+
+        // load-older with before_date = now-30d should reach back to now-60d and find it.
+        $before = now()->subDays(30)->toDateString();
+        $older = $this->withToken($token)->getJson("/api/mobile/dashboard/load-older?before_date={$before}");
+
+        $older->assertOk()->assertJsonStructure(['events']);
+        $this->assertCount(1, $older->json('events'), 'expected the 45-day-old event in the load-older window');
+    }
+
+    public function test_load_older_returns_empty_when_before_date_missing(): void
+    {
+        $user = User::factory()->create();
+        $token = $user->createToken('test-device')->plainTextToken;
+
+        $response = $this->withToken($token)->getJson('/api/mobile/dashboard/load-older');
+
+        $response->assertOk();
+        $this->assertSame([], $response->json('events'));
+    }
+
+    public function test_load_older_requires_authentication(): void
+    {
+        $this->getJson('/api/mobile/dashboard/load-older?before_date=2026-01-01')
+            ->assertUnauthorized();
+    }
 }


### PR DESCRIPTION
## Summary
- Widen the mobile dashboard's initial event window to the past **30 days** (was `now − 72h`), since the mobile dashboard is a calendar (the web feed dashboard is unchanged).
- Add `GET /api/mobile/dashboard/load-older?before_date=<iso>` returning events in `[before_date − 30d, before_date)`, mirroring the existing web `DashboardController::loadOlderEvents` pattern. The Flutter calendar calls this when the user swipes back in time.
- Reuses `UserEventsService::getEvents($afterDate, $beforeDate)` and the mobile `DashboardFormatter`, so sub/band visibility and JSON shape are unchanged.

## Test Plan
- [x] `php artisan test --filter=DashboardTest` — 9 passed (5 pre-existing + 4 new)
- [x] New tests cover: past-30d window inclusion, load-older returns the requested past window (and excludes it from the initial payload), missing `before_date` returns `{events: []}`, load-older requires auth
- [ ] Draft so staging does not auto-deploy until the paired mobile app PR is ready

🤖 Generated with [Claude Code](https://claude.com/claude-code)