### PR TITLE
Fix TTS-BAND-158: coerce single cc_id to Collection for PandaDoc

### DIFF
--- a/app/Http/Controllers/Api/Mobile/BookingsController.php
+++ b/app/Http/Controllers/Api/Mobile/BookingsController.php
@@ -534,7 +534,11 @@ class BookingsController extends Controller
             return response()->json(['message' => 'Signer contact not found on this booking.'], 422);
         }
 
-        $ccContact = !empty($validated['cc_id']) ? $booking->contacts()->find($validated['cc_id']) : null;
+        $ccContacts = null;
+        if (!empty($validated['cc_id'])) {
+            $found = $booking->contacts()->whereKey($validated['cc_id'])->get();
+            $ccContacts = $found->isNotEmpty() ? $found : null;
+        }
 
         try {
             $contractPdf = $booking->getContractPdf($contact);
@@ -553,7 +557,7 @@ class BookingsController extends Controller
         }
 
         try {
-            $contract->sendToPandaDoc($contact, $ccContact);
+            $contract->sendToPandaDoc($contact, $ccContacts);
             $booking->update(['status' => 'pending']);
 
             return response()->json([

--- a/tests/Feature/ContractSendingTest.php
+++ b/tests/Feature/ContractSendingTest.php
@@ -121,6 +121,52 @@ class ContractSendingTest extends TestCase
 
 
 
+    public function test_single_cc_id_is_coerced_to_collection_for_pandadoc()
+    {
+        // Regression for TTS-BAND-158: the mobile sendContract controller
+        // previously passed a single Contacts model (from ->find($id)) to
+        // sendToPandaDoc, which type-hints ?Eloquent\Collection and blew up
+        // with a TypeError. Resolving a single cc_id via ->whereKey()->get()
+        // must yield an Eloquent Collection that sendToPandaDoc accepts.
+        Http::fake([
+            'api.pandadoc.com/*' => Http::response([
+                'id' => 'fake-pandadoc-id',
+                'status' => 'document.draft',
+            ], 201)
+        ]);
+
+        $band = Bands::factory()->create();
+        $booking = Bookings::factory()->forBand($band)->create();
+        $contact = Contacts::factory()->create();
+        $ccContact = Contacts::factory()->create();
+        $booking->contacts()->attach($contact, ['role' => 'Primary', 'is_primary' => true]);
+        $booking->contacts()->attach($ccContact, ['role' => 'CC']);
+
+        $contract = Contracts::factory()->for($booking, 'contractable')->create([
+            'asset_url' => 'https://example.com/fake-contract.pdf',
+            'custom_terms' => [
+                ['title' => 'Term 1', 'content' => 'Content 1'],
+            ],
+        ]);
+
+        // Reproduce exactly how BookingsController::sendContract resolves a
+        // single cc_id into the argument passed to sendToPandaDoc.
+        $ccContacts = $booking->contacts()->whereKey($ccContact->id)->get();
+        $this->assertInstanceOf(\Illuminate\Database\Eloquent\Collection::class, $ccContacts);
+
+        $result = $contract->sendToPandaDoc($contact, $ccContacts);
+
+        Http::assertSent(function ($request) use ($contact, $ccContact)
+        {
+            return $request->url() == 'https://api.pandadoc.com/public/v1/documents' &&
+                $request['recipients'][0]['email'] == $contact->email &&
+                $request['recipients'][1]['email'] == $ccContact->email;
+        });
+
+        $this->assertEquals('fake-pandadoc-id', $result['id']);
+        $this->assertEquals('document.draft', $result['status']);
+    }
+
     public function test_contract_sending_handles_api_error()
     {
         // Override the fake to simulate an API error


### PR DESCRIPTION
## The bug

Sentry **TTS-BAND-158**: `TypeError` on `POST /api/mobile/bands/{band}/bookings/{booking}/contract/send`.

`BookingsController::sendContract()` resolved `cc_id` with `$booking->contacts()->find($validated['cc_id'])`, which returns a single `App\Models\Contacts` model. It then passed that to `sendToPandaDoc(Contacts $signer, ?Collection $ccRecipients = null)`, whose 2nd argument is type-hinted `?Illuminate\Database\Eloquent\Collection` and internally calls `->isNotEmpty()` / `->map()`. A single CC contact therefore blew up with:

> `App\Models\Contracts::sendToPandaDoc(): Argument #2 ($ccRecipients) must be of type ?Illuminate\Database\Eloquent\Collection, App\Models\Contacts given`

## The fix (controller only)

No change to the `sendToPandaDoc` signature. The controller now resolves the CC contact with `->whereKey($id)->get()`, which returns an Eloquent `Collection`, and falls back to `null` when the contact isn't on the booking:

```php
$ccContacts = null;
if (!empty($validated['cc_id'])) {
    $found = $booking->contacts()->whereKey($validated['cc_id'])->get();
    $ccContacts = $found->isNotEmpty() ? $found : null;
}
```

Behavior is identical to before for the empty case — the trait already treats `null` and an empty collection the same via `if ($ccRecipients && $ccRecipients->isNotEmpty())`.

## Regression test

Added `test_single_cc_id_is_coerced_to_collection_for_pandadoc` to `tests/Feature/ContractSendingTest.php`. It reproduces the controller's exact resolution (`->whereKey($ccContact->id)->get()`), asserts the result is an `Eloquent\Collection`, and passes it through `sendToPandaDoc`.

**Why existing tests missed this:** `test_cc_contacts_can_be_sent_to_pandadoc` called `sendToPandaDoc` directly with `->find([$id1, $id2])` — passing an **array** to `find()` returns a Collection, so it never exercised the failing path. The bug only manifests with a **single scalar** `cc_id` through `->find()`, which is exactly what the HTTP endpoint does.

## Test output

```
   PASS  Tests\Feature\ContractSendingTest
  ✓ contract can be sent to pandadoc                                     3.05s
  ✓ cc contacts can be sent to pandadoc                                  0.11s
  ✓ single cc id is coerced to collection for pandadoc                   0.10s
  ✓ contract sending handles api error                                   0.09s

  Tests:    4 passed (16 assertions)
  Duration: 3.39s
```

Fixes TTS-BAND-158

🤖 Generated with [Claude Code](https://claude.com/claude-code)