### PR TITLE
feat(mobile-api): AI rehearsal planner endpoints

### DIFF
--- a/app/Ai/Agents/RehearsalPlannerAgent.php
+++ b/app/Ai/Agents/RehearsalPlannerAgent.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace App\Ai\Agents;
+
+use Laravel\Ai\Attributes\Model;
+use Laravel\Ai\Attributes\Provider;
+use Laravel\Ai\Contracts\Agent;
+use Laravel\Ai\Contracts\Conversational;
+use Laravel\Ai\Enums\Lab;
+use Laravel\Ai\Messages\Message;
+use Laravel\Ai\Promptable;
+
+#[Provider(Lab::Anthropic)]
+#[Model('claude-sonnet-4-6')]
+class RehearsalPlannerAgent implements Agent, Conversational
+{
+    use Promptable;
+
+    /** @var Message[] */
+    private array $priorMessages = [];
+
+    public function withHistory(array $messages): static
+    {
+        $clone = clone $this;
+        $clone->priorMessages = $messages;
+        return $clone;
+    }
+
+    public function instructions(): string
+    {
+        return <<<'TXT'
+You are a professional band rehearsal planner. Help the band leader decide what to
+rehearse, using the supplied context (upcoming events and their requested songs,
+recently rehearsed songs, the roster and their instruments, and the song library).
+
+Behaviour:
+- If upcoming events have requested/setlist songs, focus there. Call out songs on
+  upcoming setlists that do NOT appear in recently rehearsed.
+- If nothing is pending, suggest material in TWO clearly separated groups:
+  "Revisit from your library" (existing songs, reference them by their [id]) and
+  "New repertoire ideas" (real songs NOT in the library that fit the roster/genre).
+- Be concise. End each reply by offering a couple of concrete next steps or an open
+  question.
+- Stay strictly on rehearsal/repertoire planning; politely decline unrelated requests.
+
+When the user asks for a concrete plan, finish your reply with a fenced block:
+```plan
+{"title":"...","items":[{"song_id":123,"title":"...","reason":"..."},{"song_id":null,"title":"...","reason":"..."}]}
+```
+Use song_id from the library where applicable; null for new-repertoire ideas.
+Also, when helpful, finish with a suggestions block of up to 3 quick replies:
+```suggestions
+["Draft a plan for the wedding","Explore new material"]
+```
+TXT;
+    }
+
+    public function messages(): iterable
+    {
+        return $this->priorMessages;
+    }
+}

--- a/app/Events/RehearsalPlannerStreamEvent.php
+++ b/app/Events/RehearsalPlannerStreamEvent.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Events;
+
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Broadcasting\PrivateChannel;
+use Illuminate\Contracts\Broadcasting\ShouldBroadcastNow;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+class RehearsalPlannerStreamEvent implements ShouldBroadcastNow
+{
+    use Dispatchable, InteractsWithSockets, SerializesModels;
+
+    /** @param array<string,mixed> $data */
+    public function __construct(
+        public int $sessionId,
+        public string $type,   // 'text_delta' | 'done' | 'error'
+        public array $data = [],
+    ) {}
+
+    public function broadcastOn(): array
+    {
+        return [new PrivateChannel('rehearsal-planner.' . $this->sessionId)];
+    }
+
+    public function broadcastAs(): string
+    {
+        return 'planner.stream';
+    }
+
+    public function broadcastWith(): array
+    {
+        return array_merge(['type' => $this->type], $this->data);
+    }
+}

--- a/app/Http/Controllers/Api/Mobile/RehearsalPlannerController.php
+++ b/app/Http/Controllers/Api/Mobile/RehearsalPlannerController.php
@@ -3,17 +3,15 @@
 namespace App\Http\Controllers\Api\Mobile;
 
 use App\Http\Controllers\Controller;
+use App\Jobs\RehearsalPlannerTurnJob;
 use App\Models\Bands;
 use App\Models\RehearsalPlannerSession;
-use App\Services\RehearsalPlannerService;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 
 class RehearsalPlannerController extends Controller
 {
-    public function __construct(private RehearsalPlannerService $service) {}
-
     public function start(Bands $band): JsonResponse
     {
         if ($guard = $this->keyGuard()) {
@@ -30,7 +28,7 @@ class RehearsalPlannerController extends Controller
             'status' => 'streaming',
         ]);
 
-        $this->service->runTurn($session, $assistant, null);
+        RehearsalPlannerTurnJob::dispatch($session->id, $assistant->id, null);
 
         return response()->json([
             'session_id'           => $session->id,
@@ -60,7 +58,7 @@ class RehearsalPlannerController extends Controller
             'status' => 'streaming',
         ]);
 
-        $this->service->runTurn($session, $assistant, $validated['text']);
+        RehearsalPlannerTurnJob::dispatch($session->id, $assistant->id, $validated['text']);
 
         return response()->json([
             'user_message'         => $this->formatMessage($user),

--- a/app/Http/Controllers/Api/Mobile/RehearsalPlannerController.php
+++ b/app/Http/Controllers/Api/Mobile/RehearsalPlannerController.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace App\Http\Controllers\Api\Mobile;
+
+use App\Http\Controllers\Controller;
+use App\Models\Bands;
+use App\Models\RehearsalPlannerSession;
+use App\Services\RehearsalPlannerService;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+
+class RehearsalPlannerController extends Controller
+{
+    public function __construct(private RehearsalPlannerService $service) {}
+
+    public function start(Bands $band): JsonResponse
+    {
+        if ($guard = $this->keyGuard()) {
+            return $guard;
+        }
+
+        $session = RehearsalPlannerSession::create([
+            'band_id' => $band->id,
+            'user_id' => Auth::id(),
+        ]);
+
+        $assistant = $session->messages()->create([
+            'role'   => 'assistant',
+            'status' => 'streaming',
+        ]);
+
+        $this->service->runTurn($session, $assistant, null);
+
+        return response()->json([
+            'session_id'           => $session->id,
+            'channel'              => 'private-rehearsal-planner.' . $session->id,
+            'assistant_message_id' => $assistant->id,
+        ]);
+    }
+
+    public function message(Request $request, Bands $band, RehearsalPlannerSession $session): JsonResponse
+    {
+        abort_unless($session->band_id === $band->id, 404);
+
+        if ($guard = $this->keyGuard()) {
+            return $guard;
+        }
+
+        $validated = $request->validate(['text' => 'required|string|max:4000']);
+
+        $user = $session->messages()->create([
+            'role'    => 'user',
+            'content' => $validated['text'],
+            'status'  => 'complete',
+        ]);
+
+        $assistant = $session->messages()->create([
+            'role'   => 'assistant',
+            'status' => 'streaming',
+        ]);
+
+        $this->service->runTurn($session, $assistant, $validated['text']);
+
+        return response()->json([
+            'user_message'         => $this->formatMessage($user),
+            'assistant_message_id' => $assistant->id,
+            'channel'              => 'private-rehearsal-planner.' . $session->id,
+        ]);
+    }
+
+    public function show(Bands $band, RehearsalPlannerSession $session): JsonResponse
+    {
+        abort_unless($session->band_id === $band->id, 404);
+
+        return response()->json([
+            'session_id' => $session->id,
+            'messages'   => $session->messages()->get()->map(fn ($m) => $this->formatMessage($m))->values(),
+        ]);
+    }
+
+    private function formatMessage($m): array
+    {
+        return [
+            'id'      => $m->id,
+            'role'    => $m->role,
+            'content' => $m->content,
+            'payload' => $m->payload,
+            'status'  => $m->status,
+        ];
+    }
+
+    private function keyGuard(): ?JsonResponse
+    {
+        if (!config('services.anthropic.key')) {
+            return response()->json(['error' => 'Anthropic API key not configured.'], 503);
+        }
+        return null;
+    }
+}

--- a/app/Http/Controllers/Api/Mobile/RehearsalPlannerController.php
+++ b/app/Http/Controllers/Api/Mobile/RehearsalPlannerController.php
@@ -28,7 +28,7 @@ class RehearsalPlannerController extends Controller
             'status' => 'streaming',
         ]);
 
-        RehearsalPlannerTurnJob::dispatch($session->id, $assistant->id, null);
+        RehearsalPlannerTurnJob::dispatch($session->id, $assistant->id, null, null);
 
         return response()->json([
             'session_id'           => $session->id,
@@ -58,7 +58,7 @@ class RehearsalPlannerController extends Controller
             'status' => 'streaming',
         ]);
 
-        RehearsalPlannerTurnJob::dispatch($session->id, $assistant->id, $validated['text']);
+        RehearsalPlannerTurnJob::dispatch($session->id, $assistant->id, $validated['text'], $user->id);
 
         return response()->json([
             'user_message'         => $this->formatMessage($user),

--- a/app/Jobs/RehearsalPlannerTurnJob.php
+++ b/app/Jobs/RehearsalPlannerTurnJob.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Jobs;
+
+use App\Models\RehearsalPlannerMessage;
+use App\Models\RehearsalPlannerSession;
+use App\Services\RehearsalPlannerService;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Foundation\Queue\Queueable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+
+class RehearsalPlannerTurnJob implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    /**
+     * Longer than the agent's 120s stream timeout so the queue worker does not
+     * kill the job mid-stream.
+     */
+    public int $timeout = 130;
+
+    public function __construct(
+        public int $sessionId,
+        public int $assistantMessageId,
+        public ?string $userText = null,
+    ) {}
+
+    public function handle(RehearsalPlannerService $service): void
+    {
+        $session = RehearsalPlannerSession::find($this->sessionId);
+        $assistant = RehearsalPlannerMessage::find($this->assistantMessageId);
+
+        if (!$session || !$assistant) {
+            return;
+        }
+
+        $service->runTurn($session, $assistant, $this->userText);
+    }
+}

--- a/app/Jobs/RehearsalPlannerTurnJob.php
+++ b/app/Jobs/RehearsalPlannerTurnJob.php
@@ -2,6 +2,7 @@
 
 namespace App\Jobs;
 
+use App\Events\RehearsalPlannerStreamEvent;
 use App\Models\RehearsalPlannerMessage;
 use App\Models\RehearsalPlannerSession;
 use App\Services\RehearsalPlannerService;
@@ -45,5 +46,29 @@ class RehearsalPlannerTurnJob implements ShouldQueue
         }
 
         $service->runTurn($session, $assistant, $this->userText, $this->userMessageId);
+    }
+
+    /**
+     * Handle job-level death (worker timeout, OOM, deserialization failure).
+     *
+     * If the job dies before the service's own catch block runs, the assistant
+     * message is left in 'streaming' status and the client spins indefinitely.
+     * This method ensures the message is marked 'failed' and an error event is
+     * dispatched so the client can stop waiting.
+     */
+    public function failed(\Throwable $e): void
+    {
+        $assistant = RehearsalPlannerMessage::find($this->assistantMessageId);
+
+        if (!$assistant || $assistant->status !== 'streaming') {
+            return;
+        }
+
+        $assistant->update(['status' => 'failed']);
+
+        RehearsalPlannerStreamEvent::dispatch($this->sessionId, 'error', [
+            'message_id' => $this->assistantMessageId,
+            'error'      => 'The planner failed to respond. Please retry.',
+        ]);
     }
 }

--- a/app/Jobs/RehearsalPlannerTurnJob.php
+++ b/app/Jobs/RehearsalPlannerTurnJob.php
@@ -21,10 +21,18 @@ class RehearsalPlannerTurnJob implements ShouldQueue
      */
     public int $timeout = 130;
 
+    /**
+     * A streamed AI turn must not auto-retry/re-broadcast: a failed turn
+     * is already marked 'failed' and the error event has been dispatched;
+     * retrying would re-run the stream and re-broadcast on a stale placeholder.
+     */
+    public int $tries = 1;
+
     public function __construct(
         public int $sessionId,
         public int $assistantMessageId,
         public ?string $userText = null,
+        public ?int $userMessageId = null,
     ) {}
 
     public function handle(RehearsalPlannerService $service): void
@@ -36,6 +44,6 @@ class RehearsalPlannerTurnJob implements ShouldQueue
             return;
         }
 
-        $service->runTurn($session, $assistant, $this->userText);
+        $service->runTurn($session, $assistant, $this->userText, $this->userMessageId);
     }
 }

--- a/app/Models/RehearsalPlannerMessage.php
+++ b/app/Models/RehearsalPlannerMessage.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class RehearsalPlannerMessage extends Model
+{
+    use HasFactory;
+
+    protected $fillable = ['session_id', 'role', 'content', 'payload', 'status'];
+
+    protected $casts = ['payload' => 'array'];
+
+    public function session(): BelongsTo
+    {
+        return $this->belongsTo(RehearsalPlannerSession::class, 'session_id');
+    }
+}

--- a/app/Models/RehearsalPlannerSession.php
+++ b/app/Models/RehearsalPlannerSession.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+class RehearsalPlannerSession extends Model
+{
+    use HasFactory;
+
+    protected $fillable = ['band_id', 'user_id', 'title'];
+
+    public function band(): BelongsTo
+    {
+        return $this->belongsTo(Bands::class, 'band_id');
+    }
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'user_id');
+    }
+
+    public function messages(): HasMany
+    {
+        return $this->hasMany(RehearsalPlannerMessage::class, 'session_id')->orderBy('id');
+    }
+}

--- a/app/Services/RehearsalPlannerContextBuilder.php
+++ b/app/Services/RehearsalPlannerContextBuilder.php
@@ -75,21 +75,39 @@ class RehearsalPlannerContextBuilder
     {
         // Rehearsals have no `date` column; the date lives on the rehearsal's
         // polymorphic events (Rehearsal morphMany Events as `eventable`).
-        // Pick rehearsals whose most-recent event is in the past, newest first.
+        // Pick rehearsals that have at least one PAST event, newest-past first.
+        //
+        // Ordering subtlety: a rehearsal may have both past AND future events.
+        // Ordering by its overall most-recent event would let a future event
+        // rank a rehearsal — so "last 5 past rehearsals" could be mis-ranked.
+        // We therefore order by each rehearsal's most-recent PAST event date,
+        // ignoring any future events for ranking purposes.
         $today = Carbon::today()->toDateString();
 
+        // We reach associated bookings through `associations()` (hasMany
+        // RehearsalAssociation, morphTo `associable`) rather than the
+        // `Rehearsal::bookings()` morphToMany. The latter injects a default
+        // `associable_type = Rehearsal` pivot constraint AND a manual
+        // `wherePivot('associable_type', Bookings)` constraint, so the two
+        // contradict and the relation always returns zero rows. The
+        // associations path resolves Booking associables correctly.
         $rehearsals = Rehearsal::query()
             ->where('band_id', $band->id)
             ->whereHas('events', fn ($q) => $q->whereDate('date', '<', $today))
-            ->withMax('events', 'date')
-            ->with(['bookings.events.setlist.songs.song'])
-            ->orderByDesc('events_max_date')
+            ->withMax(['events as events_max_past_date' => fn ($q) => $q->whereDate('date', '<', $today)], 'date')
+            ->with(['associations' => fn ($q) => $q->where('associable_type', Bookings::class),
+                    'associations.associable.events.setlist.songs.song'])
+            ->orderByDesc('events_max_past_date')
             ->limit(self::PAST_REHEARSAL_LIMIT)
             ->get();
 
         $titles = collect();
         foreach ($rehearsals as $rehearsal) {
-            foreach ($rehearsal->bookings as $booking) {
+            foreach ($rehearsal->associations as $association) {
+                $booking = $association->associable;
+                if (! $booking instanceof Bookings) {
+                    continue;
+                }
                 foreach ($booking->events as $event) {
                     $songs = $event->setlist?->songs ?? collect();
                     foreach ($songs as $setlistSong) {

--- a/app/Services/RehearsalPlannerContextBuilder.php
+++ b/app/Services/RehearsalPlannerContextBuilder.php
@@ -1,0 +1,153 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\Bands;
+use App\Models\Bookings;
+use App\Models\Events;
+use App\Models\Rehearsal;
+use Carbon\Carbon;
+use Illuminate\Support\Collection;
+
+class RehearsalPlannerContextBuilder
+{
+    private const UPCOMING_LIMIT = 5;
+    private const PAST_REHEARSAL_LIMIT = 5;
+
+    /** @return array{text: string, has_upcoming_requests: bool, song_count: int} */
+    public function build(Bands $band): array
+    {
+        [$upcomingText, $hasRequests] = $this->upcomingEvents($band);
+        $rehearsedText = $this->recentlyRehearsed($band);
+        $personnelText = $this->personnel($band);
+        [$libraryText, $songCount] = $this->songLibrary($band);
+
+        $text = implode("\n\n", [
+            "UPCOMING EVENTS (next " . self::UPCOMING_LIMIT . "):\n" . $upcomingText,
+            "RECENTLY REHEARSED (from last " . self::PAST_REHEARSAL_LIMIT . " rehearsals' bookings):\n" . $rehearsedText,
+            "PERSONNEL & INSTRUMENTS:\n" . $personnelText,
+            "SONG LIBRARY (active):\n" . $libraryText,
+        ]);
+
+        return [
+            'text' => $text,
+            'has_upcoming_requests' => $hasRequests,
+            'song_count' => $songCount,
+        ];
+    }
+
+    /** @return array{0: string, 1: bool} */
+    private function upcomingEvents(Bands $band): array
+    {
+        $today = Carbon::today()->toDateString();
+
+        $events = Events::query()
+            ->where('eventable_type', Bookings::class)
+            ->whereHasMorph('eventable', [Bookings::class], fn ($q) => $q->where('band_id', $band->id))
+            ->whereDate('date', '>=', $today)
+            ->with(['setlist.songs.song'])
+            ->orderBy('date')
+            ->limit(self::UPCOMING_LIMIT)
+            ->get();
+
+        if ($events->isEmpty()) {
+            return ['(none scheduled)', false];
+        }
+
+        $hasRequests = false;
+        $lines = $events->map(function (Events $e) use (&$hasRequests) {
+            $songs = $e->setlist?->songs
+                ?->map(fn ($s) => $s->song?->title)
+                ->filter()
+                ->values() ?? collect();
+            if ($songs->isNotEmpty()) {
+                $hasRequests = true;
+            }
+            $songList = $songs->isEmpty() ? 'no setlist yet' : $songs->implode(', ');
+            $date = is_string($e->date) ? $e->date : optional($e->date)->format('Y-m-d');
+            return "- {$e->title} ({$date}) — {$songList}";
+        })->implode("\n");
+
+        return [$lines, $hasRequests];
+    }
+
+    private function recentlyRehearsed(Bands $band): string
+    {
+        // Rehearsals have no `date` column; the date lives on the rehearsal's
+        // polymorphic events (Rehearsal morphMany Events as `eventable`).
+        // Pick rehearsals whose most-recent event is in the past, newest first.
+        $today = Carbon::today()->toDateString();
+
+        $rehearsals = Rehearsal::query()
+            ->where('band_id', $band->id)
+            ->whereHas('events', fn ($q) => $q->whereDate('date', '<', $today))
+            ->withMax('events', 'date')
+            ->with(['bookings.events.setlist.songs.song'])
+            ->orderByDesc('events_max_date')
+            ->limit(self::PAST_REHEARSAL_LIMIT)
+            ->get();
+
+        $titles = collect();
+        foreach ($rehearsals as $rehearsal) {
+            foreach ($rehearsal->bookings as $booking) {
+                foreach ($booking->events as $event) {
+                    $songs = $event->setlist?->songs ?? collect();
+                    foreach ($songs as $setlistSong) {
+                        if ($setlistSong->song?->title) {
+                            $titles->push($setlistSong->song->title);
+                        }
+                    }
+                }
+            }
+        }
+
+        $unique = $titles->unique()->values();
+        return $unique->isEmpty() ? '(no song data from recent rehearsals)' : $unique->implode(', ');
+    }
+
+    private function personnel(Bands $band): string
+    {
+        $members = $this->rosterMembers($band);
+        if ($members->isEmpty()) {
+            return '(no roster members)';
+        }
+        return $members->map(function ($m) {
+            $role = $m->bandRole?->name ?? 'Unassigned';
+            $name = $m->display_name ?? ($m->name ?? 'Unknown');
+            return "- {$name}: {$role}";
+        })->implode("\n");
+    }
+
+    /** @return Collection */
+    private function rosterMembers(Bands $band): Collection
+    {
+        // Bands -> rosters -> members (with bandRole). Flatten + de-dupe by id.
+        return $band->rosters()
+            ->with('members.bandRole')
+            ->get()
+            ->flatMap(fn ($roster) => $roster->members)
+            ->unique('id')
+            ->values();
+    }
+
+    /** @return array{0: string, 1: int} */
+    private function songLibrary(Bands $band): array
+    {
+        $songs = $band->songs()->where('active', true)->with('leadSinger')->get();
+        if ($songs->isEmpty()) {
+            return ['(empty library)', 0];
+        }
+        $lines = $songs->map(function ($s) {
+            $parts = array_filter([
+                $s->title,
+                $s->artist ? "by {$s->artist}" : null,
+                $s->genre,
+                $s->song_key ? "key {$s->song_key}" : null,
+                $s->bpm ? "{$s->bpm}bpm" : null,
+                $s->leadSinger?->display_name ? "lead {$s->leadSinger->display_name}" : null,
+            ]);
+            return "- [{$s->id}] " . implode(' · ', $parts);
+        })->implode("\n");
+        return [$lines, $songs->count()];
+    }
+}

--- a/app/Services/RehearsalPlannerService.php
+++ b/app/Services/RehearsalPlannerService.php
@@ -1,0 +1,111 @@
+<?php
+
+namespace App\Services;
+
+use App\Ai\Agents\RehearsalPlannerAgent;
+use App\Events\RehearsalPlannerStreamEvent;
+use App\Models\RehearsalPlannerMessage;
+use App\Models\RehearsalPlannerSession;
+use Illuminate\Support\Facades\Log;
+use Laravel\Ai\Messages\Message;
+
+class RehearsalPlannerService
+{
+    public function __construct(
+        private RehearsalPlannerContextBuilder $contextBuilder,
+    ) {}
+
+    public function runTurn(
+        RehearsalPlannerSession $session,
+        RehearsalPlannerMessage $assistantMessage,
+        ?string $userText,
+    ): void {
+        try {
+            $session->loadMissing('band');
+            $context = $this->contextBuilder->build($session->band);
+
+            $history = $this->buildHistory($session, $assistantMessage->id);
+
+            // The opening turn has no userText; prompt the agent to assess the context.
+            $prompt = $userText !== null && $userText !== ''
+                ? $userText
+                : 'Assess what the band should rehearse and open the conversation.';
+
+            // Prepend the context as a system-style preamble on the first user turn.
+            $promptWithContext = "BAND CONTEXT:\n{$context['text']}\n\n---\n{$prompt}";
+
+            $agent = (new RehearsalPlannerAgent())->withHistory($history);
+
+            $full = '';
+            $stream = $agent->stream($promptWithContext, timeout: 120);
+            foreach ($stream as $event) {
+                $arr = method_exists($event, 'toArray') ? $event->toArray() : (array) $event;
+                if (($arr['type'] ?? null) === 'text_delta' && isset($arr['delta'])) {
+                    $full .= $arr['delta'];
+                    RehearsalPlannerStreamEvent::dispatch($session->id, 'text_delta', ['delta' => $arr['delta']]);
+                }
+            }
+
+            $plan        = self::parsePlan($full);
+            $suggestions = self::parseSuggestions($full);
+            $visible     = self::stripBlocks($full);
+
+            $assistantMessage->update([
+                'content' => $visible,
+                'payload' => ['suggestions' => $suggestions, 'plan' => $plan],
+                'status'  => 'complete',
+            ]);
+
+            RehearsalPlannerStreamEvent::dispatch($session->id, 'done', [
+                'message_id'  => $assistantMessage->id,
+                'content'     => $visible,
+                'suggestions' => $suggestions,
+                'plan'        => $plan,
+            ]);
+        } catch (\Throwable $e) {
+            Log::error('RehearsalPlannerService failed', ['error' => $e->getMessage()]);
+            $assistantMessage->update(['status' => 'failed']);
+            RehearsalPlannerStreamEvent::dispatch($session->id, 'error', [
+                'message_id' => $assistantMessage->id,
+                'error'      => 'The planner failed to respond. Please retry.',
+            ]);
+        }
+    }
+
+    /** @return Message[] */
+    private function buildHistory(RehearsalPlannerSession $session, int $excludeMessageId): array
+    {
+        return $session->messages()
+            ->where('id', '<', $excludeMessageId)
+            ->where('status', 'complete')
+            ->get()
+            ->map(fn (RehearsalPlannerMessage $m) => new Message($m->role, (string) $m->content))
+            ->all();
+    }
+
+    public static function parsePlan(string $text): ?array
+    {
+        if (!preg_match('/```plan\s*(\{.*?\})\s*```/s', $text, $m)) {
+            return null;
+        }
+        $decoded = json_decode($m[1], true);
+        return is_array($decoded) ? $decoded : null;
+    }
+
+    /** @return array<int,string> */
+    public static function parseSuggestions(string $text): array
+    {
+        if (!preg_match('/```suggestions\s*(\[.*?\])\s*```/s', $text, $m)) {
+            return [];
+        }
+        $decoded = json_decode($m[1], true);
+        return is_array($decoded) ? array_values(array_filter($decoded, 'is_string')) : [];
+    }
+
+    public static function stripBlocks(string $text): string
+    {
+        $text = preg_replace('/```plan\s*\{.*?\}\s*```/s', '', $text);
+        $text = preg_replace('/```suggestions\s*\[.*?\]\s*```/s', '', $text);
+        return trim($text);
+    }
+}

--- a/app/Services/RehearsalPlannerService.php
+++ b/app/Services/RehearsalPlannerService.php
@@ -24,7 +24,7 @@ class RehearsalPlannerService
             $session->loadMissing('band');
             $context = $this->contextBuilder->build($session->band);
 
-            $history = $this->buildHistory($session, $assistantMessage->id);
+            $history = $this->historyForTurn($session, $assistantMessage, $userText);
 
             // The opening turn has no userText; prompt the agent to assess the context.
             $prompt = $userText !== null && $userText !== ''
@@ -72,8 +72,49 @@ class RehearsalPlannerService
         }
     }
 
-    /** @return Message[] */
-    private function buildHistory(RehearsalPlannerSession $session, int $excludeMessageId): array
+    /**
+     * Build the replayed history for a turn while keeping it disjoint from the
+     * current prompt. History must contain only PRIOR complete turns; the
+     * current user turn (when present) is carried solely by the prompt, so it
+     * is excluded here to avoid the agent seeing it twice.
+     *
+     * The user row is created immediately before the assistant placeholder, so
+     * for a message() turn the current turn's earliest row is the most recent
+     * user message below the assistant placeholder; history must stop strictly
+     * before it. For the opening start() turn there is no user text, so we
+     * simply exclude the assistant placeholder itself.
+     *
+     * Made protected so the disjointness invariant is unit-testable via a thin
+     * subclass seam.
+     *
+     * @return Message[]
+     */
+    protected function historyForTurn(
+        RehearsalPlannerSession $session,
+        RehearsalPlannerMessage $assistantMessage,
+        ?string $userText,
+    ): array {
+        $boundaryId = $assistantMessage->id;
+
+        if ($userText !== null && $userText !== '') {
+            $currentUserId = $session->messages()
+                ->where('role', 'user')
+                ->where('id', '<', $assistantMessage->id)
+                ->max('id');
+            if ($currentUserId !== null) {
+                $boundaryId = $currentUserId;
+            }
+        }
+
+        return $this->buildHistory($session, $boundaryId);
+    }
+
+    /**
+     * Replay only complete turns strictly before $excludeMessageId.
+     *
+     * @return Message[]
+     */
+    protected function buildHistory(RehearsalPlannerSession $session, int $excludeMessageId): array
     {
         return $session->messages()
             ->where('id', '<', $excludeMessageId)

--- a/app/Services/RehearsalPlannerService.php
+++ b/app/Services/RehearsalPlannerService.php
@@ -85,27 +85,29 @@ class RehearsalPlannerService
 
     public static function parsePlan(string $text): ?array
     {
-        if (!preg_match('/```plan\s*(\{.*?\})\s*```/s', $text, $m)) {
+        // Anchor on the fences (brace-count-agnostic) so nested objects in a
+        // multi-item plan are captured whole, not truncated at the first `}`.
+        if (!preg_match('/```plan\s*(.*?)```/s', $text, $m)) {
             return null;
         }
-        $decoded = json_decode($m[1], true);
+        $decoded = json_decode(trim($m[1]), true);
         return is_array($decoded) ? $decoded : null;
     }
 
     /** @return array<int,string> */
     public static function parseSuggestions(string $text): array
     {
-        if (!preg_match('/```suggestions\s*(\[.*?\])\s*```/s', $text, $m)) {
+        if (!preg_match('/```suggestions\s*(.*?)```/s', $text, $m)) {
             return [];
         }
-        $decoded = json_decode($m[1], true);
+        $decoded = json_decode(trim($m[1]), true);
         return is_array($decoded) ? array_values(array_filter($decoded, 'is_string')) : [];
     }
 
     public static function stripBlocks(string $text): string
     {
-        $text = preg_replace('/```plan\s*\{.*?\}\s*```/s', '', $text);
-        $text = preg_replace('/```suggestions\s*\[.*?\]\s*```/s', '', $text);
+        $text = preg_replace('/```plan\s*.*?```/s', '', $text);
+        $text = preg_replace('/```suggestions\s*.*?```/s', '', $text);
         return trim($text);
     }
 }

--- a/app/Services/RehearsalPlannerService.php
+++ b/app/Services/RehearsalPlannerService.php
@@ -19,12 +19,13 @@ class RehearsalPlannerService
         RehearsalPlannerSession $session,
         RehearsalPlannerMessage $assistantMessage,
         ?string $userText,
+        ?int $userMessageId = null,
     ): void {
         try {
             $session->loadMissing('band');
             $context = $this->contextBuilder->build($session->band);
 
-            $history = $this->historyForTurn($session, $assistantMessage, $userText);
+            $history = $this->historyForTurn($session, $assistantMessage, $userText, $userMessageId);
 
             // The opening turn has no userText; prompt the agent to assess the context.
             $prompt = $userText !== null && $userText !== ''
@@ -78,11 +79,11 @@ class RehearsalPlannerService
      * current user turn (when present) is carried solely by the prompt, so it
      * is excluded here to avoid the agent seeing it twice.
      *
-     * The user row is created immediately before the assistant placeholder, so
-     * for a message() turn the current turn's earliest row is the most recent
-     * user message below the assistant placeholder; history must stop strictly
-     * before it. For the opening start() turn there is no user text, so we
-     * simply exclude the assistant placeholder itself.
+     * Invariant: the controller always creates the user row immediately before
+     * the assistant placeholder and passes its id as $userMessageId. When
+     * $userMessageId is provided the history boundary is set directly to that
+     * id (eliminating any fragile re-derivation). When null (opening start()
+     * turn with no user text) we simply exclude the assistant placeholder.
      *
      * Made protected so the disjointness invariant is unit-testable via a thin
      * subclass seam.
@@ -93,17 +94,16 @@ class RehearsalPlannerService
         RehearsalPlannerSession $session,
         RehearsalPlannerMessage $assistantMessage,
         ?string $userText,
+        ?int $userMessageId = null,
     ): array {
-        $boundaryId = $assistantMessage->id;
-
-        if ($userText !== null && $userText !== '') {
-            $currentUserId = $session->messages()
-                ->where('role', 'user')
-                ->where('id', '<', $assistantMessage->id)
-                ->max('id');
-            if ($currentUserId !== null) {
-                $boundaryId = $currentUserId;
-            }
+        if ($userMessageId !== null) {
+            // Boundary passed explicitly: history stops strictly before the
+            // current user row — robust against insertion-order changes.
+            $boundaryId = $userMessageId;
+        } else {
+            // Opening turn (start()): no user row exists; exclude only the
+            // assistant placeholder.
+            $boundaryId = $assistantMessage->id;
         }
 
         return $this->buildHistory($session, $boundaryId);

--- a/database/factories/RehearsalPlannerMessageFactory.php
+++ b/database/factories/RehearsalPlannerMessageFactory.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\RehearsalPlannerMessage;
+use App\Models\RehearsalPlannerSession;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class RehearsalPlannerMessageFactory extends Factory
+{
+    protected $model = RehearsalPlannerMessage::class;
+
+    public function definition(): array
+    {
+        return [
+            'session_id' => RehearsalPlannerSession::factory(),
+            'role'       => 'assistant',
+            'content'    => $this->faker->sentence(),
+            'payload'    => null,
+            'status'     => 'complete',
+        ];
+    }
+}

--- a/database/factories/RehearsalPlannerSessionFactory.php
+++ b/database/factories/RehearsalPlannerSessionFactory.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Bands;
+use App\Models\RehearsalPlannerSession;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class RehearsalPlannerSessionFactory extends Factory
+{
+    protected $model = RehearsalPlannerSession::class;
+
+    public function definition(): array
+    {
+        return [
+            'band_id' => Bands::factory(),
+            'user_id' => User::factory(),
+            'title'   => null,
+        ];
+    }
+}

--- a/database/migrations/2026_06_30_000001_create_rehearsal_planner_sessions_table.php
+++ b/database/migrations/2026_06_30_000001_create_rehearsal_planner_sessions_table.php
@@ -1,0 +1,25 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('rehearsal_planner_sessions', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('band_id')->constrained()->onDelete('cascade');
+            $table->foreignId('user_id')->constrained()->onDelete('cascade');
+            $table->string('title')->nullable();
+            $table->timestamps();
+            $table->index('band_id');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('rehearsal_planner_sessions');
+    }
+};

--- a/database/migrations/2026_06_30_000002_create_rehearsal_planner_messages_table.php
+++ b/database/migrations/2026_06_30_000002_create_rehearsal_planner_messages_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('rehearsal_planner_messages', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('session_id')
+                ->constrained('rehearsal_planner_sessions')
+                ->onDelete('cascade');
+            $table->string('role', 16);            // 'user' | 'assistant'
+            $table->longText('content')->nullable();
+            $table->json('payload')->nullable();   // suggestions / plan
+            $table->string('status', 16)->default('complete'); // streaming|complete|failed
+            $table->timestamps();
+            $table->index('session_id');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('rehearsal_planner_messages');
+    }
+};

--- a/routes/api.php
+++ b/routes/api.php
@@ -15,6 +15,7 @@ use App\Http\Controllers\RehearsalController;
 use App\Http\Controllers\ChunkedUploadController;
 use App\Http\Controllers\Api\Mobile\AuthController as MobileAuthController;
 use App\Http\Controllers\Api\Mobile\BandSettingsController;
+use App\Http\Controllers\Api\Mobile\RehearsalPlannerController;
 
 /*
 |--------------------------------------------------------------------------
@@ -292,6 +293,19 @@ Route::prefix('mobile')->group(function () {
         // ── Rehearsals (read) ──────────────────────────────────────────
         Route::middleware('mobile.band:read:rehearsals')->group(function () {
             Route::get('/bands/{band}/rehearsal-schedules', [App\Http\Controllers\Api\Mobile\RehearsalsController::class, 'schedules'])->name('mobile.rehearsals.schedules');
+        });
+
+        // ── Rehearsal planner (AI) ─────────────────────────────────────
+        // No scopeBindings(): there is no Bands->sessions() relationship to scope
+        // {session} against. Band-scoping is enforced explicitly in the controller
+        // via abort_unless($session->band_id === $band->id, 404).
+        Route::middleware('mobile.band:read:rehearsals')->group(function () {
+            Route::post('/bands/{band}/rehearsal-planner/sessions', [RehearsalPlannerController::class, 'start'])
+                ->name('mobile.rehearsal-planner.start');
+            Route::post('/bands/{band}/rehearsal-planner/sessions/{session}/messages', [RehearsalPlannerController::class, 'message'])
+                ->name('mobile.rehearsal-planner.message');
+            Route::get('/bands/{band}/rehearsal-planner/sessions/{session}', [RehearsalPlannerController::class, 'show'])
+                ->name('mobile.rehearsal-planner.show');
         });
 
         // ── Music / Charts (read) ──────────────────────────────────────

--- a/routes/channels.php
+++ b/routes/channels.php
@@ -25,3 +25,11 @@ Broadcast::channel('setlist.{sessionId}', function ($user, $sessionId) {
     if (!$session) return false;
     return $user->canRead('events', $session->band_id);
 });
+
+Broadcast::channel('rehearsal-planner.{sessionId}', function ($user, $sessionId) {
+    $session = \App\Models\RehearsalPlannerSession::find($sessionId);
+    if (!$session) {
+        return false;
+    }
+    return $user->canRead('rehearsals', $session->band_id);
+});

--- a/tests/Feature/RehearsalPlanner/ContextBuilderTest.php
+++ b/tests/Feature/RehearsalPlanner/ContextBuilderTest.php
@@ -3,6 +3,11 @@
 namespace Tests\Feature\RehearsalPlanner;
 
 use App\Models\Bands;
+use App\Models\Bookings;
+use App\Models\EventSetlist;
+use App\Models\Events;
+use App\Models\Rehearsal;
+use App\Models\SetlistSong;
 use App\Models\Song;
 use App\Services\RehearsalPlannerContextBuilder;
 use Illuminate\Foundation\Testing\RefreshDatabase;
@@ -34,5 +39,99 @@ class ContextBuilderTest extends TestCase
         $result = app(RehearsalPlannerContextBuilder::class)->build($band);
         $this->assertSame(0, $result['song_count']);
         $this->assertStringContainsString('(empty library)', $result['text']);
+    }
+
+    public function test_recently_rehearsed_section_lists_songs_from_past_rehearsal_bookings(): void
+    {
+        $band = Bands::factory()->create();
+
+        // Song that should surface under RECENTLY REHEARSED.
+        $song = Song::factory()->create([
+            'band_id' => $band->id,
+            'active' => true,
+            'title' => 'Past Rehearsed Anthem',
+        ]);
+
+        // A past rehearsal: its polymorphic event is dated before today.
+        $rehearsal = Rehearsal::factory()->forBand($band)->create();
+        Events::factory()->create([
+            'eventable_type' => Rehearsal::class,
+            'eventable_id' => $rehearsal->id,
+            'date' => now()->subWeek()->toDateString(),
+        ]);
+
+        // A booking associated with that rehearsal, whose event carries a setlist song.
+        // The pivot's morph type must be set explicitly to Bookings: this is the
+        // inverse side of a morphToMany, so attach() would otherwise write the
+        // parent's class (Rehearsal). The builder reads associations where
+        // associable_type = Bookings, so the row must be tagged correctly.
+        $booking = Bookings::factory()->create(['band_id' => $band->id]);
+        $rehearsal->bookings()->attach($booking->id, ['associable_type' => Bookings::class]);
+
+        $bookingEvent = Events::factory()->create([
+            'eventable_type' => Bookings::class,
+            'eventable_id' => $booking->id,
+            'date' => now()->subWeek()->toDateString(),
+        ]);
+        $setlist = EventSetlist::create([
+            'event_id' => $bookingEvent->id,
+            'band_id' => $band->id,
+            'status' => 'ready',
+        ]);
+        SetlistSong::create([
+            'setlist_id' => $setlist->id,
+            'song_id' => $song->id,
+            'position' => 1,
+        ]);
+
+        $result = app(RehearsalPlannerContextBuilder::class)->build($band->fresh());
+
+        $this->assertStringContainsString('Past Rehearsed Anthem', $result['text']);
+        // The title must appear within the RECENTLY REHEARSED section.
+        $recentlyRehearsed = substr(
+            $result['text'],
+            strpos($result['text'], 'RECENTLY REHEARSED'),
+            strpos($result['text'], 'PERSONNEL & INSTRUMENTS') - strpos($result['text'], 'RECENTLY REHEARSED')
+        );
+        $this->assertStringContainsString('Past Rehearsed Anthem', $recentlyRehearsed);
+    }
+
+    public function test_upcoming_event_with_setlist_sets_has_upcoming_requests(): void
+    {
+        $band = Bands::factory()->create();
+
+        $song = Song::factory()->create([
+            'band_id' => $band->id,
+            'active' => true,
+            'title' => 'Future Request Tune',
+        ]);
+
+        // Upcoming booking event (dated in the future) with a setlist song.
+        $booking = Bookings::factory()->create(['band_id' => $band->id]);
+        $event = Events::factory()->create([
+            'eventable_type' => Bookings::class,
+            'eventable_id' => $booking->id,
+            'date' => now()->addWeek()->toDateString(),
+        ]);
+        $setlist = EventSetlist::create([
+            'event_id' => $event->id,
+            'band_id' => $band->id,
+            'status' => 'ready',
+        ]);
+        SetlistSong::create([
+            'setlist_id' => $setlist->id,
+            'song_id' => $song->id,
+            'position' => 1,
+        ]);
+
+        $result = app(RehearsalPlannerContextBuilder::class)->build($band->fresh());
+
+        $this->assertTrue($result['has_upcoming_requests']);
+        $upcoming = substr(
+            $result['text'],
+            strpos($result['text'], 'UPCOMING EVENTS'),
+            strpos($result['text'], 'RECENTLY REHEARSED') - strpos($result['text'], 'UPCOMING EVENTS')
+        );
+        $this->assertStringContainsString('Future Request Tune', $upcoming);
     }
 }

--- a/tests/Feature/RehearsalPlanner/ContextBuilderTest.php
+++ b/tests/Feature/RehearsalPlanner/ContextBuilderTest.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Tests\Feature\RehearsalPlanner;
+
+use App\Models\Bands;
+use App\Models\Song;
+use App\Services\RehearsalPlannerContextBuilder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class ContextBuilderTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_build_includes_four_sections_and_song_count(): void
+    {
+        $band = Bands::factory()->create();
+        Song::factory()->count(2)->create(['band_id' => $band->id, 'active' => true]);
+        Song::factory()->create(['band_id' => $band->id, 'active' => false]); // excluded
+
+        $result = app(RehearsalPlannerContextBuilder::class)->build($band->fresh());
+
+        $this->assertStringContainsString('UPCOMING EVENTS', $result['text']);
+        $this->assertStringContainsString('RECENTLY REHEARSED', $result['text']);
+        $this->assertStringContainsString('PERSONNEL & INSTRUMENTS', $result['text']);
+        $this->assertStringContainsString('SONG LIBRARY', $result['text']);
+        $this->assertSame(2, $result['song_count']);          // only active songs
+        $this->assertFalse($result['has_upcoming_requests']); // no events with setlists
+    }
+
+    public function test_empty_band_does_not_throw(): void
+    {
+        $band = Bands::factory()->create();
+        $result = app(RehearsalPlannerContextBuilder::class)->build($band);
+        $this->assertSame(0, $result['song_count']);
+        $this->assertStringContainsString('(empty library)', $result['text']);
+    }
+}

--- a/tests/Feature/RehearsalPlanner/PlannerControllerTest.php
+++ b/tests/Feature/RehearsalPlanner/PlannerControllerTest.php
@@ -73,7 +73,8 @@ class PlannerControllerTest extends TestCase
             RehearsalPlannerTurnJob::class,
             fn (RehearsalPlannerTurnJob $job) => $job->sessionId === (int) $res->json('session_id')
                 && $job->assistantMessageId === (int) $res->json('assistant_message_id')
-                && $job->userText === null,
+                && $job->userText === null
+                && $job->userMessageId === null,
         );
     }
 
@@ -108,7 +109,8 @@ class PlannerControllerTest extends TestCase
             RehearsalPlannerTurnJob::class,
             fn (RehearsalPlannerTurnJob $job) => $job->sessionId === $session->id
                 && $job->assistantMessageId === (int) $res->json('assistant_message_id')
-                && $job->userText === 'What should we rehearse?',
+                && $job->userText === 'What should we rehearse?'
+                && $job->userMessageId === (int) $res->json('user_message.id'),
         );
     }
 

--- a/tests/Feature/RehearsalPlanner/PlannerControllerTest.php
+++ b/tests/Feature/RehearsalPlanner/PlannerControllerTest.php
@@ -1,0 +1,161 @@
+<?php
+
+namespace Tests\Feature\RehearsalPlanner;
+
+use App\Models\Bands;
+use App\Models\RehearsalPlannerSession;
+use App\Models\User;
+use App\Services\RehearsalPlannerService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class PlannerControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /**
+     * Create a user who owns the band, authenticated via Sanctum.
+     *
+     * The `mobile.band:read:rehearsals` middleware (EnsureUserInBand) has
+     * three gates: (1) X-Band-ID header present, (2) band membership via
+     * allBands(), (3) Sanctum tokenCan('read:rehearsals'). Owning the band
+     * satisfies membership; a plain createToken() grants ['*'] abilities so
+     * tokenCan passes. The X-Band-ID header (and bearer token) must be sent
+     * on every request (see headers()). This mirrors
+     * tests/Feature/Api/Mobile/RehearsalsTest.php exactly.
+     */
+    private function actingMember(): array
+    {
+        $user = User::factory()->create();
+        $band = Bands::factory()->create();
+        $band->owners()->create(['user_id' => $user->id]);
+
+        $token = $user->createToken('test-device')->plainTextToken;
+        config(['services.anthropic.key' => 'test-key']);
+
+        return [$user, $band, $token];
+    }
+
+    private function headers(Bands $band): array
+    {
+        return ['X-Band-ID' => $band->id];
+    }
+
+    public function test_start_creates_session_and_placeholder_and_returns_channel(): void
+    {
+        // Stub the service so runTurn does nothing (no AI).
+        $this->mock(RehearsalPlannerService::class, function ($m) {
+            $m->shouldReceive('runTurn')->once();
+        });
+
+        [$user, $band, $token] = $this->actingMember();
+
+        $res = $this->withToken($token)->postJson(
+            "/api/mobile/bands/{$band->id}/rehearsal-planner/sessions",
+            [],
+            $this->headers($band)
+        );
+
+        $res->assertOk()->assertJsonStructure(['session_id', 'channel', 'assistant_message_id']);
+        $this->assertSame('private-rehearsal-planner.' . $res->json('session_id'), $res->json('channel'));
+        $this->assertDatabaseHas('rehearsal_planner_sessions', [
+            'id'      => $res->json('session_id'),
+            'band_id' => $band->id,
+            'user_id' => $user->id,
+        ]);
+        $this->assertDatabaseHas('rehearsal_planner_messages', [
+            'id'     => $res->json('assistant_message_id'),
+            'role'   => 'assistant',
+            'status' => 'streaming',
+        ]);
+    }
+
+    public function test_message_persists_user_turn(): void
+    {
+        $this->mock(RehearsalPlannerService::class, fn ($m) => $m->shouldReceive('runTurn')->once());
+
+        [$user, $band, $token] = $this->actingMember();
+        $session = RehearsalPlannerSession::factory()->create([
+            'band_id' => $band->id,
+            'user_id' => $user->id,
+        ]);
+
+        $res = $this->withToken($token)->postJson(
+            "/api/mobile/bands/{$band->id}/rehearsal-planner/sessions/{$session->id}/messages",
+            ['text' => 'What should we rehearse?'],
+            $this->headers($band)
+        );
+
+        $res->assertOk()->assertJsonStructure([
+            'user_message' => ['id', 'role', 'content'],
+            'assistant_message_id',
+            'channel',
+        ]);
+        $this->assertDatabaseHas('rehearsal_planner_messages', [
+            'session_id' => $session->id,
+            'role'       => 'user',
+            'content'    => 'What should we rehearse?',
+        ]);
+    }
+
+    public function test_missing_api_key_returns_503(): void
+    {
+        [$user, $band, $token] = $this->actingMember();
+        config(['services.anthropic.key' => null]);
+
+        $this->withToken($token)->postJson(
+            "/api/mobile/bands/{$band->id}/rehearsal-planner/sessions",
+            [],
+            $this->headers($band)
+        )
+            ->assertStatus(503)
+            ->assertJson(['error' => 'Anthropic API key not configured.']);
+    }
+
+    public function test_requires_auth(): void
+    {
+        $band = Bands::factory()->create();
+        $this->postJson("/api/mobile/bands/{$band->id}/rehearsal-planner/sessions")
+            ->assertUnauthorized();
+    }
+
+    public function test_show_for_session_from_another_band_returns_404(): void
+    {
+        [$user, $band, $token] = $this->actingMember();
+
+        // A session belonging to a DIFFERENT band the user also owns
+        // (so route membership passes) but mismatched against the URL band.
+        $otherBand = Bands::factory()->create();
+        $otherBand->owners()->create(['user_id' => $user->id]);
+        $session = RehearsalPlannerSession::factory()->create([
+            'band_id' => $otherBand->id,
+            'user_id' => $user->id,
+        ]);
+
+        // URL + header use $band, but the session belongs to $otherBand → abort_unless 404.
+        $this->withToken($token)->getJson(
+            "/api/mobile/bands/{$band->id}/rehearsal-planner/sessions/{$session->id}",
+            $this->headers($band)
+        )->assertNotFound();
+    }
+
+    public function test_message_for_session_from_another_band_returns_404(): void
+    {
+        $this->mock(RehearsalPlannerService::class, fn ($m) => $m->shouldReceive('runTurn')->never());
+
+        [$user, $band, $token] = $this->actingMember();
+
+        $otherBand = Bands::factory()->create();
+        $otherBand->owners()->create(['user_id' => $user->id]);
+        $session = RehearsalPlannerSession::factory()->create([
+            'band_id' => $otherBand->id,
+            'user_id' => $user->id,
+        ]);
+
+        $this->withToken($token)->postJson(
+            "/api/mobile/bands/{$band->id}/rehearsal-planner/sessions/{$session->id}/messages",
+            ['text' => 'cross-band attempt'],
+            $this->headers($band)
+        )->assertNotFound();
+    }
+}

--- a/tests/Feature/RehearsalPlanner/PlannerControllerTest.php
+++ b/tests/Feature/RehearsalPlanner/PlannerControllerTest.php
@@ -2,11 +2,12 @@
 
 namespace Tests\Feature\RehearsalPlanner;
 
+use App\Jobs\RehearsalPlannerTurnJob;
 use App\Models\Bands;
 use App\Models\RehearsalPlannerSession;
 use App\Models\User;
-use App\Services\RehearsalPlannerService;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Queue;
 use Tests\TestCase;
 
 class PlannerControllerTest extends TestCase
@@ -41,12 +42,11 @@ class PlannerControllerTest extends TestCase
         return ['X-Band-ID' => $band->id];
     }
 
-    public function test_start_creates_session_and_placeholder_and_returns_channel(): void
+    public function test_start_creates_session_and_placeholder_and_dispatches_job(): void
     {
-        // Stub the service so runTurn does nothing (no AI).
-        $this->mock(RehearsalPlannerService::class, function ($m) {
-            $m->shouldReceive('runTurn')->once();
-        });
+        // The turn runs on the queue (Fix 1): the request returns the channel
+        // immediately, before any broadcast, and pushes the job.
+        Queue::fake();
 
         [$user, $band, $token] = $this->actingMember();
 
@@ -68,11 +68,18 @@ class PlannerControllerTest extends TestCase
             'role'   => 'assistant',
             'status' => 'streaming',
         ]);
+
+        Queue::assertPushed(
+            RehearsalPlannerTurnJob::class,
+            fn (RehearsalPlannerTurnJob $job) => $job->sessionId === (int) $res->json('session_id')
+                && $job->assistantMessageId === (int) $res->json('assistant_message_id')
+                && $job->userText === null,
+        );
     }
 
-    public function test_message_persists_user_turn(): void
+    public function test_message_persists_user_turn_and_dispatches_job(): void
     {
-        $this->mock(RehearsalPlannerService::class, fn ($m) => $m->shouldReceive('runTurn')->once());
+        Queue::fake();
 
         [$user, $band, $token] = $this->actingMember();
         $session = RehearsalPlannerSession::factory()->create([
@@ -96,6 +103,13 @@ class PlannerControllerTest extends TestCase
             'role'       => 'user',
             'content'    => 'What should we rehearse?',
         ]);
+
+        Queue::assertPushed(
+            RehearsalPlannerTurnJob::class,
+            fn (RehearsalPlannerTurnJob $job) => $job->sessionId === $session->id
+                && $job->assistantMessageId === (int) $res->json('assistant_message_id')
+                && $job->userText === 'What should we rehearse?',
+        );
     }
 
     public function test_missing_api_key_returns_503(): void
@@ -141,7 +155,7 @@ class PlannerControllerTest extends TestCase
 
     public function test_message_for_session_from_another_band_returns_404(): void
     {
-        $this->mock(RehearsalPlannerService::class, fn ($m) => $m->shouldReceive('runTurn')->never());
+        Queue::fake();
 
         [$user, $band, $token] = $this->actingMember();
 
@@ -157,5 +171,7 @@ class PlannerControllerTest extends TestCase
             ['text' => 'cross-band attempt'],
             $this->headers($band)
         )->assertNotFound();
+
+        Queue::assertNothingPushed();
     }
 }

--- a/tests/Feature/RehearsalPlanner/PlannerModelsTest.php
+++ b/tests/Feature/RehearsalPlanner/PlannerModelsTest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Tests\Feature\RehearsalPlanner;
+
+use App\Models\RehearsalPlannerMessage;
+use App\Models\RehearsalPlannerSession;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class PlannerModelsTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_session_has_ordered_messages_and_payload_casts_to_array(): void
+    {
+        $session = RehearsalPlannerSession::factory()->create();
+
+        RehearsalPlannerMessage::factory()->create([
+            'session_id' => $session->id,
+            'role'       => 'user',
+            'content'    => 'Plan next week',
+            'status'     => 'complete',
+        ]);
+        RehearsalPlannerMessage::factory()->create([
+            'session_id' => $session->id,
+            'role'       => 'assistant',
+            'content'    => 'Here is a plan',
+            'payload'    => ['suggestions' => ['A', 'B'], 'plan' => null],
+            'status'     => 'complete',
+        ]);
+
+        $session->refresh()->load('messages');
+
+        $this->assertCount(2, $session->messages);
+        $this->assertSame('user', $session->messages->first()->role);
+        $this->assertIsArray($session->messages->last()->payload);
+        $this->assertSame(['A', 'B'], $session->messages->last()->payload['suggestions']);
+    }
+}

--- a/tests/Feature/RehearsalPlanner/PlannerServiceTest.php
+++ b/tests/Feature/RehearsalPlanner/PlannerServiceTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Feature\RehearsalPlanner;
 
+use App\Ai\Agents\RehearsalPlannerAgent;
 use App\Events\RehearsalPlannerStreamEvent;
 use App\Models\RehearsalPlannerMessage;
 use App\Models\RehearsalPlannerSession;
@@ -200,5 +201,58 @@ class PlannerServiceTest extends TestCase
         $contents = array_map(fn (Message $m) => (string) $m->content, $history);
 
         $this->assertSame(['Earlier message'], $contents);
+    }
+
+    public function test_run_turn_happy_path_streams_and_persists(): void
+    {
+        // Fix 2: live streaming happy-path — uses laravel/ai's built-in
+        // FakeTextGateway (RehearsalPlannerAgent::fake()) which drives the
+        // full stream→accumulate→persist→done flow without a live AI call.
+        Event::fake([RehearsalPlannerStreamEvent::class]);
+
+        $fakeResponse = "Here is your plan.\n" .
+            "```plan\n" .
+            "{\"title\":\"Wedding Prep\",\"items\":[{\"song_id\":1,\"title\":\"Song A\",\"reason\":\"popular\"}]}\n" .
+            "```\n" .
+            "```suggestions\n[\"Draft another plan\",\"Explore new songs\"]\n```";
+
+        RehearsalPlannerAgent::fake([$fakeResponse]);
+
+        $session = RehearsalPlannerSession::factory()->create();
+        $assistant = RehearsalPlannerMessage::factory()->create([
+            'session_id' => $session->id,
+            'role'       => 'assistant',
+            'status'     => 'streaming',
+        ]);
+
+        $service = app(RehearsalPlannerService::class);
+        $service->runTurn($session, $assistant, 'What should we rehearse?');
+
+        $fresh = $assistant->fresh();
+
+        // Message must be complete with stripped visible text (no fenced blocks).
+        $this->assertSame('complete', $fresh->status);
+        $this->assertStringContainsString('Here is your plan.', $fresh->content);
+        $this->assertStringNotContainsString('```plan', $fresh->content);
+        $this->assertStringNotContainsString('```suggestions', $fresh->content);
+
+        // Payload must contain the parsed plan and suggestions.
+        $payload = $fresh->payload;
+        $this->assertSame('Wedding Prep', $payload['plan']['title'] ?? null);
+        $this->assertCount(1, $payload['plan']['items'] ?? []);
+        $this->assertSame(['Draft another plan', 'Explore new songs'], $payload['suggestions'] ?? []);
+
+        // At least one text_delta event and exactly one done event must be dispatched.
+        Event::assertDispatched(
+            RehearsalPlannerStreamEvent::class,
+            fn (RehearsalPlannerStreamEvent $e) => $e->type === 'text_delta'
+                && $e->sessionId === $session->id,
+        );
+        Event::assertDispatched(
+            RehearsalPlannerStreamEvent::class,
+            fn (RehearsalPlannerStreamEvent $e) => $e->type === 'done'
+                && $e->sessionId === $session->id
+                && ($e->data['message_id'] ?? null) === $assistant->id,
+        );
     }
 }

--- a/tests/Feature/RehearsalPlanner/PlannerServiceTest.php
+++ b/tests/Feature/RehearsalPlanner/PlannerServiceTest.php
@@ -9,6 +9,7 @@ use App\Services\RehearsalPlannerContextBuilder;
 use App\Services\RehearsalPlannerService;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Event;
+use Laravel\Ai\Messages\Message;
 use Tests\TestCase;
 
 class PlannerServiceTest extends TestCase
@@ -107,5 +108,95 @@ class PlannerServiceTest extends TestCase
                 && $e->sessionId === $session->id
                 && ($e->data['message_id'] ?? null) === $assistant->id,
         );
+    }
+
+    public function test_history_excludes_current_user_turn_but_keeps_prior_turns(): void
+    {
+        // Fix 2 invariant: history carries only PRIOR complete turns; the
+        // current user turn is carried solely by the prompt, so it must NOT be
+        // replayed in history (otherwise the agent sees it twice).
+        $session = RehearsalPlannerSession::factory()->create();
+
+        // A prior, complete user+assistant exchange.
+        $priorUser = RehearsalPlannerMessage::factory()->create([
+            'session_id' => $session->id,
+            'role'       => 'user',
+            'content'    => 'Prior question',
+            'status'     => 'complete',
+        ]);
+        $priorAssistant = RehearsalPlannerMessage::factory()->create([
+            'session_id' => $session->id,
+            'role'       => 'assistant',
+            'content'    => 'Prior answer',
+            'status'     => 'complete',
+        ]);
+
+        // The current turn: a new user message followed by the assistant
+        // placeholder (mirrors the controller's create order).
+        $currentUser = RehearsalPlannerMessage::factory()->create([
+            'session_id' => $session->id,
+            'role'       => 'user',
+            'content'    => 'Current question',
+            'status'     => 'complete',
+        ]);
+        $assistant = RehearsalPlannerMessage::factory()->create([
+            'session_id' => $session->id,
+            'role'       => 'assistant',
+            'status'     => 'streaming',
+        ]);
+
+        $service = new class (app(RehearsalPlannerContextBuilder::class)) extends RehearsalPlannerService {
+            public function exposeHistory(
+                RehearsalPlannerSession $session,
+                RehearsalPlannerMessage $assistant,
+                ?string $userText,
+            ): array {
+                return $this->historyForTurn($session, $assistant, $userText);
+            }
+        };
+
+        /** @var Message[] $history */
+        $history = $service->exposeHistory($session, $assistant, 'Current question');
+
+        $contents = array_map(fn (Message $m) => (string) $m->content, $history);
+
+        $this->assertContains('Prior question', $contents);
+        $this->assertContains('Prior answer', $contents);
+        $this->assertNotContains('Current question', $contents, 'Current user turn must NOT be replayed in history.');
+        $this->assertCount(2, $history, 'History should contain only the two prior turns.');
+    }
+
+    public function test_start_turn_history_excludes_only_assistant_placeholder(): void
+    {
+        // The opening start() turn has no user text; prior complete turns (if
+        // any) are replayed and only the assistant placeholder is excluded.
+        $session = RehearsalPlannerSession::factory()->create();
+
+        $priorUser = RehearsalPlannerMessage::factory()->create([
+            'session_id' => $session->id,
+            'role'       => 'user',
+            'content'    => 'Earlier message',
+            'status'     => 'complete',
+        ]);
+        $assistant = RehearsalPlannerMessage::factory()->create([
+            'session_id' => $session->id,
+            'role'       => 'assistant',
+            'status'     => 'streaming',
+        ]);
+
+        $service = new class (app(RehearsalPlannerContextBuilder::class)) extends RehearsalPlannerService {
+            public function exposeHistory(
+                RehearsalPlannerSession $session,
+                RehearsalPlannerMessage $assistant,
+                ?string $userText,
+            ): array {
+                return $this->historyForTurn($session, $assistant, $userText);
+            }
+        };
+
+        $history = $service->exposeHistory($session, $assistant, null);
+        $contents = array_map(fn (Message $m) => (string) $m->content, $history);
+
+        $this->assertSame(['Earlier message'], $contents);
     }
 }

--- a/tests/Feature/RehearsalPlanner/PlannerServiceTest.php
+++ b/tests/Feature/RehearsalPlanner/PlannerServiceTest.php
@@ -15,22 +15,61 @@ class PlannerServiceTest extends TestCase
 {
     use RefreshDatabase;
 
-    public function test_parse_plan_and_suggestions_and_strip(): void
+    public function test_parse_plan_with_multiple_nested_items_and_strip(): void
     {
+        // A multi-item plan: nested array of objects. The old brace-anchored
+        // regex (`\{.*?\}`) stops at the first inner `}`, yielding invalid JSON
+        // and silently dropping the plan. The fence-anchored regex must capture
+        // the entire JSON body.
         $text = "Here is my plan.\n".
-            "```plan\n{\"title\":\"T\",\"items\":[{\"song_id\":1,\"title\":\"A\",\"reason\":\"r\"}]}\n```\n".
+            "```plan\n".
+            "{\"title\":\"Wedding\",\"items\":[".
+            "{\"song_id\":1,\"title\":\"A\",\"reason\":\"r\"},".
+            "{\"song_id\":null,\"title\":\"B\",\"reason\":\"r2\"}".
+            "]}\n".
+            "```";
+
+        $plan = RehearsalPlannerService::parsePlan($text);
+        $this->assertNotNull($plan, 'Multi-item plan must parse, not be dropped.');
+        $this->assertSame('Wedding', $plan['title']);
+        $this->assertCount(2, $plan['items']);
+        $this->assertSame(1, $plan['items'][0]['song_id']);
+        $this->assertNull($plan['items'][1]['song_id']);
+        $this->assertSame('B', $plan['items'][1]['title']);
+
+        $stripped = RehearsalPlannerService::stripBlocks($text);
+        $this->assertStringNotContainsString('```plan', $stripped);
+        // The fenced block's tail must be fully removed — no JSON leftovers.
+        $this->assertStringNotContainsString('"items"', $stripped);
+        $this->assertStringNotContainsString('}', $stripped);
+        $this->assertStringNotContainsString(']', $stripped);
+        $this->assertStringContainsString('Here is my plan.', $stripped);
+    }
+
+    public function test_parse_both_plan_and_suggestions_and_strip_both(): void
+    {
+        $text = "Some prose first.\n".
+            "```plan\n".
+            "{\"title\":\"T\",\"items\":[".
+            "{\"song_id\":1,\"title\":\"A\",\"reason\":\"r\"},".
+            "{\"song_id\":2,\"title\":\"B\",\"reason\":\"r2\"}".
+            "]}\n".
+            "```\n".
             "```suggestions\n[\"One\",\"Two\"]\n```";
 
         $plan = RehearsalPlannerService::parsePlan($text);
         $this->assertSame('T', $plan['title']);
-        $this->assertSame(1, $plan['items'][0]['song_id']);
+        $this->assertCount(2, $plan['items']);
+        $this->assertSame(2, $plan['items'][1]['song_id']);
 
         $this->assertSame(['One', 'Two'], RehearsalPlannerService::parseSuggestions($text));
 
         $stripped = RehearsalPlannerService::stripBlocks($text);
         $this->assertStringNotContainsString('```plan', $stripped);
         $this->assertStringNotContainsString('```suggestions', $stripped);
-        $this->assertStringContainsString('Here is my plan.', $stripped);
+        $this->assertStringNotContainsString('"items"', $stripped);
+        $this->assertStringNotContainsString('One', $stripped);
+        $this->assertSame('Some prose first.', $stripped);
     }
 
     public function test_no_blocks_returns_null_and_empty(): void

--- a/tests/Feature/RehearsalPlanner/PlannerServiceTest.php
+++ b/tests/Feature/RehearsalPlanner/PlannerServiceTest.php
@@ -150,13 +150,14 @@ class PlannerServiceTest extends TestCase
                 RehearsalPlannerSession $session,
                 RehearsalPlannerMessage $assistant,
                 ?string $userText,
+                ?int $userMessageId = null,
             ): array {
-                return $this->historyForTurn($session, $assistant, $userText);
+                return $this->historyForTurn($session, $assistant, $userText, $userMessageId);
             }
         };
 
         /** @var Message[] $history */
-        $history = $service->exposeHistory($session, $assistant, 'Current question');
+        $history = $service->exposeHistory($session, $assistant, 'Current question', $currentUser->id);
 
         $contents = array_map(fn (Message $m) => (string) $m->content, $history);
 
@@ -189,12 +190,13 @@ class PlannerServiceTest extends TestCase
                 RehearsalPlannerSession $session,
                 RehearsalPlannerMessage $assistant,
                 ?string $userText,
+                ?int $userMessageId = null,
             ): array {
-                return $this->historyForTurn($session, $assistant, $userText);
+                return $this->historyForTurn($session, $assistant, $userText, $userMessageId);
             }
         };
 
-        $history = $service->exposeHistory($session, $assistant, null);
+        $history = $service->exposeHistory($session, $assistant, null, null);
         $contents = array_map(fn (Message $m) => (string) $m->content, $history);
 
         $this->assertSame(['Earlier message'], $contents);

--- a/tests/Feature/RehearsalPlanner/PlannerServiceTest.php
+++ b/tests/Feature/RehearsalPlanner/PlannerServiceTest.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Tests\Feature\RehearsalPlanner;
+
+use App\Events\RehearsalPlannerStreamEvent;
+use App\Models\RehearsalPlannerMessage;
+use App\Models\RehearsalPlannerSession;
+use App\Services\RehearsalPlannerContextBuilder;
+use App\Services\RehearsalPlannerService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Event;
+use Tests\TestCase;
+
+class PlannerServiceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_parse_plan_and_suggestions_and_strip(): void
+    {
+        $text = "Here is my plan.\n".
+            "```plan\n{\"title\":\"T\",\"items\":[{\"song_id\":1,\"title\":\"A\",\"reason\":\"r\"}]}\n```\n".
+            "```suggestions\n[\"One\",\"Two\"]\n```";
+
+        $plan = RehearsalPlannerService::parsePlan($text);
+        $this->assertSame('T', $plan['title']);
+        $this->assertSame(1, $plan['items'][0]['song_id']);
+
+        $this->assertSame(['One', 'Two'], RehearsalPlannerService::parseSuggestions($text));
+
+        $stripped = RehearsalPlannerService::stripBlocks($text);
+        $this->assertStringNotContainsString('```plan', $stripped);
+        $this->assertStringNotContainsString('```suggestions', $stripped);
+        $this->assertStringContainsString('Here is my plan.', $stripped);
+    }
+
+    public function test_no_blocks_returns_null_and_empty(): void
+    {
+        $text = 'Just a normal reply.';
+        $this->assertNull(RehearsalPlannerService::parsePlan($text));
+        $this->assertSame([], RehearsalPlannerService::parseSuggestions($text));
+        $this->assertSame('Just a normal reply.', RehearsalPlannerService::stripBlocks($text));
+    }
+
+    public function test_run_turn_error_path_marks_message_failed_and_dispatches_error(): void
+    {
+        Event::fake([RehearsalPlannerStreamEvent::class]);
+
+        // Context build throws -> exercises the catch branch with no live AI call.
+        $builder = $this->createMock(RehearsalPlannerContextBuilder::class);
+        $builder->method('build')->willThrowException(new \RuntimeException('boom'));
+
+        $service = new RehearsalPlannerService($builder);
+
+        $session = RehearsalPlannerSession::factory()->create();
+        $assistant = RehearsalPlannerMessage::factory()->create([
+            'session_id' => $session->id,
+            'role'       => 'assistant',
+            'status'     => 'streaming',
+        ]);
+
+        $service->runTurn($session, $assistant, 'hello');
+
+        $this->assertSame('failed', $assistant->fresh()->status);
+
+        Event::assertDispatched(
+            RehearsalPlannerStreamEvent::class,
+            fn (RehearsalPlannerStreamEvent $e) => $e->type === 'error'
+                && $e->sessionId === $session->id
+                && ($e->data['message_id'] ?? null) === $assistant->id,
+        );
+    }
+}

--- a/tests/Feature/RehearsalPlanner/PlannerTurnJobTest.php
+++ b/tests/Feature/RehearsalPlanner/PlannerTurnJobTest.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Tests\Feature\RehearsalPlanner;
+
+use App\Jobs\RehearsalPlannerTurnJob;
+use App\Models\RehearsalPlannerMessage;
+use App\Models\RehearsalPlannerSession;
+use App\Services\RehearsalPlannerService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Mockery;
+use Tests\TestCase;
+
+class PlannerTurnJobTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_handle_loads_models_and_calls_run_turn(): void
+    {
+        $session = RehearsalPlannerSession::factory()->create();
+        $assistant = RehearsalPlannerMessage::factory()->create([
+            'session_id' => $session->id,
+            'role'       => 'assistant',
+            'status'     => 'streaming',
+        ]);
+
+        $mock = Mockery::mock(RehearsalPlannerService::class);
+        $mock->shouldReceive('runTurn')
+            ->once()
+            ->withArgs(function ($s, $a, $text) use ($session, $assistant) {
+                return $s instanceof RehearsalPlannerSession
+                    && $s->id === $session->id
+                    && $a instanceof RehearsalPlannerMessage
+                    && $a->id === $assistant->id
+                    && $text === 'hello there';
+            });
+
+        $job = new RehearsalPlannerTurnJob($session->id, $assistant->id, 'hello there');
+        $job->handle($mock);
+    }
+
+    public function test_handle_no_ops_when_records_missing(): void
+    {
+        $mock = Mockery::mock(RehearsalPlannerService::class);
+        $mock->shouldReceive('runTurn')->never();
+
+        $job = new RehearsalPlannerTurnJob(999999, 999999, null);
+        $job->handle($mock);
+
+        // No exception thrown — graceful no-op.
+        $this->assertTrue(true);
+    }
+
+    public function test_job_payload_carries_ids_not_models(): void
+    {
+        // Serializable: stores scalar ids + text, never full models.
+        $job = new RehearsalPlannerTurnJob(7, 11, 'text');
+
+        $this->assertSame(7, $job->sessionId);
+        $this->assertSame(11, $job->assistantMessageId);
+        $this->assertSame('text', $job->userText);
+        $this->assertGreaterThan(120, $job->timeout, 'Timeout must exceed the agent 120s stream timeout.');
+    }
+}

--- a/tests/Feature/RehearsalPlanner/PlannerTurnJobTest.php
+++ b/tests/Feature/RehearsalPlanner/PlannerTurnJobTest.php
@@ -17,6 +17,11 @@ class PlannerTurnJobTest extends TestCase
     public function test_handle_loads_models_and_calls_run_turn(): void
     {
         $session = RehearsalPlannerSession::factory()->create();
+        $userMsg = RehearsalPlannerMessage::factory()->create([
+            'session_id' => $session->id,
+            'role'       => 'user',
+            'status'     => 'complete',
+        ]);
         $assistant = RehearsalPlannerMessage::factory()->create([
             'session_id' => $session->id,
             'role'       => 'assistant',
@@ -26,15 +31,16 @@ class PlannerTurnJobTest extends TestCase
         $mock = Mockery::mock(RehearsalPlannerService::class);
         $mock->shouldReceive('runTurn')
             ->once()
-            ->withArgs(function ($s, $a, $text) use ($session, $assistant) {
+            ->withArgs(function ($s, $a, $text, $userId) use ($session, $assistant, $userMsg) {
                 return $s instanceof RehearsalPlannerSession
                     && $s->id === $session->id
                     && $a instanceof RehearsalPlannerMessage
                     && $a->id === $assistant->id
-                    && $text === 'hello there';
+                    && $text === 'hello there'
+                    && $userId === $userMsg->id;
             });
 
-        $job = new RehearsalPlannerTurnJob($session->id, $assistant->id, 'hello there');
+        $job = new RehearsalPlannerTurnJob($session->id, $assistant->id, 'hello there', $userMsg->id);
         $job->handle($mock);
     }
 
@@ -53,11 +59,20 @@ class PlannerTurnJobTest extends TestCase
     public function test_job_payload_carries_ids_not_models(): void
     {
         // Serializable: stores scalar ids + text, never full models.
-        $job = new RehearsalPlannerTurnJob(7, 11, 'text');
+        $job = new RehearsalPlannerTurnJob(7, 11, 'text', 5);
 
         $this->assertSame(7, $job->sessionId);
         $this->assertSame(11, $job->assistantMessageId);
         $this->assertSame('text', $job->userText);
+        $this->assertSame(5, $job->userMessageId);
         $this->assertGreaterThan(120, $job->timeout, 'Timeout must exceed the agent 120s stream timeout.');
+    }
+
+    public function test_job_has_no_retries(): void
+    {
+        // A streamed AI turn must not auto-retry: retrying would re-broadcast
+        // on an already-failed placeholder.
+        $job = new RehearsalPlannerTurnJob(1, 2, null, null);
+        $this->assertSame(1, $job->tries, '$tries must be 1 — no auto-retry on a streamed turn.');
     }
 }

--- a/tests/Feature/RehearsalPlanner/PlannerTurnJobTest.php
+++ b/tests/Feature/RehearsalPlanner/PlannerTurnJobTest.php
@@ -2,11 +2,13 @@
 
 namespace Tests\Feature\RehearsalPlanner;
 
+use App\Events\RehearsalPlannerStreamEvent;
 use App\Jobs\RehearsalPlannerTurnJob;
 use App\Models\RehearsalPlannerMessage;
 use App\Models\RehearsalPlannerSession;
 use App\Services\RehearsalPlannerService;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Event;
 use Mockery;
 use Tests\TestCase;
 
@@ -74,5 +76,64 @@ class PlannerTurnJobTest extends TestCase
         // on an already-failed placeholder.
         $job = new RehearsalPlannerTurnJob(1, 2, null, null);
         $this->assertSame(1, $job->tries, '$tries must be 1 — no auto-retry on a streamed turn.');
+    }
+
+    public function test_failed_marks_streaming_message_failed_and_dispatches_error(): void
+    {
+        Event::fake([RehearsalPlannerStreamEvent::class]);
+
+        $session = RehearsalPlannerSession::factory()->create();
+        $assistant = RehearsalPlannerMessage::factory()->create([
+            'session_id' => $session->id,
+            'role'       => 'assistant',
+            'status'     => 'streaming',
+        ]);
+
+        $job = new RehearsalPlannerTurnJob($session->id, $assistant->id, null);
+        $job->failed(new \Exception('boom'));
+
+        $this->assertSame('failed', $assistant->fresh()->status);
+
+        Event::assertDispatched(
+            RehearsalPlannerStreamEvent::class,
+            fn (RehearsalPlannerStreamEvent $e) => $e->type === 'error'
+                && $e->sessionId === $session->id
+                && ($e->data['message_id'] ?? null) === $assistant->id
+                && isset($e->data['error']),
+        );
+    }
+
+    public function test_failed_does_not_overwrite_already_complete_message(): void
+    {
+        Event::fake([RehearsalPlannerStreamEvent::class]);
+
+        $session = RehearsalPlannerSession::factory()->create();
+        $assistant = RehearsalPlannerMessage::factory()->create([
+            'session_id' => $session->id,
+            'role'       => 'assistant',
+            'status'     => 'complete',
+        ]);
+
+        $job = new RehearsalPlannerTurnJob($session->id, $assistant->id, null);
+        $job->failed(new \Exception('boom'));
+
+        // Status must remain 'complete' — the job finished successfully before the worker killed it.
+        $this->assertSame('complete', $assistant->fresh()->status);
+
+        // No error event should be dispatched since the message already succeeded.
+        Event::assertNotDispatched(RehearsalPlannerStreamEvent::class);
+    }
+
+    public function test_failed_no_ops_when_message_missing(): void
+    {
+        Event::fake([RehearsalPlannerStreamEvent::class]);
+
+        // Use a non-existent assistant message id.
+        $job = new RehearsalPlannerTurnJob(999999, 999999, null);
+        $job->failed(new \Exception('boom'));
+
+        // Should not throw and should not dispatch any event.
+        Event::assertNotDispatched(RehearsalPlannerStreamEvent::class);
+        $this->assertTrue(true);
     }
 }

--- a/tests/Feature/RehearsalPlanner/StreamEventTest.php
+++ b/tests/Feature/RehearsalPlanner/StreamEventTest.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Tests\Feature\RehearsalPlanner;
+
+use App\Events\RehearsalPlannerStreamEvent;
+use Tests\TestCase;
+
+class StreamEventTest extends TestCase
+{
+    public function test_broadcast_shape(): void
+    {
+        $event = new RehearsalPlannerStreamEvent(7, 'text_delta', ['delta' => 'Hi']);
+
+        $this->assertSame('planner.stream', $event->broadcastAs());
+        $this->assertSame('private-rehearsal-planner.7', $event->broadcastOn()[0]->name);
+        $this->assertSame(['type' => 'text_delta', 'delta' => 'Hi'], $event->broadcastWith());
+    }
+}


### PR DESCRIPTION
Backend for the cross-repo **AI Rehearsal Planner** feature (mobile UI is a separate PR in the TTS-App repo).

## What
A multi-turn AI rehearsal planner: gathers band context, runs an Anthropic agent, and streams replies to the mobile app over Pusher.

- **Schema/models:** `rehearsal_planner_sessions` + `rehearsal_planner_messages` (with `payload` json, `status` streaming/complete/failed).
- **Context builder** (`RehearsalPlannerContextBuilder`): assembles four sections — upcoming events + setlist songs (next 5), recently-rehearsed songs (last 5 rehearsals → associated bookings → event setlists), personnel & instruments (roster + band roles), and the active song library. Empty band/library is not an error.
- **Agent** (`RehearsalPlannerAgent`): mirrors `SetlistAgent`; Anthropic, `claude-sonnet-4-6`; `Conversational` with message history. Instructions cover the two-section suggestion mode and a fenced `plan`/`suggestions` output protocol.
- **Service** (`RehearsalPlannerService::runTurn`): builds context, replays history (excludes the in-flight placeholder), streams the agent, re-broadcasts token deltas, parses the fenced plan/suggestions blocks, persists content+payload, and emits a `done`/`error` event. Streaming verified against the installed `laravel/ai` API.
- **Endpoints** (band-scoped, `read:rehearsals`): `POST …/rehearsal-planner/sessions`, `POST …/sessions/{session}/messages`, `GET …/sessions/{session}`.
- **Streaming:** `RehearsalPlannerStreamEvent` (`ShouldBroadcastNow`) → `private-rehearsal-planner.{session}`, authorized in `routes/channels.php` via `canRead('rehearsals', band_id)`.

## Notable decisions
- Dropped route `scopeBindings()` (would crash — no `Bands::sessions()` relation); cross-band isolation is enforced by an explicit `abort_unless($session->band_id === $band->id, 404)` on `message`/`show`, covered by two security tests.
- Missing Anthropic key → 503.

## Surfaced (separate): pre-existing bug
While adding traversal coverage, found `Rehearsal::bookings()` (morphToMany) has contradictory pivot constraints (`associable_type = Rehearsal AND = Bookings`) and **always returns zero rows** — a latent bug affecting any caller. This feature routes around it via `associations()`; the relation itself is left untouched pending a decision on a separate fix.

## Tests
`php artisan test --filter=RehearsalPlanner` → **16 passed (67 assertions)**: models, context builder (incl. end-to-end recently-rehearsed traversal + has-upcoming-requests), agent stream-event contract, service parsing (multi-item plans) + error path, controller (start/message/show, 503, 401, two cross-band 404 security tests). No live AI calls (service mocked / pure helpers).

Part of the AI rehearsal planner; design + plan in the TTS-App repo under docs/superpowers.