### PR TITLE
feat(mobile-api): band finances trends endpoint

### DIFF
--- a/app/Http/Controllers/Api/Mobile/FinancesController.php
+++ b/app/Http/Controllers/Api/Mobile/FinancesController.php
@@ -103,4 +103,83 @@ class FinancesController extends Controller
 
         return response()->json(['revenue' => $revenue]);
     }
+
+    /**
+     * GET /api/mobile/bands/{band}/finances/trends
+     *
+     * Per-month paid/unpaid/forecast/net/count for a year (cents), scoped to the
+     * band. Optional ?snapshot_date=Y-m-d limits the primary series to bookings
+     * created on/before that date; ?compare_with_current=1 (only with a snapshot)
+     * additionally returns the current (unfiltered) series as current_months.
+     */
+    public function trends(Request $request): JsonResponse
+    {
+        $band = $request->input('mobile_band');
+        $year = $request->integer('year') ?: (int) date('Y');
+        $snapshotDate = $request->input('snapshot_date');
+        $compare = $request->boolean('compare_with_current');
+
+        $months = $this->bucketByMonth($band, $year, $snapshotDate);
+
+        $payload = [
+            'year' => $year,
+            'snapshot_date' => $snapshotDate,
+            'available_years' => $this->availableYears($band),
+            'months' => $months,
+        ];
+
+        if ($compare && $snapshotDate) {
+            $payload['current_months'] = $this->bucketByMonth($band, $year, null);
+        }
+
+        return response()->json($payload);
+    }
+
+    private function bucketByMonth($band, int $year, ?string $snapshotDate): array
+    {
+        $bands = $this->financeServices->getPaidUnpaid([$band], $snapshotDate);
+        $b = $bands->first();
+        $bookings = collect($b->paidBookings)->concat(collect($b->unpaidBookings));
+
+        $rows = [];
+        for ($m = 1; $m <= 12; $m++) {
+            $rows[$m] = ['month' => $m, 'paid' => 0.0, 'unpaid' => 0.0, 'forecast' => 0.0, 'net' => 0.0, 'count' => 0];
+        }
+
+        foreach ($bookings as $booking) {
+            if (($booking->status ?? null) === 'cancelled') continue;
+            if (empty($booking->start_date)) continue;
+            $date = \Carbon\Carbon::parse($booking->start_date);
+            if ((int) $date->year !== $year) continue;
+            $m = (int) $date->month;
+            $price = (float) $booking->price;
+            $paid = (float) $booking->amount_paid;
+            $net = (float) ($booking->net_amount ?? 0);
+            $rows[$m]['forecast'] += $price;
+            $rows[$m]['paid'] += $paid;
+            $rows[$m]['unpaid'] += max(0, $price - $paid);
+            $rows[$m]['net'] += $net;
+            $rows[$m]['count'] += 1;
+        }
+
+        return array_values(array_map(fn ($r) => [
+            'month' => $r['month'],
+            'paid' => (int) round($r['paid'] * 100),
+            'unpaid' => (int) round($r['unpaid'] * 100),
+            'forecast' => (int) round($r['forecast'] * 100),
+            'net' => (int) round($r['net'] * 100),
+            'count' => $r['count'],
+        ], $rows));
+    }
+
+    private function availableYears($band): array
+    {
+        $bands = $this->financeServices->getPaidUnpaid([$band], null);
+        $b = $bands->first();
+        $bookings = collect($b->paidBookings)->concat(collect($b->unpaidBookings));
+        return $bookings
+            ->filter(fn ($bk) => ($bk->status ?? null) !== 'cancelled' && !empty($bk->start_date))
+            ->map(fn ($bk) => (int) \Carbon\Carbon::parse($bk->start_date)->year)
+            ->unique()->sortDesc()->values()->all();
+    }
 }

--- a/routes/api.php
+++ b/routes/api.php
@@ -260,6 +260,7 @@ Route::prefix('mobile')->group(function () {
             Route::get('/bands/{band}/finances/unpaid', [App\Http\Controllers\Api\Mobile\FinancesController::class, 'unpaid'])->name('mobile.finances.unpaid');
             Route::get('/bands/{band}/finances/paid', [App\Http\Controllers\Api\Mobile\FinancesController::class, 'paid'])->name('mobile.finances.paid');
             Route::get('/bands/{band}/finances/revenue', [App\Http\Controllers\Api\Mobile\FinancesController::class, 'revenue'])->name('mobile.finances.revenue');
+            Route::get('/bands/{band}/finances/trends', [App\Http\Controllers\Api\Mobile\FinancesController::class, 'trends'])->name('mobile.finances.trends');
         });
 
         // ── Payout flow editor: reads + preview (band member) ──────────

--- a/tests/Feature/Api/Mobile/FinanceTrendsTest.php
+++ b/tests/Feature/Api/Mobile/FinanceTrendsTest.php
@@ -1,0 +1,244 @@
+<?php
+
+namespace Tests\Feature\Api\Mobile;
+
+use App\Models\BandMembers;
+use App\Models\BandPayoutConfig;
+use App\Models\Bands;
+use App\Models\Bookings;
+use App\Models\Events;
+use App\Models\Payments;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class FinanceTrendsTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected User $member;
+    protected Bands $band;
+    protected string $memberToken;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->member = User::factory()->create();
+        $this->band = Bands::factory()->create();
+
+        // Band member with the read:bookings ability — the finances routes are
+        // gated by `mobile.band:read:bookings`.
+        BandMembers::create(['band_id' => $this->band->id, 'user_id' => $this->member->id]);
+        $this->memberToken = $this->member
+            ->createToken('test-device', ['read:bookings'])
+            ->plainTextToken;
+
+        // Active percentage payout config so net_amount (band cut) is populated.
+        BandPayoutConfig::create([
+            'band_id' => $this->band->id,
+            'name' => 'Default',
+            'is_active' => true,
+            'band_cut_type' => 'percentage',
+            'band_cut_value' => 50,
+        ]);
+    }
+
+    private function headers(string $token, ?int $bandId = null): array
+    {
+        return [
+            'Authorization' => "Bearer {$token}",
+            'X-Band-ID' => $bandId ?? $this->band->id,
+            'Accept' => 'application/json',
+        ];
+    }
+
+    /**
+     * Create a booking on a band with a known price (dollars), a primary event
+     * on $eventDate (drives start_date), and optional fully/partially paid state.
+     *
+     * @param  int    $priceDollars  Dollar price; stored as cents by the Price cast.
+     * @param  int    $paidDollars   Dollars paid; a single 'paid' payment is recorded.
+     */
+    private function booking(
+        Bands $band,
+        int $priceDollars,
+        string $eventDate,
+        int $paidDollars = 0,
+        string $status = 'confirmed',
+        ?string $createdAt = null,
+    ): Bookings {
+        $booking = Bookings::factory()->for($band, 'band')->create([
+            'price' => $priceDollars,
+            'status' => $status,
+        ]);
+
+        if ($createdAt !== null) {
+            $booking->forceFill(['created_at' => $createdAt])->save();
+        }
+
+        // Primary event drives the derived start_date accessor (first event date).
+        Events::factory()->forBand($band)->create([
+            'eventable_type' => Bookings::class,
+            'eventable_id' => $booking->id,
+            'date' => $eventDate,
+        ]);
+
+        if ($paidDollars > 0) {
+            Payments::factory()->create([
+                'band_id' => $band->id,
+                'payable_type' => Bookings::class,
+                'payable_id' => $booking->id,
+                'amount' => $paidDollars,
+                'status' => 'paid',
+                'date' => $eventDate,
+            ]);
+        }
+
+        return $booking->refresh();
+    }
+
+    public function test_buckets_by_month_in_cents_and_excludes_cancelled(): void
+    {
+        // $1500 fully paid in March 2026 → paid = 150000 cents, net = 50% = 75000.
+        $this->booking($this->band, 1500, '2026-03-10', paidDollars: 1500);
+        // $2000 unpaid in July 2026 → forecast/unpaid = 200000 cents, net = 100000.
+        $this->booking($this->band, 2000, '2026-07-04', paidDollars: 0);
+        // Cancelled booking that must be excluded entirely.
+        $this->booking($this->band, 9999, '2026-05-01', paidDollars: 0, status: 'cancelled');
+
+        $res = $this->withHeaders($this->headers($this->memberToken))
+            ->getJson("/api/mobile/bands/{$this->band->id}/finances/trends?year=2026");
+
+        $res->assertOk();
+        $res->assertJsonPath('year', 2026);
+        $res->assertJsonCount(12, 'months');
+
+        // March (index 2): fully paid $1500.
+        $res->assertJsonPath('months.2.month', 3);
+        $res->assertJsonPath('months.2.paid', 150000);
+        $res->assertJsonPath('months.2.unpaid', 0);
+        $res->assertJsonPath('months.2.forecast', 150000);
+        $res->assertJsonPath('months.2.net', 75000);
+        $res->assertJsonPath('months.2.count', 1);
+
+        // July (index 6): $2000 unpaid.
+        $res->assertJsonPath('months.6.month', 7);
+        $res->assertJsonPath('months.6.paid', 0);
+        $res->assertJsonPath('months.6.unpaid', 200000);
+        $res->assertJsonPath('months.6.forecast', 200000);
+        $res->assertJsonPath('months.6.net', 100000);
+        $res->assertJsonPath('months.6.count', 1);
+
+        // May (index 4): cancelled booking excluded → zero-filled.
+        $res->assertJsonPath('months.4.count', 0);
+        $res->assertJsonPath('months.4.forecast', 0);
+
+        // January (index 0): nothing → zero-filled.
+        $res->assertJsonPath('months.0.month', 1);
+        $res->assertJsonPath('months.0.count', 0);
+        $res->assertJsonPath('months.0.paid', 0);
+    }
+
+    public function test_available_years_lists_distinct_booking_years_descending(): void
+    {
+        $this->booking($this->band, 1000, '2024-02-01', paidDollars: 1000);
+        $this->booking($this->band, 1000, '2026-02-01', paidDollars: 0);
+        $this->booking($this->band, 1000, '2025-08-01', paidDollars: 0);
+        // Duplicate year should collapse.
+        $this->booking($this->band, 1000, '2026-11-01', paidDollars: 0);
+
+        // available_years is independent of the ?year filter.
+        $res = $this->withHeaders($this->headers($this->memberToken))
+            ->getJson("/api/mobile/bands/{$this->band->id}/finances/trends?year=2024");
+
+        $res->assertOk();
+        $this->assertSame([2026, 2025, 2024], $res->json('available_years'));
+    }
+
+    public function test_snapshot_date_limits_primary_series_by_created_at(): void
+    {
+        // Booking created before the snapshot → included in months.
+        $this->booking(
+            $this->band,
+            1000,
+            '2026-04-01',
+            paidDollars: 1000,
+            createdAt: '2026-01-15 00:00:00',
+        );
+        // Booking created AFTER the snapshot → excluded from snapshot months,
+        // but present in current_months when comparing.
+        $this->booking(
+            $this->band,
+            3000,
+            '2026-06-01',
+            paidDollars: 0,
+            createdAt: '2026-09-20 00:00:00',
+        );
+
+        $res = $this->withHeaders($this->headers($this->memberToken))
+            ->getJson("/api/mobile/bands/{$this->band->id}/finances/trends?year=2026&snapshot_date=2026-02-01&compare_with_current=1");
+
+        $res->assertOk();
+        $res->assertJsonPath('snapshot_date', '2026-02-01');
+
+        // April booking is in the snapshot series; June booking is not.
+        $res->assertJsonPath('months.3.paid', 100000);
+        $res->assertJsonPath('months.3.count', 1);
+        $res->assertJsonPath('months.5.count', 0);
+        $res->assertJsonPath('months.5.forecast', 0);
+
+        // current_months (unfiltered) includes the later June booking.
+        $res->assertJsonPath('current_months.5.count', 1);
+        $res->assertJsonPath('current_months.5.forecast', 300000);
+        $res->assertJsonPath('current_months.3.count', 1);
+    }
+
+    public function test_compare_without_snapshot_omits_current_months(): void
+    {
+        $this->booking($this->band, 1000, '2026-04-01', paidDollars: 1000);
+
+        $res = $this->withHeaders($this->headers($this->memberToken))
+            ->getJson("/api/mobile/bands/{$this->band->id}/finances/trends?year=2026&compare_with_current=1");
+
+        $res->assertOk();
+        $this->assertNull($res->json('current_months'));
+    }
+
+    public function test_scopes_to_requested_band_only(): void
+    {
+        $other = Bands::factory()->create();
+        BandPayoutConfig::create([
+            'band_id' => $other->id,
+            'name' => 'Other',
+            'is_active' => true,
+            'band_cut_type' => 'percentage',
+            'band_cut_value' => 50,
+        ]);
+
+        $this->booking($this->band, 1000, '2026-04-01', paidDollars: 1000);
+        // Belongs to a different band — must not leak.
+        $this->booking($other, 5000, '2026-04-01', paidDollars: 5000);
+
+        $res = $this->withHeaders($this->headers($this->memberToken))
+            ->getJson("/api/mobile/bands/{$this->band->id}/finances/trends?year=2026");
+
+        $res->assertOk();
+        // April carries only this band's $1000 booking.
+        $res->assertJsonPath('months.3.paid', 100000);
+        $res->assertJsonPath('months.3.count', 1);
+    }
+
+    public function test_requires_band_access(): void
+    {
+        // A user with the read:bookings ability but NO membership of $this->band.
+        $stranger = User::factory()->create();
+        $strangerToken = $stranger
+            ->createToken('test-device', ['read:bookings'])
+            ->plainTextToken;
+
+        $this->withHeaders($this->headers($strangerToken))
+            ->getJson("/api/mobile/bands/{$this->band->id}/finances/trends?year=2026")
+            ->assertForbidden();
+    }
+}


### PR DESCRIPTION
Adds `GET /api/mobile/bands/{band}/finances/trends` for the new mobile Finances → **Trends** tab — a per-month chart with time travel.

## What
- New `trends()` on `Api/Mobile/FinancesController` (+ `bucketByMonth`/`availableYears` helpers), registered as `mobile.finances.trends` in the existing `mobile.band:read:bookings` group.
- Returns 12 zero-filled month rows of `{paid, unpaid, forecast, net, count}` in **cents**, scoped to the band, plus `available_years`.
- `?snapshot_date=Y-m-d` filters the primary series by booking `created_at` (true time travel); `?compare_with_current=1` (with a snapshot) adds `current_months`.
- Reuses the existing snapshot-aware `FinanceServices::getPaidUnpaid($band, $snapshotDate)` + `addNetAmount`; buckets by `start_date` (first event date), excludes cancelled bookings.

## Tests
`tests/Feature/Api/Mobile/FinanceTrendsTest.php` — 6 cases (37 assertions): month bucketing in cents + cancelled exclusion, `available_years`, snapshot `created_at` filtering, compare-without-snapshot omission, band scoping, 403 access control.

🤖 Generated with [Claude Code](https://claude.com/claude-code)