### PR TITLE
fix(mobile-api): emit real rehearsal id on dashboard so detail route resolves

### DIFF
--- a/app/Services/Mobile/DashboardFormatter.php
+++ b/app/Services/Mobile/DashboardFormatter.php
@@ -86,8 +86,18 @@ class DashboardFormatter
             $time = substr($time, 0, 5);
         }
 
+        // For real rehearsals the dashboard query selects events.id as `id`, but
+        // the mobile /rehearsals/{id} route resolves App\Models\Rehearsal by its
+        // own primary key — which is events.eventable_id, NOT events.id. Emitting
+        // events.id here makes the detail lookup 404. Virtual rehearsals
+        // (event_source "rehearsal_schedule") have no real row yet, so they keep a
+        // null id and the app navigates them by key.
+        $id = ($source === 'rehearsal')
+            ? ($e['eventable_id'] ?? $e['id'] ?? null)
+            : ($e['id'] ?? null);
+
         return [
-            'id'              => $e['id'] ?? null,
+            'id'              => $id,
             'key'             => $e['key'] ?? null,
             'title'           => $e['title'] ?? $e['booking_name'] ?? 'Untitled',
             'date'            => $date,

--- a/tests/Feature/Api/Mobile/DashboardTest.php
+++ b/tests/Feature/Api/Mobile/DashboardTest.php
@@ -226,4 +226,64 @@ class DashboardTest extends TestCase
         $this->getJson('/api/mobile/dashboard/load-older?before_date=2026-01-01')
             ->assertUnauthorized();
     }
+
+    /**
+     * Regression: a real rehearsal on the dashboard must carry an `id` that
+     * resolves at /api/mobile/rehearsals/{id}. The bug emitted events.id, which
+     * 404'd as "No query results for model [App\Models\Rehearsal]".
+     */
+    public function test_dashboard_rehearsal_id_resolves_against_the_detail_route(): void
+    {
+        $user = User::factory()->create();
+        $band = Bands::factory()->create();
+        $band->owners()->create(['user_id' => $user->id]);
+
+        $eventType = EventTypes::factory()->create();
+
+        // Create a decoy event first so the rehearsal's event row gets a HIGHER
+        // events.id than the rehearsals.id — otherwise both would be 1 and the
+        // test couldn't tell which key the payload echoed (the original bug
+        // emitted events.id).
+        $decoyBooking = Bookings::factory()->create(['band_id' => $band->id]);
+        Events::factory()->create([
+            'eventable_id'   => $decoyBooking->id,
+            'eventable_type' => 'App\\Models\\Bookings',
+            'event_type_id'  => $eventType->id,
+            'date'           => now()->addDays(3)->format('Y-m-d'),
+        ]);
+
+        $schedule = \App\Models\RehearsalSchedule::factory()->weekly()->create(['band_id' => $band->id]);
+        $rehearsal = \App\Models\Rehearsal::factory()->create([
+            'rehearsal_schedule_id' => $schedule->id,
+            'band_id'               => $band->id,
+        ]);
+
+        $event = Events::factory()->create([
+            'eventable_id'   => $rehearsal->id,
+            'eventable_type' => 'App\\Models\\Rehearsal',
+            'event_type_id'  => $eventType->id,
+            'date'           => now()->addDays(7)->format('Y-m-d'),
+            'start_time'     => '19:00:00',
+        ]);
+
+        $token = $user->createToken('test-device')->plainTextToken;
+
+        $dashboard = $this->withToken($token)
+            ->withHeaders(['X-Band-ID' => $band->id])
+            ->getJson('/api/mobile/dashboard');
+        $dashboard->assertOk();
+
+        $rehearsalItem = collect($dashboard->json('events'))
+            ->firstWhere('event_source', 'rehearsal');
+
+        $this->assertNotNull($rehearsalItem, 'expected the rehearsal in the dashboard payload');
+        $this->assertSame($rehearsal->id, $rehearsalItem['id'], 'dashboard must emit the rehearsals.id, not events.id');
+        $this->assertNotSame($event->id, $rehearsalItem['id'], 'dashboard must not emit events.id as the rehearsal id');
+
+        // The id the dashboard handed back must resolve at the detail route.
+        $this->withToken($token)
+            ->withHeaders(['X-Band-ID' => $band->id])
+            ->getJson("/api/mobile/rehearsals/{$rehearsalItem['id']}")
+            ->assertOk();
+    }
 }

--- a/tests/Unit/Services/Mobile/DashboardFormatterTest.php
+++ b/tests/Unit/Services/Mobile/DashboardFormatterTest.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Tests\Unit\Services\Mobile;
+
+use App\Services\Mobile\DashboardFormatter;
+use PHPUnit\Framework\TestCase;
+
+class DashboardFormatterTest extends TestCase
+{
+    private DashboardFormatter $formatter;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->formatter = new DashboardFormatter();
+    }
+
+    /**
+     * A real rehearsal must expose the Rehearsal model's primary key
+     * (events.eventable_id) as `id` — NOT events.id. The mobile app navigates
+     * to /rehearsals/{id} which resolves App\Models\Rehearsal::findOrFail($id),
+     * so emitting events.id here 404s ("No query results for model
+     * [App\Models\Rehearsal]").
+     */
+    public function test_rehearsal_id_is_the_rehearsal_pk_not_the_event_id(): void
+    {
+        $rehearsalEvent = [
+            'id'             => 741,            // events.id — must NOT leak as the item id
+            'eventable_id'   => 42,            // rehearsals.id — the real navigable id
+            'eventable_type' => 'App\\Models\\Rehearsal',
+            'key'            => 'rehearsal-abc',
+            'title'          => 'Weekly Rehearsal',
+            'date'           => '2026-06-27',
+            'event_source'   => 'rehearsal',
+            'band_id'        => null,
+        ];
+
+        $out = $this->formatter->formatEvents([$rehearsalEvent]);
+
+        $this->assertCount(1, $out);
+        $this->assertSame('rehearsal', $out[0]['event_source']);
+        $this->assertSame(42, $out[0]['id'], 'Rehearsal id should be the rehearsals.id (eventable_id), not events.id');
+        $this->assertSame('rehearsal-abc', $out[0]['key']);
+    }
+
+    /**
+     * Virtual rehearsals (recurring schedule projections) have no real Rehearsal
+     * row yet — their id stays null and the mobile app navigates by key.
+     */
+    public function test_virtual_rehearsal_id_stays_null(): void
+    {
+        $virtual = [
+            'id'                  => null,
+            'key'                 => 'virtual-rehearsal-9-2026-06-27',
+            'title'               => 'Weekly Rehearsal',
+            'date'                => '2026-06-27',
+            'event_source'        => 'rehearsal_schedule',
+            'rehearsal_schedule_id' => 9,
+            'band_id'             => null,
+        ];
+
+        $out = $this->formatter->formatEvents([$virtual]);
+
+        $this->assertCount(1, $out);
+        $this->assertSame('rehearsal_schedule', $out[0]['event_source']);
+        $this->assertNull($out[0]['id']);
+        $this->assertSame('virtual-rehearsal-9-2026-06-27', $out[0]['key']);
+    }
+
+    /**
+     * Bookings and band events are unaffected — their `id` passes through as-is
+     * (the mobile app navigates them by key regardless, but the contract should
+     * not change for non-rehearsal sources).
+     */
+    public function test_booking_id_passes_through_unchanged(): void
+    {
+        $booking = [
+            'id'             => 555,
+            'eventable_id'   => 7,
+            'eventable_type' => 'App\\Models\\Bookings',
+            'key'            => 'booking-xyz',
+            'title'          => 'Bar Gig',
+            'date'           => '2026-07-01',
+            'event_source'   => 'booking',
+            'band_id'        => null,
+        ];
+
+        $out = $this->formatter->formatEvents([$booking]);
+
+        $this->assertSame('booking', $out[0]['event_source']);
+        $this->assertSame(555, $out[0]['id']);
+    }
+}


### PR DESCRIPTION
## Problem

Tapping a rehearsal on the mobile dashboard threw a Dio error page: **"No query results for model [App\Models\Rehearsal] 741"**.

## Root cause

The mobile dashboard query (`User::getEventsAttribute`) selects `events.id` as each item's `id`. For a rehearsal, the app navigates to `/rehearsals/{id}`, and `RehearsalsController::show` resolves `App\Models\Rehearsal::findOrFail($id)` — which expects the **`rehearsals` table PK** (i.e. `events.eventable_id`), not `events.id`. So a rehearsal whose `events.id` was 741 looked up Rehearsal 741, which doesn't exist → 404.

## Fix

`DashboardFormatter::normalizeEvent` now emits `eventable_id` (the real `rehearsals.id`) as the `id` for **real rehearsals** (`event_source: "rehearsal"`). Virtual rehearsals (`rehearsal_schedule`) keep `id: null` and are navigated by key, as before. Bookings and band events are unchanged.

Scoped to the mobile formatter only — the shared `events` accessor used by the web calendar is untouched. **Deploys instantly, so it fixes app versions already in users' hands** (no app-store release needed).

## Tests

- New `tests/Unit/Services/Mobile/DashboardFormatterTest.php` pins the id semantics for real/virtual rehearsals and bookings.
- New end-to-end regression in `DashboardTest.php` asserts the id the dashboard hands back actually resolves at `GET /api/mobile/rehearsals/{id}`.
- Full mobile suite: 316 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)