### PR TITLE
feat(rehearsal-planner): scope a planner session to a specific rehearsal

### DIFF
--- a/app/Http/Controllers/Api/Mobile/RehearsalPlannerController.php
+++ b/app/Http/Controllers/Api/Mobile/RehearsalPlannerController.php
@@ -20,11 +20,16 @@ class RehearsalPlannerController extends Controller
         }
 
         $validated = $request->validate([
-            // The rehearsal must belong to this band — scope the exists rule to it.
+            // The rehearsal must belong to this band and not be soft-deleted —
+            // Rehearsal uses SoftDeletes, and exists() ignores the global scope,
+            // so exclude trashed rows explicitly (matches the codebase
+            // convention in StoreRosterMemberRequest / SendQuestionnaireRequest).
             'rehearsal_id' => [
                 'nullable',
                 'integer',
-                Rule::exists('rehearsals', 'id')->where('band_id', $band->id),
+                Rule::exists('rehearsals', 'id')
+                    ->where('band_id', $band->id)
+                    ->whereNull('deleted_at'),
             ],
         ]);
 

--- a/app/Http/Controllers/Api/Mobile/RehearsalPlannerController.php
+++ b/app/Http/Controllers/Api/Mobile/RehearsalPlannerController.php
@@ -9,18 +9,29 @@ use App\Models\RehearsalPlannerSession;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Validation\Rule;
 
 class RehearsalPlannerController extends Controller
 {
-    public function start(Bands $band): JsonResponse
+    public function start(Request $request, Bands $band): JsonResponse
     {
         if ($guard = $this->keyGuard()) {
             return $guard;
         }
 
+        $validated = $request->validate([
+            // The rehearsal must belong to this band — scope the exists rule to it.
+            'rehearsal_id' => [
+                'nullable',
+                'integer',
+                Rule::exists('rehearsals', 'id')->where('band_id', $band->id),
+            ],
+        ]);
+
         $session = RehearsalPlannerSession::create([
-            'band_id' => $band->id,
-            'user_id' => Auth::id(),
+            'band_id'      => $band->id,
+            'user_id'      => Auth::id(),
+            'rehearsal_id' => $validated['rehearsal_id'] ?? null,
         ]);
 
         $assistant = $session->messages()->create([

--- a/app/Models/RehearsalPlannerSession.php
+++ b/app/Models/RehearsalPlannerSession.php
@@ -11,11 +11,16 @@ class RehearsalPlannerSession extends Model
 {
     use HasFactory;
 
-    protected $fillable = ['band_id', 'user_id', 'title'];
+    protected $fillable = ['band_id', 'user_id', 'rehearsal_id', 'title'];
 
     public function band(): BelongsTo
     {
         return $this->belongsTo(Bands::class, 'band_id');
+    }
+
+    public function rehearsal(): BelongsTo
+    {
+        return $this->belongsTo(Rehearsal::class, 'rehearsal_id');
     }
 
     public function user(): BelongsTo

--- a/app/Services/RehearsalPlannerService.php
+++ b/app/Services/RehearsalPlannerService.php
@@ -22,18 +22,24 @@ class RehearsalPlannerService
         ?int $userMessageId = null,
     ): void {
         try {
-            $session->loadMissing('band');
+            $session->loadMissing(['band', 'rehearsal.rehearsalSchedule', 'rehearsal.events']);
             $context = $this->contextBuilder->build($session->band);
 
             $history = $this->historyForTurn($session, $assistantMessage, $userText, $userMessageId);
 
+            $focus = $this->rehearsalFocus($session);
+
             // The opening turn has no userText; prompt the agent to assess the context.
             $prompt = $userText !== null && $userText !== ''
                 ? $userText
-                : 'Assess what the band should rehearse and open the conversation.';
+                : ($focus !== ''
+                    ? 'Assess what the band should rehearse at this rehearsal and open the conversation.'
+                    : 'Assess what the band should rehearse and open the conversation.');
 
             // Prepend the context as a system-style preamble on the first user turn.
-            $promptWithContext = "BAND CONTEXT:\n{$context['text']}\n\n---\n{$prompt}";
+            // When the session targets a specific rehearsal, lead with that focus so
+            // the agent centers its advice on it (context sources are unchanged).
+            $promptWithContext = "BAND CONTEXT:\n{$context['text']}\n{$focus}\n---\n{$prompt}";
 
             $agent = (new RehearsalPlannerAgent())->withHistory($history);
 
@@ -122,6 +128,37 @@ class RehearsalPlannerService
             ->get()
             ->map(fn (RehearsalPlannerMessage $m) => new Message($m->role, (string) $m->content))
             ->all();
+    }
+
+    /**
+     * When the session targets a specific rehearsal, produce a short focus
+     * block telling the agent to center its advice on that rehearsal. Returns
+     * an empty string for band-wide sessions (no rehearsal). The four context
+     * sources are unchanged — this only frames them.
+     */
+    protected function rehearsalFocus(RehearsalPlannerSession $session): string
+    {
+        $rehearsal = $session->rehearsal;
+        if ($rehearsal === null) {
+            return '';
+        }
+
+        // Date comes from the rehearsal's first associated event (the rehearsals
+        // table itself has no date column); fall back gracefully if absent.
+        $event = $rehearsal->events->first();
+        $date = $event
+            ? (is_string($event->date) ? $event->date : optional($event->date)->format('Y-m-d'))
+            : null;
+        $scheduleName = $rehearsal->rehearsalSchedule?->name;
+
+        $label = trim(implode(' ', array_filter([
+            $date ? "on {$date}" : null,
+            $scheduleName ? "({$scheduleName})" : null,
+        ])));
+        $label = $label !== '' ? " {$label}" : '';
+
+        return "\nPLANNING FOCUS: The band leader is planning for a specific upcoming rehearsal{$label}. "
+            . "Center your advice on what to rehearse at THIS rehearsal, drawing on the context above.\n";
     }
 
     public static function parsePlan(string $text): ?array

--- a/database/migrations/2026_06_30_000003_add_rehearsal_id_to_rehearsal_planner_sessions_table.php
+++ b/database/migrations/2026_06_30_000003_add_rehearsal_id_to_rehearsal_planner_sessions_table.php
@@ -1,0 +1,26 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('rehearsal_planner_sessions', function (Blueprint $table) {
+            $table->foreignId('rehearsal_id')
+                ->nullable()
+                ->after('user_id')
+                ->constrained('rehearsals')
+                ->nullOnDelete();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('rehearsal_planner_sessions', function (Blueprint $table) {
+            $table->dropConstrainedForeignId('rehearsal_id');
+        });
+    }
+};

--- a/tests/Feature/RehearsalPlanner/PlannerControllerTest.php
+++ b/tests/Feature/RehearsalPlanner/PlannerControllerTest.php
@@ -203,6 +203,31 @@ class PlannerControllerTest extends TestCase
         ]);
     }
 
+    public function test_start_rejects_soft_deleted_rehearsal(): void
+    {
+        Queue::fake();
+
+        [$user, $band, $token] = $this->actingMember();
+
+        // A trashed rehearsal must not be plannable: exists() ignores the
+        // SoftDeletes global scope, so the rule must exclude deleted rows or it
+        // would persist a dangling rehearsal_id that resolves to null focus.
+        $schedule = \App\Models\RehearsalSchedule::factory()->create(['band_id' => $band->id]);
+        $rehearsal = \App\Models\Rehearsal::factory()->create([
+            'band_id'               => $band->id,
+            'rehearsal_schedule_id' => $schedule->id,
+        ]);
+        $rehearsal->delete();
+
+        $this->withToken($token)->postJson(
+            "/api/mobile/bands/{$band->id}/rehearsal-planner/sessions",
+            ['rehearsal_id' => $rehearsal->id],
+            $this->headers($band)
+        )->assertStatus(422)->assertJsonValidationErrors('rehearsal_id');
+
+        Queue::assertNothingPushed();
+    }
+
     public function test_start_rejects_rehearsal_id_from_another_band(): void
     {
         Queue::fake();

--- a/tests/Feature/RehearsalPlanner/PlannerControllerTest.php
+++ b/tests/Feature/RehearsalPlanner/PlannerControllerTest.php
@@ -176,4 +176,54 @@ class PlannerControllerTest extends TestCase
 
         Queue::assertNothingPushed();
     }
+
+    public function test_start_with_valid_rehearsal_id_persists_it_on_the_session(): void
+    {
+        Queue::fake();
+
+        [$user, $band, $token] = $this->actingMember();
+
+        $schedule = \App\Models\RehearsalSchedule::factory()->create(['band_id' => $band->id]);
+        $rehearsal = \App\Models\Rehearsal::factory()->create([
+            'band_id'               => $band->id,
+            'rehearsal_schedule_id' => $schedule->id,
+        ]);
+
+        $res = $this->withToken($token)->postJson(
+            "/api/mobile/bands/{$band->id}/rehearsal-planner/sessions",
+            ['rehearsal_id' => $rehearsal->id],
+            $this->headers($band)
+        );
+
+        $res->assertOk();
+        $this->assertDatabaseHas('rehearsal_planner_sessions', [
+            'id'           => $res->json('session_id'),
+            'band_id'      => $band->id,
+            'rehearsal_id' => $rehearsal->id,
+        ]);
+    }
+
+    public function test_start_rejects_rehearsal_id_from_another_band(): void
+    {
+        Queue::fake();
+
+        [$user, $band, $token] = $this->actingMember();
+
+        // A rehearsal that belongs to a DIFFERENT band must not be plannable
+        // under this band's route — the scoped exists rule rejects it (422).
+        $otherBand = Bands::factory()->create();
+        $otherSchedule = \App\Models\RehearsalSchedule::factory()->create(['band_id' => $otherBand->id]);
+        $otherRehearsal = \App\Models\Rehearsal::factory()->create([
+            'band_id'               => $otherBand->id,
+            'rehearsal_schedule_id' => $otherSchedule->id,
+        ]);
+
+        $this->withToken($token)->postJson(
+            "/api/mobile/bands/{$band->id}/rehearsal-planner/sessions",
+            ['rehearsal_id' => $otherRehearsal->id],
+            $this->headers($band)
+        )->assertStatus(422)->assertJsonValidationErrors('rehearsal_id');
+
+        Queue::assertNothingPushed();
+    }
 }

--- a/tests/Feature/RehearsalPlanner/PlannerServiceTest.php
+++ b/tests/Feature/RehearsalPlanner/PlannerServiceTest.php
@@ -255,4 +255,58 @@ class PlannerServiceTest extends TestCase
                 && ($e->data['message_id'] ?? null) === $assistant->id,
         );
     }
+
+    public function test_rehearsal_focus_is_empty_for_band_wide_session(): void
+    {
+        $session = RehearsalPlannerSession::factory()->create(['rehearsal_id' => null]);
+
+        $service = $this->focusSeam();
+
+        $this->assertSame('', $service->exposeFocus($session->fresh()));
+    }
+
+    public function test_rehearsal_focus_centers_on_selected_rehearsal(): void
+    {
+        $band = \App\Models\Bands::factory()->create();
+        $schedule = \App\Models\RehearsalSchedule::factory()->create([
+            'band_id' => $band->id,
+            'name'    => 'Tuesday Practice',
+        ]);
+        $rehearsal = \App\Models\Rehearsal::factory()->create([
+            'band_id'               => $band->id,
+            'rehearsal_schedule_id' => $schedule->id,
+        ]);
+        // The rehearsal's date lives on its associated event.
+        \App\Models\Events::factory()->create([
+            'eventable_type' => \App\Models\Rehearsal::class,
+            'eventable_id'   => $rehearsal->id,
+            'date'           => '2026-07-15',
+        ]);
+
+        $session = RehearsalPlannerSession::factory()->create([
+            'band_id'      => $band->id,
+            'rehearsal_id' => $rehearsal->id,
+        ]);
+
+        $focus = $this->focusSeam()->exposeFocus($session->fresh());
+
+        $this->assertStringContainsString('PLANNING FOCUS', $focus);
+        $this->assertStringContainsString('2026-07-15', $focus);
+        $this->assertStringContainsString('Tuesday Practice', $focus);
+    }
+
+    /**
+     * Anonymous subclass exposing the protected rehearsalFocus() for testing,
+     * mirroring the exposeHistory() seam used above.
+     */
+    private function focusSeam(): RehearsalPlannerService
+    {
+        return new class (app(RehearsalPlannerContextBuilder::class)) extends RehearsalPlannerService {
+            public function exposeFocus(RehearsalPlannerSession $session): string
+            {
+                $session->loadMissing(['rehearsal.rehearsalSchedule', 'rehearsal.events']);
+                return $this->rehearsalFocus($session);
+            }
+        };
+    }
 }


### PR DESCRIPTION
Follow-up to #491 (merged). Makes the AI Rehearsal Planner launch **from a specific upcoming rehearsal** instead of band-wide.

## What changed
- **Migration:** nullable `rehearsal_id` FK on `rehearsal_planner_sessions` (null-on-delete).
- **Model:** `rehearsal_id` fillable + `rehearsal()` relation.
- **`start()`:** accepts optional `rehearsal_id`, validated to belong to the band via a scoped `Rule::exists(...)->where('band_id', ...)` (cross-band → 422); persists it on the session.
- **Service:** injects a `PLANNING FOCUS` preamble framing the **existing four context sources** around the selected rehearsal (date from its associated event + schedule name). Band-wide sessions (no `rehearsal_id`) are byte-stable unchanged.

## Tests
+4 tests (persist, cross-band reject 422, focus empty vs centered). Full planner suite: **30 passed (106 assertions)**.

## Coordination
Pairs with mobile PR eddimull/TTS-App#78 (which moves the entry point to the rehearsal detail screen and removes the band-wide button). Backend is backward-compatible — `rehearsal_id` is optional everywhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)