### PR TITLE
Mobile API: per-booking payout endpoints

### DIFF
--- a/app/Http/Controllers/Api/Mobile/BookingsController.php
+++ b/app/Http/Controllers/Api/Mobile/BookingsController.php
@@ -622,4 +622,71 @@ class BookingsController extends Controller
 
         return response()->json(['history' => $contract->auditTrail()]);
     }
+
+    public function payout(Request $request, Bands $band, Bookings $booking): JsonResponse
+    {
+        $payout = $this->getOrCreatePayout($booking, $band);
+
+        $booking->load([
+            'events.eventMembers.rosterMember',
+            'events.eventMembers.user',
+        ]);
+
+        $config = $payout->payout_config_id
+            ? \App\Models\BandPayoutConfig::where('id', $payout->payout_config_id)->where('band_id', $band->id)->with(['band.paymentGroups.users'])->first()
+            : \App\Models\BandPayoutConfig::where('band_id', $band->id)->where('is_active', true)->with(['band.paymentGroups.users'])->first();
+
+        $adjustedTotal = $payout->adjusted_amount_float;
+        $result = ($config && $adjustedTotal > 0)
+            ? $config->calculatePayouts($adjustedTotal, null, $booking)
+            : null;
+
+        $events = $booking->events->map(fn ($e) => [
+            'id' => $e->id,
+            'label' => trim(($e->date ? $e->date->format('D M j') : '').($e->title ? ' · '.$e->title : '')),
+            'value' => (string) $e->value,
+            'members' => $e->eventMembers->map(fn ($m) => [
+                'id' => $m->id,
+                'user_id' => $m->user_id,
+                'name' => $m->name ?? optional($m->user)->name ?? '',
+                'attendance_status' => $m->attendance_status,
+            ])->values(),
+        ])->values();
+
+        $availableConfigs = \App\Models\BandPayoutConfig::where('band_id', $band->id)
+            ->get(['id', 'name', 'is_active'])
+            ->map(fn ($c) => ['id' => $c->id, 'name' => $c->name, 'is_active' => (bool) $c->is_active]);
+
+        return response()->json([
+            'payout' => [
+                'id' => $payout->id,
+                'base_amount' => (string) $payout->base_amount,
+                'adjusted_amount' => (string) $payout->adjusted_amount,
+                'payout_config_id' => $payout->payout_config_id,
+            ],
+            'config' => $config ? ['id' => $config->id, 'name' => $config->name, 'is_active' => (bool) $config->is_active] : null,
+            'result' => $result,
+            'adjustments' => $payout->adjustments->map(fn ($a) => [
+                'id' => $a->id,
+                'amount' => (string) $a->amount,
+                'description' => $a->description,
+                'notes' => $a->notes,
+            ])->values(),
+            'events' => $events,
+            'available_configs' => $availableConfigs,
+        ]);
+    }
+
+    private function getOrCreatePayout(Bookings $booking, Bands $band): \App\Models\Payout
+    {
+        if ($booking->payout) {
+            return $booking->payout;
+        }
+        $baseAmount = $booking->total_event_value;
+        return $booking->payout()->create([
+            'band_id' => $band->id,
+            'base_amount' => $baseAmount,
+            'adjusted_amount' => $baseAmount,
+        ]);
+    }
 }

--- a/app/Http/Controllers/Api/Mobile/BookingsController.php
+++ b/app/Http/Controllers/Api/Mobile/BookingsController.php
@@ -634,6 +634,8 @@ class BookingsController extends Controller
             abort(403);
         }
 
+        abort_unless($booking->band_id === $band->id, 404);
+
         $payout = $this->getOrCreatePayout($booking, $band);
 
         $booking->load([
@@ -712,6 +714,8 @@ class BookingsController extends Controller
             abort(403);
         }
 
+        abort_unless($booking->band_id === $band->id, 404);
+
         $validated = $request->validate([
             'amount' => 'required|numeric',
             'description' => 'required|string|max:255',
@@ -726,6 +730,16 @@ class BookingsController extends Controller
             'created_by' => $user->id,
         ]);
         $payout->recalculateAdjustedAmount();
+
+        activity()
+            ->performedOn($booking)
+            ->causedBy($user)
+            ->withProperties([
+                'adjustment_id' => $adjustment->id,
+                'amount' => $validated['amount'],
+                'description' => $validated['description'],
+            ])
+            ->log('payout_adjustment_added');
 
         return response()->json(['adjustment' => [
             'id' => $adjustment->id,
@@ -743,12 +757,26 @@ class BookingsController extends Controller
             abort(403);
         }
 
+        abort_unless($booking->band_id === $band->id, 404);
+
         $payout = $booking->payout;
         abort_unless($payout, 404, 'Payout not found');
         abort_unless($adjustment->payout_id === $payout->id, 403, 'Adjustment does not belong to this booking payout');
 
+        $amount = $adjustment->amount;
+        $description = $adjustment->description;
+
         $adjustment->delete();
         $payout->recalculateAdjustedAmount();
+
+        activity()
+            ->performedOn($booking)
+            ->causedBy($user)
+            ->withProperties([
+                'amount' => $amount,
+                'description' => $description,
+            ])
+            ->log('payout_adjustment_removed');
 
         return response()->json(['message' => 'Payout adjustment removed']);
     }
@@ -760,6 +788,8 @@ class BookingsController extends Controller
         if (!$user->bands()->contains('id', $band->id)) {
             abort(403);
         }
+
+        abort_unless($booking->band_id === $band->id, 404);
 
         $validated = $request->validate(['payout_config_id' => 'required|exists:band_payout_configs,id']);
 
@@ -777,6 +807,15 @@ class BookingsController extends Controller
         $payout->calculation_result = $result;
         $payout->save();
 
+        activity()
+            ->performedOn($booking)
+            ->causedBy($user)
+            ->withProperties([
+                'config_id' => $config->id,
+                'config_name' => $config->name,
+            ])
+            ->log('payout_configuration_updated');
+
         return response()->json(['result' => $result]);
     }
 
@@ -787,6 +826,8 @@ class BookingsController extends Controller
         if (!$user->bands()->contains('id', $band->id)) {
             abort(403);
         }
+
+        abort_unless($booking->band_id === $band->id, 404);
 
         if ($event->eventable_type !== Bookings::class || $event->eventable_id !== $booking->id) {
             return response()->json(['error' => 'Event does not belong to this booking.'], 404);

--- a/app/Http/Controllers/Api/Mobile/BookingsController.php
+++ b/app/Http/Controllers/Api/Mobile/BookingsController.php
@@ -17,6 +17,7 @@ use App\Models\BookingContacts;
 use App\Models\Bookings;
 use App\Models\Contacts;
 use App\Models\Contracts;
+use App\Models\EventMember;
 use App\Models\Events;
 use App\Models\Payments;
 use App\Services\BookingActivityService;
@@ -787,11 +788,15 @@ class BookingsController extends Controller
             abort(403);
         }
 
+        if ($event->eventable_type !== Bookings::class || $event->eventable_id !== $booking->id) {
+            return response()->json(['error' => 'Event does not belong to this booking.'], 404);
+        }
+
         $validated = $request->validate([
             'attendance_status' => 'required|in:confirmed,attended,absent,excused',
         ]);
 
-        $eventMember = \App\Models\EventMember::where('id', $member)
+        $eventMember = EventMember::where('id', $member)
             ->where('event_id', $event->id)
             ->firstOrFail();
 

--- a/app/Http/Controllers/Api/Mobile/BookingsController.php
+++ b/app/Http/Controllers/Api/Mobile/BookingsController.php
@@ -625,6 +625,14 @@ class BookingsController extends Controller
 
     public function payout(Request $request, Bands $band, Bookings $booking): JsonResponse
     {
+        // Authorize: user must belong to the band (owner or member). Subs are
+        // intentionally excluded — payout data carries money/PII they shouldn't
+        // see (matches indexForUser's bands() vs allBands() rule).
+        $user = $request->user();
+        if (!$user->bands()->contains('id', $band->id)) {
+            abort(403);
+        }
+
         $payout = $this->getOrCreatePayout($booking, $band);
 
         $booking->load([
@@ -632,11 +640,27 @@ class BookingsController extends Controller
             'events.eventMembers.user',
         ]);
 
-        $config = $payout->payout_config_id
-            ? \App\Models\BandPayoutConfig::where('id', $payout->payout_config_id)->where('band_id', $band->id)->with(['band.paymentGroups.users'])->first()
-            : \App\Models\BandPayoutConfig::where('band_id', $band->id)->where('is_active', true)->with(['band.paymentGroups.users'])->first();
-
         $adjustedTotal = $payout->adjusted_amount_float;
+
+        // Use stored config if exists, otherwise fall back to active config.
+        $config = null;
+        if ($adjustedTotal > 0) {
+            if ($payout->payout_config_id) {
+                $config = \App\Models\BandPayoutConfig::where('id', $payout->payout_config_id)
+                    ->where('band_id', $band->id)
+                    ->with(['band.paymentGroups.users'])
+                    ->first();
+            }
+
+            // Fallback to active config if no stored config or stored config not found.
+            if (!$config) {
+                $config = \App\Models\BandPayoutConfig::where('band_id', $band->id)
+                    ->where('is_active', true)
+                    ->with(['band.paymentGroups.users'])
+                    ->first();
+            }
+        }
+
         $result = ($config && $adjustedTotal > 0)
             ? $config->calculatePayouts($adjustedTotal, null, $booking)
             : null;
@@ -654,6 +678,8 @@ class BookingsController extends Controller
         ])->values();
 
         $availableConfigs = \App\Models\BandPayoutConfig::where('band_id', $band->id)
+            ->orderBy('is_active', 'desc')
+            ->orderBy('name')
             ->get(['id', 'name', 'is_active'])
             ->map(fn ($c) => ['id' => $c->id, 'name' => $c->name, 'is_active' => (bool) $c->is_active]);
 

--- a/app/Http/Controllers/Api/Mobile/BookingsController.php
+++ b/app/Http/Controllers/Api/Mobile/BookingsController.php
@@ -752,6 +752,33 @@ class BookingsController extends Controller
         return response()->json(['message' => 'Payout adjustment removed']);
     }
 
+    public function updatePayoutConfiguration(Request $request, Bands $band, Bookings $booking): JsonResponse
+    {
+        // Authorize: owner/member only — subs must not mutate payout data.
+        $user = $request->user();
+        if (!$user->bands()->contains('id', $band->id)) {
+            abort(403);
+        }
+
+        $validated = $request->validate(['payout_config_id' => 'required|exists:band_payout_configs,id']);
+
+        $payout = $this->getOrCreatePayout($booking, $band);
+        $config = \App\Models\BandPayoutConfig::where('id', $validated['payout_config_id'])
+            ->where('band_id', $band->id)
+            ->with(['band.paymentGroups.users'])
+            ->firstOrFail();
+
+        $booking->load(['events.eventMembers.rosterMember', 'events.eventMembers.user']);
+
+        $payout->payout_config_id = $config->id;
+        $adjustedTotal = $payout->adjusted_amount_float;
+        $result = $adjustedTotal > 0 ? $config->calculatePayouts($adjustedTotal, null, $booking) : null;
+        $payout->calculation_result = $result;
+        $payout->save();
+
+        return response()->json(['result' => $result]);
+    }
+
     private function getOrCreatePayout(Bookings $booking, Bands $band): \App\Models\Payout
     {
         if ($booking->payout) {

--- a/app/Http/Controllers/Api/Mobile/BookingsController.php
+++ b/app/Http/Controllers/Api/Mobile/BookingsController.php
@@ -703,6 +703,55 @@ class BookingsController extends Controller
         ]);
     }
 
+    public function storePayoutAdjustment(Request $request, Bands $band, Bookings $booking): JsonResponse
+    {
+        // Authorize: owner/member only — subs must not mutate payout data.
+        $user = $request->user();
+        if (!$user->bands()->contains('id', $band->id)) {
+            abort(403);
+        }
+
+        $validated = $request->validate([
+            'amount' => 'required|numeric',
+            'description' => 'required|string|max:255',
+            'notes' => 'nullable|string',
+        ]);
+
+        $payout = $this->getOrCreatePayout($booking, $band);
+        $adjustment = $payout->adjustments()->create([
+            'amount' => $validated['amount'],
+            'description' => $validated['description'],
+            'notes' => $validated['notes'] ?? null,
+            'created_by' => \Illuminate\Support\Facades\Auth::id(),
+        ]);
+        $payout->recalculateAdjustedAmount();
+
+        return response()->json(['adjustment' => [
+            'id' => $adjustment->id,
+            'amount' => (string) $adjustment->amount,
+            'description' => $adjustment->description,
+            'notes' => $adjustment->notes,
+        ]], 201);
+    }
+
+    public function destroyPayoutAdjustment(Request $request, Bands $band, Bookings $booking, \App\Models\PayoutAdjustment $adjustment): JsonResponse
+    {
+        // Authorize: owner/member only — subs must not mutate payout data.
+        $user = $request->user();
+        if (!$user->bands()->contains('id', $band->id)) {
+            abort(403);
+        }
+
+        $payout = $booking->payout;
+        abort_unless($payout, 404, 'Payout not found');
+        abort_unless($adjustment->payout_id === $payout->id, 403, 'Adjustment does not belong to this booking payout');
+
+        $adjustment->delete();
+        $payout->recalculateAdjustedAmount();
+
+        return response()->json(['message' => 'Payout adjustment removed']);
+    }
+
     private function getOrCreatePayout(Bookings $booking, Bands $band): \App\Models\Payout
     {
         if ($booking->payout) {

--- a/app/Http/Controllers/Api/Mobile/BookingsController.php
+++ b/app/Http/Controllers/Api/Mobile/BookingsController.php
@@ -722,7 +722,7 @@ class BookingsController extends Controller
             'amount' => $validated['amount'],
             'description' => $validated['description'],
             'notes' => $validated['notes'] ?? null,
-            'created_by' => \Illuminate\Support\Facades\Auth::id(),
+            'created_by' => $user->id,
         ]);
         $payout->recalculateAdjustedAmount();
 

--- a/app/Http/Controllers/Api/Mobile/BookingsController.php
+++ b/app/Http/Controllers/Api/Mobile/BookingsController.php
@@ -779,6 +779,30 @@ class BookingsController extends Controller
         return response()->json(['result' => $result]);
     }
 
+    public function updateMemberAttendance(Request $request, Bands $band, Bookings $booking, Events $event, int $member): JsonResponse
+    {
+        // Authorize: owner/member only — subs must not mutate attendance data.
+        $user = $request->user();
+        if (!$user->bands()->contains('id', $band->id)) {
+            abort(403);
+        }
+
+        $validated = $request->validate([
+            'attendance_status' => 'required|in:confirmed,attended,absent,excused',
+        ]);
+
+        $eventMember = \App\Models\EventMember::where('id', $member)
+            ->where('event_id', $event->id)
+            ->firstOrFail();
+
+        $eventMember->update(['attendance_status' => $validated['attendance_status']]);
+
+        return response()->json(['member' => [
+            'id' => $eventMember->id,
+            'attendance_status' => $eventMember->attendance_status,
+        ]]);
+    }
+
     private function getOrCreatePayout(Bookings $booking, Bands $band): \App\Models\Payout
     {
         if ($booking->payout) {

--- a/database/factories/BandPayoutConfigFactory.php
+++ b/database/factories/BandPayoutConfigFactory.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\BandPayoutConfig;
+use App\Models\Bands;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class BandPayoutConfigFactory extends Factory
+{
+    protected $model = BandPayoutConfig::class;
+
+    public function definition(): array
+    {
+        return [
+            'band_id' => Bands::factory(),
+            'name' => $this->faker->words(3, true),
+            'is_active' => false,
+            'band_cut_type' => 'percentage',
+            'band_cut_value' => 0,
+            'member_payout_type' => 'equal_split',
+            'include_owners' => true,
+            'include_members' => true,
+        ];
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -219,6 +219,7 @@ Route::prefix('mobile')->group(function () {
             Route::get('/bands/{band}/bookings/{booking}/contract/view-url', [App\Http\Controllers\Api\Mobile\BookingsController::class, 'viewContractUrl'])->name('mobile.bookings.contract.view.url');
             Route::get('/bands/{band}/bookings/{booking}/contract/download', [App\Http\Controllers\Api\Mobile\BookingsController::class, 'downloadContract'])->name('mobile.bookings.contract.download');
             Route::get('/bands/{band}/bookings/{booking}/history', [App\Http\Controllers\Api\Mobile\BookingsController::class, 'showHistory'])->name('mobile.bookings.history');
+            Route::get('/bands/{band}/bookings/{booking}/payout', [App\Http\Controllers\Api\Mobile\BookingsController::class, 'payout'])->name('mobile.bookings.payout.show');
         });
 
         // ── Bookings (write) ───────────────────────────────────────────

--- a/routes/api.php
+++ b/routes/api.php
@@ -253,6 +253,14 @@ Route::prefix('mobile')->group(function () {
             Route::post('/bands/{band}/bookings/{booking}/contract/upload', [App\Http\Controllers\Api\Mobile\BookingsController::class, 'uploadContract'])->name('mobile.bookings.contract.upload');
             Route::post('/bands/{band}/bookings/{booking}/contract/send', [App\Http\Controllers\Api\Mobile\BookingsController::class, 'sendContract'])->name('mobile.bookings.contract.send');
             Route::post('/bands/{band}/bookings/{booking}/contract/terms', [App\Http\Controllers\Api\Mobile\BookingsController::class, 'saveContractTerms'])->name('mobile.bookings.contract.terms');
+
+        });
+
+        // Booking payout adjustments (write) — separate group to avoid scopeBindings
+        // scoping {adjustment} through Bookings (PayoutAdjustment belongs to Payout, not Booking directly)
+        Route::middleware('mobile.band:write:bookings')->group(function () {
+            Route::post('/bands/{band}/bookings/{booking}/payout/adjustments', [App\Http\Controllers\Api\Mobile\BookingsController::class, 'storePayoutAdjustment'])->name('mobile.bookings.payout.adjustments.store');
+            Route::delete('/bands/{band}/bookings/{booking}/payout/adjustments/{adjustment}', [App\Http\Controllers\Api\Mobile\BookingsController::class, 'destroyPayoutAdjustment'])->name('mobile.bookings.payout.adjustments.destroy');
         });
 
         // ── Finances (uses read:bookings permission) ───────────────────

--- a/routes/api.php
+++ b/routes/api.php
@@ -262,6 +262,7 @@ Route::prefix('mobile')->group(function () {
             Route::post('/bands/{band}/bookings/{booking}/payout/adjustments', [App\Http\Controllers\Api\Mobile\BookingsController::class, 'storePayoutAdjustment'])->name('mobile.bookings.payout.adjustments.store');
             Route::delete('/bands/{band}/bookings/{booking}/payout/adjustments/{adjustment}', [App\Http\Controllers\Api\Mobile\BookingsController::class, 'destroyPayoutAdjustment'])->name('mobile.bookings.payout.adjustments.destroy');
             Route::put('/bands/{band}/bookings/{booking}/payout/configuration', [App\Http\Controllers\Api\Mobile\BookingsController::class, 'updatePayoutConfiguration'])->name('mobile.bookings.payout.configuration.update');
+            Route::patch('/bands/{band}/bookings/{booking}/events/{event}/members/{member}/attendance', [App\Http\Controllers\Api\Mobile\BookingsController::class, 'updateMemberAttendance'])->name('mobile.bookings.events.members.attendance');
         });
 
         // ── Finances (uses read:bookings permission) ───────────────────

--- a/routes/api.php
+++ b/routes/api.php
@@ -261,6 +261,7 @@ Route::prefix('mobile')->group(function () {
         Route::middleware('mobile.band:write:bookings')->group(function () {
             Route::post('/bands/{band}/bookings/{booking}/payout/adjustments', [App\Http\Controllers\Api\Mobile\BookingsController::class, 'storePayoutAdjustment'])->name('mobile.bookings.payout.adjustments.store');
             Route::delete('/bands/{band}/bookings/{booking}/payout/adjustments/{adjustment}', [App\Http\Controllers\Api\Mobile\BookingsController::class, 'destroyPayoutAdjustment'])->name('mobile.bookings.payout.adjustments.destroy');
+            Route::put('/bands/{band}/bookings/{booking}/payout/configuration', [App\Http\Controllers\Api\Mobile\BookingsController::class, 'updatePayoutConfiguration'])->name('mobile.bookings.payout.configuration.update');
         });
 
         // ── Finances (uses read:bookings permission) ───────────────────

--- a/tests/Feature/Api/Mobile/BookingPayoutTest.php
+++ b/tests/Feature/Api/Mobile/BookingPayoutTest.php
@@ -4,6 +4,7 @@ namespace Tests\Feature\Api\Mobile;
 
 use App\Models\BandOwners;
 use App\Models\BandPayoutConfig;
+use App\Models\BandSubs;
 use App\Models\Bands;
 use App\Models\Bookings;
 use App\Models\Events;
@@ -50,6 +51,10 @@ class BookingPayoutTest extends TestCase
             'events' => [['id', 'label', 'value', 'members']],
             'available_configs' => [['id', 'name', 'is_active']],
         ]);
+
+        $response->assertJsonPath('config.is_active', true);
+        // 20% of 1000 = 200; PHP returns an int here, assertJsonPath uses ===
+        $response->assertJsonPath('result.band_cut', 200);
     }
 
     public function test_payout_show_forbidden_for_non_member(): void
@@ -57,6 +62,20 @@ class BookingPayoutTest extends TestCase
         ['band' => $band, 'booking' => $booking] = $this->setup_booking();
         $outsider = User::factory()->create();
         $token = $outsider->createToken('d')->plainTextToken;
+
+        $this->withHeaders($this->headers($token, $band->id))
+            ->getJson("/api/mobile/bands/{$band->id}/bookings/{$booking->id}/payout")
+            ->assertForbidden();
+    }
+
+    public function test_payout_show_forbidden_for_sub(): void
+    {
+        ['band' => $band, 'booking' => $booking] = $this->setup_booking();
+
+        // Create a sub: a user who appears in band_subs but NOT in band_owners/band_members
+        $sub = User::factory()->create();
+        BandSubs::create(['user_id' => $sub->id, 'band_id' => $band->id]);
+        $token = $sub->createToken('sub-device')->plainTextToken;
 
         $this->withHeaders($this->headers($token, $band->id))
             ->getJson("/api/mobile/bands/{$band->id}/bookings/{$booking->id}/payout")

--- a/tests/Feature/Api/Mobile/BookingPayoutTest.php
+++ b/tests/Feature/Api/Mobile/BookingPayoutTest.php
@@ -81,4 +81,75 @@ class BookingPayoutTest extends TestCase
             ->getJson("/api/mobile/bands/{$band->id}/bookings/{$booking->id}/payout")
             ->assertForbidden();
     }
+
+    public function test_store_adjustment_recalculates_adjusted_amount(): void
+    {
+        ['band' => $band, 'booking' => $booking, 'token' => $token] = $this->setup_booking();
+
+        $response = $this->withHeaders($this->headers($token, $band->id))
+            ->postJson("/api/mobile/bands/{$band->id}/bookings/{$booking->id}/payout/adjustments", [
+                'amount' => -250, 'description' => 'Gas / travel', 'notes' => 'Reimbursed',
+            ]);
+
+        $response->assertCreated()->assertJsonStructure(['adjustment' => ['id', 'amount', 'description', 'notes']]);
+        $this->assertSame('750.00', (string) $booking->fresh()->payout->adjusted_amount);
+    }
+
+    public function test_store_adjustment_validates_description_required(): void
+    {
+        ['band' => $band, 'booking' => $booking, 'token' => $token] = $this->setup_booking();
+        $this->withHeaders($this->headers($token, $band->id))
+            ->postJson("/api/mobile/bands/{$band->id}/bookings/{$booking->id}/payout/adjustments", ['amount' => 10])
+            ->assertStatus(422);
+    }
+
+    public function test_destroy_adjustment_recalculates_and_rejects_foreign(): void
+    {
+        ['band' => $band, 'booking' => $booking, 'token' => $token] = $this->setup_booking();
+        $this->withHeaders($this->headers($token, $band->id))
+            ->postJson("/api/mobile/bands/{$band->id}/bookings/{$booking->id}/payout/adjustments", ['amount' => -250, 'description' => 'X']);
+        $adjId = $booking->fresh()->payout->adjustments->first()->id;
+
+        $this->withHeaders($this->headers($token, $band->id))
+            ->deleteJson("/api/mobile/bands/{$band->id}/bookings/{$booking->id}/payout/adjustments/{$adjId}")
+            ->assertOk();
+        $this->assertSame('1000.00', (string) $booking->fresh()->payout->adjusted_amount);
+    }
+
+    public function test_store_adjustment_forbidden_for_sub(): void
+    {
+        ['band' => $band, 'booking' => $booking] = $this->setup_booking();
+
+        $sub = User::factory()->create();
+        BandSubs::create(['user_id' => $sub->id, 'band_id' => $band->id]);
+        $token = $sub->createToken('sub-device')->plainTextToken;
+
+        $this->withHeaders($this->headers($token, $band->id))
+            ->postJson("/api/mobile/bands/{$band->id}/bookings/{$booking->id}/payout/adjustments", [
+                'amount' => -100, 'description' => 'Should be blocked',
+            ])
+            ->assertForbidden();
+    }
+
+    public function test_destroy_adjustment_forbidden_for_sub(): void
+    {
+        ['band' => $band, 'booking' => $booking, 'token' => $token] = $this->setup_booking();
+
+        // Owner creates an adjustment first
+        $this->withHeaders($this->headers($token, $band->id))
+            ->postJson("/api/mobile/bands/{$band->id}/bookings/{$booking->id}/payout/adjustments", [
+                'amount' => -100, 'description' => 'Owner adjustment',
+            ]);
+        $adjId = $booking->fresh()->payout->adjustments->first()->id;
+
+        // Sub attempts to delete it — use actingAs to avoid Sanctum token-cache
+        // interference from the preceding owner request in this same test.
+        $sub = User::factory()->create();
+        BandSubs::create(['user_id' => $sub->id, 'band_id' => $band->id]);
+
+        $this->actingAs($sub, 'sanctum')
+            ->withHeaders(['X-Band-ID' => $band->id, 'Accept' => 'application/json'])
+            ->deleteJson("/api/mobile/bands/{$band->id}/bookings/{$booking->id}/payout/adjustments/{$adjId}")
+            ->assertForbidden();
+    }
 }

--- a/tests/Feature/Api/Mobile/BookingPayoutTest.php
+++ b/tests/Feature/Api/Mobile/BookingPayoutTest.php
@@ -354,4 +354,94 @@ class BookingPayoutTest extends TestCase
             ])
             ->assertForbidden();
     }
+
+    // ── C1: cross-band booking IDOR rejection ──────────────────────────
+    // The four write endpoints sit in a route group WITHOUT scopeBindings(),
+    // so {booking} resolves by id alone. An attacker who owns band A could pass
+    // a DIFFERENT band's booking id and mutate its payout/attendance. Each test
+    // authenticates as band A's owner, uses band A in the URL but band B's
+    // booking id, and asserts the booking→band guard rejects it (404) with no
+    // mutation on band B's data.
+
+    public function test_store_adjustment_rejects_cross_band_booking(): void
+    {
+        // Band A — the authenticated attacker's own band.
+        ['band' => $bandA, 'token' => $token] = $this->setup_booking();
+        // Band B — a separate band with its own owner + booking.
+        ['band' => $bandB, 'booking' => $bookingB] = $this->setup_booking();
+
+        // Attacker (band A owner) targets band B's booking via band A's URL.
+        $this->withHeaders($this->headers($token, $bandA->id))
+            ->postJson("/api/mobile/bands/{$bandA->id}/bookings/{$bookingB->id}/payout/adjustments", [
+                'amount' => -250, 'description' => 'Cross-band attack',
+            ])
+            ->assertNotFound();
+
+        // No adjustment may have been created against band B's payout.
+        $payoutB = $bookingB->fresh()->payout;
+        $this->assertTrue($payoutB === null || $payoutB->adjustments()->count() === 0);
+        $this->assertDatabaseMissing('payout_adjustments', ['description' => 'Cross-band attack']);
+    }
+
+    public function test_destroy_adjustment_rejects_cross_band_booking(): void
+    {
+        ['band' => $bandA, 'token' => $token] = $this->setup_booking();
+        ['band' => $bandB, 'booking' => $bookingB, 'user' => $ownerB] = $this->setup_booking();
+
+        // Band B's booking has a payout + adjustment (created directly to keep this
+        // test on a single authenticated HTTP call — the attacker's).
+        $payoutB = $bookingB->payout()->create([
+            'band_id' => $bandB->id, 'base_amount' => 500, 'adjusted_amount' => 500,
+        ]);
+        $adjId = $payoutB->adjustments()->create([
+            'amount' => -100, 'description' => 'BandB adjustment', 'created_by' => $ownerB->id,
+        ])->id;
+
+        // Attacker (band A owner) tries to delete it via band A's URL + band B's booking.
+        $this->withHeaders($this->headers($token, $bandA->id))
+            ->deleteJson("/api/mobile/bands/{$bandA->id}/bookings/{$bookingB->id}/payout/adjustments/{$adjId}")
+            ->assertNotFound();
+
+        // Band B's adjustment must still exist.
+        $this->assertDatabaseHas('payout_adjustments', ['id' => $adjId]);
+    }
+
+    public function test_update_configuration_rejects_cross_band_booking(): void
+    {
+        ['band' => $bandA, 'token' => $token] = $this->setup_booking();
+        ['band' => $bandB, 'booking' => $bookingB, 'config' => $configB] = $this->setup_booking();
+
+        $this->withHeaders($this->headers($token, $bandA->id))
+            ->putJson("/api/mobile/bands/{$bandA->id}/bookings/{$bookingB->id}/payout/configuration", [
+                'payout_config_id' => $configB->id,
+            ])
+            ->assertNotFound();
+
+        // Band B's booking must have no payout config set by the attacker.
+        $payoutB = $bookingB->fresh()->payout;
+        $this->assertTrue($payoutB === null || $payoutB->payout_config_id === null);
+    }
+
+    public function test_update_attendance_rejects_cross_band_booking(): void
+    {
+        ['band' => $bandA, 'token' => $token] = $this->setup_booking();
+        ['band' => $bandB, 'booking' => $bookingB] = $this->setup_booking();
+
+        // Band B's own event + member.
+        $eventB = $bookingB->fresh()->events->first();
+        $memberB = \App\Models\EventMember::create([
+            'event_id' => $eventB->id, 'band_id' => $bandB->id,
+            'name' => 'Bob', 'attendance_status' => 'confirmed',
+        ]);
+
+        // Attacker (band A owner) targets band B's booking/event/member.
+        $this->withHeaders($this->headers($token, $bandA->id))
+            ->patchJson("/api/mobile/bands/{$bandA->id}/bookings/{$bookingB->id}/events/{$eventB->id}/members/{$memberB->id}/attendance", [
+                'attendance_status' => 'absent',
+            ])
+            ->assertNotFound();
+
+        // Band B's member attendance must be unchanged.
+        $this->assertSame('confirmed', $memberB->fresh()->attendance_status);
+    }
 }

--- a/tests/Feature/Api/Mobile/BookingPayoutTest.php
+++ b/tests/Feature/Api/Mobile/BookingPayoutTest.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Tests\Feature\Api\Mobile;
+
+use App\Models\BandOwners;
+use App\Models\BandPayoutConfig;
+use App\Models\Bands;
+use App\Models\Bookings;
+use App\Models\Events;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class BookingPayoutTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function setup_booking(): array
+    {
+        $user = User::factory()->create();
+        $band = Bands::factory()->create();
+        BandOwners::create(['band_id' => $band->id, 'user_id' => $user->id]);
+        $config = BandPayoutConfig::factory()->create([
+            'band_id' => $band->id, 'is_active' => true,
+            'band_cut_type' => 'percentage', 'band_cut_value' => 20,
+        ]);
+        $booking = Bookings::factory()->create(['band_id' => $band->id, 'price' => 1000]);
+        Events::factory()->create(['eventable_id' => $booking->id, 'eventable_type' => Bookings::class, 'value' => 1000]);
+        $token = $user->createToken('test-device')->plainTextToken;
+        return compact('user', 'band', 'booking', 'config', 'token');
+    }
+
+    private function headers(string $token, int $bandId): array
+    {
+        return ['Authorization' => "Bearer {$token}", 'X-Band-ID' => $bandId, 'Accept' => 'application/json'];
+    }
+
+    public function test_payout_show_returns_breakdown_structure(): void
+    {
+        ['band' => $band, 'booking' => $booking, 'token' => $token] = $this->setup_booking();
+
+        $response = $this->withHeaders($this->headers($token, $band->id))
+            ->getJson("/api/mobile/bands/{$band->id}/bookings/{$booking->id}/payout");
+
+        $response->assertOk()->assertJsonStructure([
+            'payout' => ['id', 'base_amount', 'adjusted_amount', 'payout_config_id'],
+            'config' => ['id', 'name', 'is_active'],
+            'result' => ['total_amount', 'band_cut', 'distributable_amount', 'member_payouts', 'payment_group_payouts'],
+            'adjustments',
+            'events' => [['id', 'label', 'value', 'members']],
+            'available_configs' => [['id', 'name', 'is_active']],
+        ]);
+    }
+
+    public function test_payout_show_forbidden_for_non_member(): void
+    {
+        ['band' => $band, 'booking' => $booking] = $this->setup_booking();
+        $outsider = User::factory()->create();
+        $token = $outsider->createToken('d')->plainTextToken;
+
+        $this->withHeaders($this->headers($token, $band->id))
+            ->getJson("/api/mobile/bands/{$band->id}/bookings/{$booking->id}/payout")
+            ->assertForbidden();
+    }
+}

--- a/tests/Feature/Api/Mobile/BookingPayoutTest.php
+++ b/tests/Feature/Api/Mobile/BookingPayoutTest.php
@@ -311,6 +311,30 @@ class BookingPayoutTest extends TestCase
             ->assertNotFound();
     }
 
+    public function test_update_attendance_rejects_event_from_other_booking(): void
+    {
+        ['band' => $band, 'booking' => $booking, 'token' => $token] = $this->setup_booking();
+
+        // Create a second booking in the SAME band with its own event + member.
+        $booking2 = Bookings::factory()->create(['band_id' => $band->id, 'price' => 500]);
+        $event2 = Events::factory()->create([
+            'eventable_id'   => $booking2->id,
+            'eventable_type' => Bookings::class,
+            'value'          => 500,
+        ]);
+        $member2 = \App\Models\EventMember::create([
+            'event_id' => $event2->id, 'band_id' => $band->id,
+            'name' => 'Alice', 'attendance_status' => 'confirmed',
+        ]);
+
+        // PATCH attendance via booking #1's URL but with booking #2's event and member → 404.
+        $this->withHeaders($this->headers($token, $band->id))
+            ->patchJson("/api/mobile/bands/{$band->id}/bookings/{$booking->id}/events/{$event2->id}/members/{$member2->id}/attendance", [
+                'attendance_status' => 'absent',
+            ])
+            ->assertNotFound();
+    }
+
     public function test_update_attendance_forbidden_for_sub(): void
     {
         ['band' => $band, 'booking' => $booking] = $this->setup_booking();

--- a/tests/Feature/Api/Mobile/BookingPayoutTest.php
+++ b/tests/Feature/Api/Mobile/BookingPayoutTest.php
@@ -209,6 +209,11 @@ class BookingPayoutTest extends TestCase
         $response->assertOk()->assertJsonStructure(['result' => ['band_cut', 'distributable_amount']]);
         $this->assertEquals($other->id, $booking->fresh()->payout->payout_config_id);
         $this->assertEqualsWithDelta(500.0, $response->json('result.band_cut'), 0.01);
+
+        // Assert calculation_result is persisted to the DB and reflects the switched config.
+        $persistedResult = $booking->fresh()->payout->calculation_result;
+        $this->assertIsArray($persistedResult);
+        $this->assertEqualsWithDelta(500.0, $persistedResult['band_cut'], 0.01);
     }
 
     public function test_update_configuration_rejects_config_from_other_band(): void

--- a/tests/Feature/Api/Mobile/BookingPayoutTest.php
+++ b/tests/Feature/Api/Mobile/BookingPayoutTest.php
@@ -103,7 +103,7 @@ class BookingPayoutTest extends TestCase
             ->assertStatus(422);
     }
 
-    public function test_destroy_adjustment_recalculates_and_rejects_foreign(): void
+    public function test_destroy_adjustment_recalculates(): void
     {
         ['band' => $band, 'booking' => $booking, 'token' => $token] = $this->setup_booking();
         $this->withHeaders($this->headers($token, $band->id))
@@ -114,6 +114,46 @@ class BookingPayoutTest extends TestCase
             ->deleteJson("/api/mobile/bands/{$band->id}/bookings/{$booking->id}/payout/adjustments/{$adjId}")
             ->assertOk();
         $this->assertSame('1000.00', (string) $booking->fresh()->payout->adjusted_amount);
+    }
+
+    public function test_destroy_adjustment_rejects_foreign_adjustment(): void
+    {
+        // booking1 belongs to the same band as booking2.  The band-membership
+        // middleware passes for both routes (same user, same band).  The 403
+        // must come exclusively from the payout-ownership guard:
+        //   abort_unless($adjustment->payout_id === $payout->id, 403, …)
+        ['band' => $band, 'booking' => $booking, 'token' => $token] = $this->setup_booking();
+
+        // Create a second booking for the SAME band and same owner.
+        $booking2 = Bookings::factory()->create(['band_id' => $band->id, 'price' => 500]);
+        Events::factory()->create([
+            'eventable_id'   => $booking2->id,
+            'eventable_type' => Bookings::class,
+            'value'          => 500,
+        ]);
+
+        // Add an adjustment to booking #1's payout.
+        $this->withHeaders($this->headers($token, $band->id))
+            ->postJson("/api/mobile/bands/{$band->id}/bookings/{$booking->id}/payout/adjustments", [
+                'amount'      => -100,
+                'description' => 'Booking1 adjustment',
+            ]);
+
+        $adjId = $booking->fresh()->payout->adjustments->first()->id;
+
+        // Ensure booking #2 has a payout record so the cross-ownership guard is
+        // reached (not the earlier 404 "payout not found" guard).
+        $this->withHeaders($this->headers($token, $band->id))
+            ->getJson("/api/mobile/bands/{$band->id}/bookings/{$booking2->id}/payout")
+            ->assertOk();
+
+        // Attempt to delete booking #1's adjustment via booking #2's URL — must be 403.
+        $this->withHeaders($this->headers($token, $band->id))
+            ->deleteJson("/api/mobile/bands/{$band->id}/bookings/{$booking2->id}/payout/adjustments/{$adjId}")
+            ->assertForbidden();
+
+        // Adjustment must still exist in the DB.
+        $this->assertDatabaseHas('payout_adjustments', ['id' => $adjId]);
     }
 
     public function test_store_adjustment_forbidden_for_sub(): void

--- a/tests/Feature/Api/Mobile/BookingPayoutTest.php
+++ b/tests/Feature/Api/Mobile/BookingPayoutTest.php
@@ -192,4 +192,61 @@ class BookingPayoutTest extends TestCase
             ->deleteJson("/api/mobile/bands/{$band->id}/bookings/{$booking->id}/payout/adjustments/{$adjId}")
             ->assertForbidden();
     }
+
+    public function test_update_configuration_switches_and_returns_result(): void
+    {
+        ['band' => $band, 'booking' => $booking, 'token' => $token] = $this->setup_booking();
+        $other = \App\Models\BandPayoutConfig::factory()->create([
+            'band_id' => $band->id, 'is_active' => false,
+            'band_cut_type' => 'percentage', 'band_cut_value' => 50,
+        ]);
+
+        $response = $this->withHeaders($this->headers($token, $band->id))
+            ->putJson("/api/mobile/bands/{$band->id}/bookings/{$booking->id}/payout/configuration", [
+                'payout_config_id' => $other->id,
+            ]);
+
+        $response->assertOk()->assertJsonStructure(['result' => ['band_cut', 'distributable_amount']]);
+        $this->assertEquals($other->id, $booking->fresh()->payout->payout_config_id);
+        $this->assertEqualsWithDelta(500.0, $response->json('result.band_cut'), 0.01);
+    }
+
+    public function test_update_configuration_rejects_config_from_other_band(): void
+    {
+        ['band' => $band, 'booking' => $booking, 'token' => $token] = $this->setup_booking();
+        $foreign = \App\Models\BandPayoutConfig::factory()->create(['band_id' => Bands::factory()->create()->id]);
+
+        $this->withHeaders($this->headers($token, $band->id))
+            ->putJson("/api/mobile/bands/{$band->id}/bookings/{$booking->id}/payout/configuration", ['payout_config_id' => $foreign->id])
+            ->assertStatus(404);
+    }
+
+    public function test_update_configuration_forbidden_for_sub(): void
+    {
+        ['band' => $band, 'booking' => $booking, 'token' => $token] = $this->setup_booking();
+
+        // Owner first switches config to ensure a payout record exists.
+        $config = \App\Models\BandPayoutConfig::factory()->create([
+            'band_id' => $band->id, 'is_active' => false,
+            'band_cut_type' => 'percentage', 'band_cut_value' => 10,
+        ]);
+
+        $this->withHeaders($this->headers($token, $band->id))
+            ->putJson("/api/mobile/bands/{$band->id}/bookings/{$booking->id}/payout/configuration", [
+                'payout_config_id' => $config->id,
+            ])
+            ->assertOk();
+
+        // Sub attempts the same — use actingAs to avoid Sanctum token-cache
+        // interference from the preceding owner request in this same test.
+        $sub = User::factory()->create();
+        BandSubs::create(['user_id' => $sub->id, 'band_id' => $band->id]);
+
+        $this->actingAs($sub, 'sanctum')
+            ->withHeaders(['X-Band-ID' => $band->id, 'Accept' => 'application/json'])
+            ->putJson("/api/mobile/bands/{$band->id}/bookings/{$booking->id}/payout/configuration", [
+                'payout_config_id' => $config->id,
+            ])
+            ->assertForbidden();
+    }
 }

--- a/tests/Feature/Api/Mobile/BookingPayoutTest.php
+++ b/tests/Feature/Api/Mobile/BookingPayoutTest.php
@@ -254,4 +254,80 @@ class BookingPayoutTest extends TestCase
             ])
             ->assertForbidden();
     }
+
+    public function test_update_attendance_sets_status(): void
+    {
+        ['band' => $band, 'booking' => $booking, 'token' => $token] = $this->setup_booking();
+        $event = $booking->fresh()->events->first();
+        $member = \App\Models\EventMember::create([
+            'event_id' => $event->id, 'band_id' => $band->id,
+            'name' => 'Bob', 'attendance_status' => 'confirmed',
+        ]);
+
+        $response = $this->withHeaders($this->headers($token, $band->id))
+            ->patchJson("/api/mobile/bands/{$band->id}/bookings/{$booking->id}/events/{$event->id}/members/{$member->id}/attendance", [
+                'attendance_status' => 'absent',
+            ]);
+
+        $response->assertOk()->assertJsonPath('member.attendance_status', 'absent');
+        $this->assertSame('absent', $member->fresh()->attendance_status);
+    }
+
+    public function test_update_attendance_validates_status_enum(): void
+    {
+        ['band' => $band, 'booking' => $booking, 'token' => $token] = $this->setup_booking();
+        $event = $booking->fresh()->events->first();
+        $member = \App\Models\EventMember::create([
+            'event_id' => $event->id, 'band_id' => $band->id, 'name' => 'Bob',
+            'attendance_status' => 'confirmed',
+        ]);
+
+        $this->withHeaders($this->headers($token, $band->id))
+            ->patchJson("/api/mobile/bands/{$band->id}/bookings/{$booking->id}/events/{$event->id}/members/{$member->id}/attendance", ['attendance_status' => 'playing'])
+            ->assertStatus(422);
+    }
+
+    public function test_update_attendance_member_from_other_event_404(): void
+    {
+        ['band' => $band, 'booking' => $booking, 'token' => $token] = $this->setup_booking();
+        $event = $booking->fresh()->events->first();
+
+        // Create a second event and an EventMember on it.
+        $otherEvent = Events::factory()->create([
+            'eventable_id' => $booking->id,
+            'eventable_type' => Bookings::class,
+            'value' => 0,
+        ]);
+        $otherMember = \App\Models\EventMember::create([
+            'event_id' => $otherEvent->id, 'band_id' => $band->id,
+            'name' => 'Alice', 'attendance_status' => 'confirmed',
+        ]);
+
+        // PATCH via the FIRST event's URL with the member belonging to otherEvent → 404.
+        $this->withHeaders($this->headers($token, $band->id))
+            ->patchJson("/api/mobile/bands/{$band->id}/bookings/{$booking->id}/events/{$event->id}/members/{$otherMember->id}/attendance", [
+                'attendance_status' => 'absent',
+            ])
+            ->assertNotFound();
+    }
+
+    public function test_update_attendance_forbidden_for_sub(): void
+    {
+        ['band' => $band, 'booking' => $booking] = $this->setup_booking();
+        $event = $booking->fresh()->events->first();
+        $member = \App\Models\EventMember::create([
+            'event_id' => $event->id, 'band_id' => $band->id,
+            'name' => 'Bob', 'attendance_status' => 'confirmed',
+        ]);
+
+        $sub = User::factory()->create();
+        BandSubs::create(['user_id' => $sub->id, 'band_id' => $band->id]);
+
+        $this->actingAs($sub, 'sanctum')
+            ->withHeaders(['X-Band-ID' => $band->id, 'Accept' => 'application/json'])
+            ->patchJson("/api/mobile/bands/{$band->id}/bookings/{$booking->id}/events/{$event->id}/members/{$member->id}/attendance", [
+                'attendance_status' => 'absent',
+            ])
+            ->assertForbidden();
+    }
 }


### PR DESCRIPTION
## Summary

Adds mobile-API endpoints exposing **per-booking payout** to the Flutter app (TTS-App), reaching parity with the web payout page. All endpoints wrap the existing payout model logic (`getOrCreatePayout`, `BandPayoutConfig::calculatePayouts`, `Payout::recalculateAdjustedAmount`) and return JSON.

Pairs with the mobile PR: **eddimull/TTS-App#73** (the Flutter consumer).

## Endpoints (all under `/api/mobile/bands/{band}/bookings/{booking}`)

| Method | Path | Purpose | Middleware |
|---|---|---|---|
| GET | `/payout` | Full breakdown: per-member shares across performances, band cut, adjustments, events, available configs | `read:bookings` |
| POST | `/payout/adjustments` | Add a payout adjustment | `write:bookings` |
| DELETE | `/payout/adjustments/{adjustment}` | Remove an adjustment | `write:bookings` |
| PUT | `/payout/configuration` | Switch which payout config applies to this booking | `write:bookings` |
| PATCH | `/events/{event}/members/{member}/attendance` | Set event-member attendance (re-weights payouts) | `write:bookings` |

## Security

- **Sub exclusion:** every payout endpoint rejects band subs (owners + members only) — payout data is financial PII, mirroring `contractHistory`.
- **Cross-band/booking/payout/event isolation:** every mutating endpoint guards `booking → band`, plus the existing `adjustment → payout`, `event → booking`, and `member → event` checks. A dedicated set of regression tests proves cross-band requests return 404 and do not mutate the victim band's data.
- Attendance writes the `attendance_status` column (`confirmed|attended|absent|excused`) — not the legacy `status`/`playing` contract.

## Audit

Adjustment add/remove and config switch emit the same `activity()` log entries as the web controller, so app-driven changes appear in booking history.

## Tests

`docker compose exec app php artisan test --filter=BookingPayoutTest` → **21 passed (74 assertions)**, including same-band happy paths, validation, sub-exclusion (5), and cross-band IDOR regressions (4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)