### PR TITLE
fix(broadcasting): default pusher to Pusher Cloud (fixes on-device realtime: planner + setlist)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,7 +14,7 @@ DB_DATABASE=ttsband_test_
 DB_USERNAME=root
 DB_PASSWORD=
 
-BROADCAST_DRIVER=log
+BROADCAST_DRIVER=pusher
 CACHE_DRIVER=file
 QUEUE_CONNECTION=sync
 SESSION_DRIVER=file
@@ -47,6 +47,25 @@ PUSHER_APP_ID=
 PUSHER_APP_KEY=
 PUSHER_APP_SECRET=
 PUSHER_APP_CLUSTER=mt1
+
+# Broadcast broker. The server, the web client (VITE_*), and the mobile app must
+# all terminate at the SAME broker. The mobile app (pusher_channels_flutter) can
+# ONLY reach Pusher Cloud (ws-<cluster>.pusher.com), so prod uses Pusher Cloud:
+# leave PUSHER_HOST / PORT / SCHEME blank → config/broadcasting.php falls back to
+# api-<cluster>.pusher.com : 443 : https. To use a self-hosted soketi instead,
+# set all three (and VITE_PUSHER_HOST/PORT to the public soketi endpoint), but
+# note mobile realtime will NOT work against soketi.
+PUSHER_HOST=
+PUSHER_PORT=
+PUSHER_SCHEME=
+
+# Web (Vite/Echo) client. Leave VITE_PUSHER_HOST/PORT blank for Pusher Cloud so
+# Echo routes via cluster; set them to the soketi endpoint only if self-hosting.
+VITE_PUSHER_APP_KEY="${PUSHER_APP_KEY}"
+VITE_PUSHER_APP_CLUSTER="${PUSHER_APP_CLUSTER}"
+VITE_PUSHER_HOST=
+VITE_PUSHER_PORT=
+VITE_PUSHER_SCHEME=https
 
 MIX_PUSHER_APP_KEY="${PUSHER_APP_KEY}"
 MIX_PUSHER_APP_CLUSTER="${PUSHER_APP_CLUSTER}"

--- a/config/broadcasting.php
+++ b/config/broadcasting.php
@@ -37,10 +37,25 @@ return [
             'app_id' => env('PUSHER_APP_ID'),
             'options' => [
                 'cluster' => env('PUSHER_APP_CLUSTER'),
-                'host' => env('PUSHER_HOST', '127.0.0.1'),
-                'port' => env('PUSHER_PORT', 6001),
-                'scheme' => env('PUSHER_SCHEME', 'http'),
-                'useTLS' => false,
+                // When PUSHER_HOST is unset, fall back to Pusher Cloud's host for
+                // the configured cluster (api-<cluster>.pusher.com) rather than a
+                // self-hosted default. A blank/absent PUSHER_HOST therefore means
+                // "use real Pusher", while a self-hosted soketi can still override
+                // host/port/scheme via env.
+                //
+                // The mobile client (pusher_channels_flutter) connects to
+                // ws-<cluster>.pusher.com and cannot target a custom host, so the
+                // server MUST broadcast to the same Pusher Cloud endpoint or events
+                // never reach the device (silent: no error, message marked complete,
+                // client spins forever).
+                // Use ?: (not env()'s default arg) so a set-but-empty env var
+                // (PUSHER_HOST= / PUSHER_PORT=) still falls through to the Pusher
+                // Cloud default — env('KEY', $default) only applies $default when
+                // the key is absent, not when it's present-but-blank.
+                'host' => env('PUSHER_HOST') ?: 'api-' . env('PUSHER_APP_CLUSTER') . '.pusher.com',
+                'port' => env('PUSHER_PORT') ?: 443,
+                'scheme' => env('PUSHER_SCHEME') ?: 'https',
+                'useTLS' => (env('PUSHER_SCHEME') ?: 'https') === 'https',
             ],
         ],
 

--- a/resources/js/bootstrap.js
+++ b/resources/js/bootstrap.js
@@ -24,14 +24,27 @@ import Pusher from 'pusher-js';
 
 window.Pusher = Pusher;
 
+// When VITE_PUSHER_HOST is set (self-hosted soketi, e.g. tts.band), pin Echo to
+// that host/port. When it is blank/absent, omit wsHost/wsPort entirely so
+// pusher-js routes to Pusher Cloud via `cluster` (ws-<cluster>.pusher.com).
+// This must track the server's broadcast target in config/broadcasting.php: the
+// browser and the backend have to terminate at the same broker. The mobile app
+// (pusher_channels_flutter) can only reach Pusher Cloud, so when the server moves
+// to Pusher Cloud the web client must move with it by blanking VITE_PUSHER_HOST.
+const pusherHost = import.meta.env.VITE_PUSHER_HOST;
+
 window.Echo = new Echo({
     broadcaster: 'pusher',
     key: import.meta.env.VITE_PUSHER_APP_KEY,
-    wsHost: import.meta.env.VITE_PUSHER_HOST,
-    wsPort: import.meta.env.VITE_PUSHER_PORT,
-    wssPort: import.meta.env.VITE_PUSHER_PORT,
+    cluster: import.meta.env.VITE_PUSHER_APP_CLUSTER || 'mt1',
     forceTLS: true,
     disableStats: true,
     enabledTransports: ['ws', 'wss'],
-    cluster: 'mt1',
+    ...(pusherHost
+        ? {
+              wsHost: pusherHost,
+              wsPort: import.meta.env.VITE_PUSHER_PORT,
+              wssPort: import.meta.env.VITE_PUSHER_PORT,
+          }
+        : {}),
 });


### PR DESCRIPTION
## ⚠️ DRAFT — do not merge until Pusher Cloud credentials are provisioned in all 3 places

Merging to `staging` auto-deploys. These code changes are inert until the env/secrets are switched (see runbook). Hold as draft so the deploy lands together with the env changes.

## Problem

On-device realtime is broken on prod for **both** the AI rehearsal planner and live setlist. The mobile client (`pusher_channels_flutter`) connects to **Pusher Cloud** (`ws-<cluster>.pusher.com`) and the plugin cannot be pointed at a custom host (its Dart `init()` never forwards a host; Android native v2.6.0 ignores host entirely). The server, however, broadcasts to self-hosted **soketi** (public at `wss://tts.band`, reached locally at `127.0.0.1:6001`). Server publishes into soketi; the mobile device listens on Pusher Cloud; they never meet → silent failure (no error, no Sentry, message marked complete, client spins forever).

The **web** client already works because it's pinned to soketi (`wsHost: tts.band`). Only mobile is stranded.

## Why Pusher Cloud (vs keeping soketi)

soketi is fine and public, but the mobile plugin (2.6.0, latest) can't reach a custom host without forking the native plugin or migrating to a different Dart websocket library. Pointing the whole stack at Pusher Cloud fixes mobile with no plugin fork. Trade-off accepted: managed dependency + per-message cost, in exchange for no mobile-client rewrite.

## The catch: one server connection, three consumers

The server has a single broadcast connection consumed by **web (Echo)**, **mobile (plugin)**, and the **publishing backend**. Moving the server to Pusher Cloud fixes mobile but **breaks web** unless web moves too — so this PR changes both.

## Changes

1. **`config/broadcasting.php`** — pusher connection defaults to Pusher Cloud (`api-<cluster>.pusher.com`, 443, TLS) when `PUSHER_HOST` is blank; soketi still overridable via env. Uses `?:` so a set-but-empty env var still falls through to the cloud default. Verified in-container: blank env → `{host: api-mt1.pusher.com, port: 443, scheme: https, useTLS: true}`; soketi env → `{host: localhost, port: 6001, scheme: http, useTLS: false}`.
2. **`resources/js/bootstrap.js`** — Echo omits `wsHost`/`wsPort` when `VITE_PUSHER_HOST` is blank, routing to Pusher Cloud via `cluster`; soketi still pinnable by setting `VITE_PUSHER_HOST`.

## Required to fix prod (env/ops — NOT in this PR)

1. Create a Pusher Channels app, cluster **`mt1`** (to match the mobile build).
2. **Server `.env`** (Forge): set `PUSHER_APP_ID/KEY/SECRET`, `PUSHER_APP_CLUSTER=mt1`; blank `PUSHER_HOST` / `PUSHER_PORT` / `PUSHER_SCHEME`. Then `php artisan config:clear` + restart Horizon.
3. **Web build env**: set `VITE_PUSHER_APP_KEY` (= the real key), `VITE_PUSHER_APP_CLUSTER=mt1`; blank `VITE_PUSHER_HOST` / `VITE_PUSHER_PORT`. Rebuild assets.
4. **GitHub Actions secrets** (mobile): set `PUSHER_APP_KEY` + `PUSHER_APP_CLUSTER` to the real values, then cut a new mobile build (key is baked in at build time → build 131 must be rebuilt).
5. Verify on-device + web: server `config('broadcasting.connections.pusher.options')` shows the Pusher Cloud host; test a live setlist session AND a planner message on the new mobile build, and confirm web realtime still works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)