### PR TITLE
feat(mobile-api): band finances revenue endpoint

### DIFF
--- a/app/Http/Controllers/Api/Mobile/FinancesController.php
+++ b/app/Http/Controllers/Api/Mobile/FinancesController.php
@@ -7,6 +7,7 @@ use App\Http\Requests\Mobile\FinanceYearRequest;
 use App\Services\FinanceServices;
 use App\Services\Mobile\BookingFormatter;
 use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
 
 class FinancesController extends Controller
 {
@@ -87,7 +88,7 @@ class FinancesController extends Controller
      * the band. Amounts are in cents. Payments without a date (e.g. pending
      * invoices) are excluded.
      */
-    public function revenue(\Illuminate\Http\Request $request): JsonResponse
+    public function revenue(Request $request): JsonResponse
     {
         $band = $request->input('mobile_band');
 

--- a/app/Http/Controllers/Api/Mobile/FinancesController.php
+++ b/app/Http/Controllers/Api/Mobile/FinancesController.php
@@ -79,4 +79,27 @@ class FinancesController extends Controller
             'bookings' => $paid->map(fn ($b) => $this->formatter->formatForFinance($b))->values(),
         ]);
     }
+
+    /**
+     * GET /api/mobile/bands/{band}/finances/revenue
+     *
+     * Returns total recorded revenue grouped by year (newest first), scoped to
+     * the band. Amounts are in cents. Payments without a date (e.g. pending
+     * invoices) are excluded.
+     */
+    public function revenue(\Illuminate\Http\Request $request): JsonResponse
+    {
+        $band = $request->input('mobile_band');
+
+        $revenue = $band->paymentsByYear()
+            ->whereNotNull('date')
+            ->get()
+            ->map(fn ($row) => [
+                'year'  => (int) $row->year,
+                'total' => (int) $row->total,
+            ])
+            ->values();
+
+        return response()->json(['revenue' => $revenue]);
+    }
 }

--- a/routes/api.php
+++ b/routes/api.php
@@ -259,6 +259,7 @@ Route::prefix('mobile')->group(function () {
             Route::get('/bands/{band}/finances', [App\Http\Controllers\Api\Mobile\FinancesController::class, 'index'])->name('mobile.finances.index');
             Route::get('/bands/{band}/finances/unpaid', [App\Http\Controllers\Api\Mobile\FinancesController::class, 'unpaid'])->name('mobile.finances.unpaid');
             Route::get('/bands/{band}/finances/paid', [App\Http\Controllers\Api\Mobile\FinancesController::class, 'paid'])->name('mobile.finances.paid');
+            Route::get('/bands/{band}/finances/revenue', [App\Http\Controllers\Api\Mobile\FinancesController::class, 'revenue'])->name('mobile.finances.revenue');
         });
 
         // ── Payout flow editor: reads + preview (band member) ──────────

--- a/tests/Feature/Api/Mobile/FinanceRevenueTest.php
+++ b/tests/Feature/Api/Mobile/FinanceRevenueTest.php
@@ -1,0 +1,123 @@
+<?php
+
+namespace Tests\Feature\Api\Mobile;
+
+use App\Models\BandMembers;
+use App\Models\Bands;
+use App\Models\Bookings;
+use App\Models\Payments;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class FinanceRevenueTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected User $member;
+    protected Bands $band;
+    protected string $memberToken;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->member = User::factory()->create();
+        $this->band = Bands::factory()->create();
+
+        // Band member with the read:bookings ability — the finances routes are
+        // gated by `mobile.band:read:bookings`.
+        BandMembers::create(['band_id' => $this->band->id, 'user_id' => $this->member->id]);
+        $this->memberToken = $this->member
+            ->createToken('test-device', ['read:bookings'])
+            ->plainTextToken;
+    }
+
+    private function headers(string $token, ?int $bandId = null): array
+    {
+        return [
+            'Authorization' => "Bearer {$token}",
+            'X-Band-ID' => $bandId ?? $this->band->id,
+            'Accept' => 'application/json',
+        ];
+    }
+
+    /**
+     * Create a payment on a band. $dollars is multiplied by 100 by the Price
+     * cast, so $dollars=1500 is stored as 150000 cents.
+     */
+    private function payment(Bands $band, ?int $dollars, ?string $date): Payments
+    {
+        $booking = Bookings::factory()->for($band, 'band')->create();
+
+        return Payments::factory()->create([
+            'band_id' => $band->id,
+            'payable_type' => Bookings::class,
+            'payable_id' => $booking->id,
+            'amount' => $dollars,
+            'date' => $date,
+        ]);
+    }
+
+    public function test_returns_revenue_grouped_by_year_in_cents(): void
+    {
+        // 2026: 150000 + 50000 = 200000 cents
+        $this->payment($this->band, 1500, '2026-03-01');
+        $this->payment($this->band, 500, '2026-09-15');
+        // 2025: 98000 cents
+        $this->payment($this->band, 980, '2025-07-04');
+
+        $res = $this->withHeaders($this->headers($this->memberToken))
+            ->getJson("/api/mobile/bands/{$this->band->id}/finances/revenue");
+
+        $res->assertOk();
+        $this->assertSame(
+            [
+                ['year' => 2026, 'total' => 200000],
+                ['year' => 2025, 'total' => 98000],
+            ],
+            $res->json('revenue'),
+        );
+    }
+
+    public function test_excludes_payments_with_null_date(): void
+    {
+        $this->payment($this->band, 100, '2026-01-01');   // 10000 cents
+        $this->payment($this->band, 999, null);            // pending, no date
+
+        $res = $this->withHeaders($this->headers($this->memberToken))
+            ->getJson("/api/mobile/bands/{$this->band->id}/finances/revenue");
+
+        $res->assertOk();
+        $revenue = $res->json('revenue');
+        $this->assertCount(1, $revenue);
+        $this->assertSame([['year' => 2026, 'total' => 10000]], $revenue);
+    }
+
+    public function test_scopes_to_requested_band_only(): void
+    {
+        $other = Bands::factory()->create();
+
+        $this->payment($this->band, 100, '2026-01-01');  // 10000 cents
+        $this->payment($other, 700, '2026-01-01');       // belongs to a different band
+
+        $res = $this->withHeaders($this->headers($this->memberToken))
+            ->getJson("/api/mobile/bands/{$this->band->id}/finances/revenue");
+
+        $res->assertOk();
+        $this->assertSame([['year' => 2026, 'total' => 10000]], $res->json('revenue'));
+    }
+
+    public function test_requires_band_access(): void
+    {
+        // A user with the read:bookings ability but NO membership of $this->band.
+        $stranger = User::factory()->create();
+        $strangerToken = $stranger
+            ->createToken('test-device', ['read:bookings'])
+            ->plainTextToken;
+
+        $this->withHeaders($this->headers($strangerToken))
+            ->getJson("/api/mobile/bands/{$this->band->id}/finances/revenue")
+            ->assertForbidden();
+    }
+}


### PR DESCRIPTION
Adds `GET /api/mobile/bands/{band}/finances/revenue` for the new mobile Finances → Revenue tab.

## What
- New `revenue()` method on `Api/Mobile/FinancesController`, registered in the existing `mobile.band:read:bookings` route group as `mobile.finances.revenue`.
- Returns `{"revenue": [{"year": <int>, "total": <int cents>}, ...]}` grouped by year, newest-first, scoped to the band.
- Wraps the existing `Bands::paymentsByYear()` aggregation with a `whereNotNull('date')` guard so pending invoices (null date → NULL year group) are excluded.

## Tests
`tests/Feature/Api/Mobile/FinanceRevenueTest.php` — 4 cases: grouped-by-year in cents, null-date exclusion, band scoping, and access control (non-member → 403).

🤖 Generated with [Claude Code](https://claude.com/claude-code)