### PR TITLE
test(mobile): HTTP endpoint regression test for TTS-BAND-158 (follow-up to #498)

### DIFF
--- a/tests/Feature/Api/Mobile/SendContractCcRecipientTest.php
+++ b/tests/Feature/Api/Mobile/SendContractCcRecipientTest.php
@@ -1,0 +1,117 @@
+<?php
+
+namespace Tests\Feature\Api\Mobile;
+
+use App\Models\Bands;
+use App\Models\Bookings;
+use App\Models\Contacts;
+use App\Models\User;
+use App\Services\PdfGeneratorService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Storage;
+use Tests\TestCase;
+
+/**
+ * End-to-end regression coverage for TTS-BAND-158.
+ *
+ * The mobile contract/send endpoint used to resolve a single `cc_id` with
+ * ->find($id) (a single Contacts model) and hand it to
+ * sendToPandaDoc(Contacts $signer, ?Eloquent\Collection $ccRecipients), which
+ * blew up with a TypeError. This test drives the real controller over HTTP with
+ * a single cc_id, so it fails with the original TypeError if the fix is reverted.
+ */
+class SendContractCcRecipientTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Config::set('services.pandadoc.api_key', 'fake-api-key');
+
+        // Fake S3 so getContractPdf()/storeContractPdf() don't touch a real bucket.
+        Storage::fake('s3');
+
+        // Swap the real Browsershot-backed PDF generator for a stub so we never
+        // spin up headless Chromium during the test.
+        $this->app->bind(PdfGeneratorService::class, function () {
+            return new class extends PdfGeneratorService {
+                public function generateFromHtml(string $html, string $format = 'Legal', bool $taggedPdf = false): string
+                {
+                    return '%PDF-1.4 fake contract bytes';
+                }
+            };
+        });
+    }
+
+    public function test_send_contract_with_single_cc_id_coerces_to_collection(): void
+    {
+        Http::fake([
+            'api.pandadoc.com/*' => Http::response([
+                'id'     => 'fake-pandadoc-id',
+                'status' => 'document.draft',
+            ], 201),
+        ]);
+
+        $user = User::factory()->create();
+        // A valid address is required or getContractPdf() throws before we ever
+        // reach the cc_id coercion we are trying to exercise.
+        $band = Bands::factory()->create([
+            'address' => '123 Main',
+            'city'    => 'New Orleans',
+            'state'   => 'LA',
+            'zip'     => '70112',
+            'logo'    => '/images/logo.png',
+        ]);
+        $band->owners()->create(['user_id' => $user->id]);
+
+        // getContractPdf() reads the band logo off S3; put a fake asset there.
+        Storage::disk('s3')->put('logo.png', 'fake-png-bytes');
+
+        $booking = Bookings::factory()->create([
+            'band_id' => $band->id,
+            'status'  => 'draft',
+        ]);
+
+        // In the real flow the app saves contract terms before sending; the
+        // contract PDF view iterates $booking->contract->custom_terms.
+        $booking->contract()->create([
+            'author_id'    => $user->id,
+            'status'       => 'pending',
+            'custom_terms' => [
+                ['title' => 'Cancellation', 'content' => 'No refunds within 7 days.'],
+            ],
+        ]);
+
+        $signer = Contacts::factory()->create(['band_id' => $band->id]);
+        $cc     = Contacts::factory()->create(['band_id' => $band->id]);
+        $booking->contacts()->attach($signer, ['role' => 'Primary', 'is_primary' => true]);
+        $booking->contacts()->attach($cc, ['role' => 'CC']);
+
+        $token = $user->createToken('test-device')->plainTextToken;
+
+        $response = $this->withToken($token)
+            ->withHeaders(['X-Band-ID' => $band->id])
+            ->postJson("/api/mobile/bands/{$band->id}/bookings/{$booking->id}/contract/send", [
+                'signer_id' => $signer->id,
+                'cc_id'     => $cc->id,
+            ]);
+
+        $response->assertOk();
+
+        // Prove the coercion worked end-to-end: PandaDoc was called with both the
+        // signer and the single CC recipient in the payload.
+        Http::assertSent(function ($request) use ($signer, $cc) {
+            return $request->url() === 'https://api.pandadoc.com/public/v1/documents'
+                && $request['recipients'][0]['email'] === $signer->email
+                && collect($request['recipients'])->contains(
+                    fn ($r) => ($r['email'] ?? null) === $cc->email && ($r['recipient_type'] ?? null) === 'CC'
+                );
+        });
+
+        $this->assertSame('pending', $booking->fresh()->status);
+    }
+}

--- a/tests/Feature/Api/Mobile/SendContractCcRecipientTest.php
+++ b/tests/Feature/Api/Mobile/SendContractCcRecipientTest.php
@@ -103,11 +103,18 @@ class SendContractCcRecipientTest extends TestCase
         $response->assertOk();
 
         // Prove the coercion worked end-to-end: PandaDoc was called with both the
-        // signer and the single CC recipient in the payload.
+        // signer and the single CC recipient in the payload. Assert on presence
+        // (not position) so the test isn't coupled to sendToPandaDoc()'s
+        // recipient ordering.
         Http::assertSent(function ($request) use ($signer, $cc) {
-            return $request->url() === 'https://api.pandadoc.com/public/v1/documents'
-                && $request['recipients'][0]['email'] === $signer->email
-                && collect($request['recipients'])->contains(
+            if ($request->url() !== 'https://api.pandadoc.com/public/v1/documents') {
+                return false;
+            }
+
+            $recipients = collect($request['recipients'] ?? []);
+
+            return $recipients->contains(fn ($r) => ($r['email'] ?? null) === $signer->email)
+                && $recipients->contains(
                     fn ($r) => ($r['email'] ?? null) === $cc->email && ($r['recipient_type'] ?? null) === 'CC'
                 );
         });

--- a/tests/Feature/ContractSendingTest.php
+++ b/tests/Feature/ContractSendingTest.php
@@ -121,52 +121,6 @@ class ContractSendingTest extends TestCase
 
 
 
-    public function test_single_cc_id_is_coerced_to_collection_for_pandadoc()
-    {
-        // Regression for TTS-BAND-158: the mobile sendContract controller
-        // previously passed a single Contacts model (from ->find($id)) to
-        // sendToPandaDoc, which type-hints ?Eloquent\Collection and blew up
-        // with a TypeError. Resolving a single cc_id via ->whereKey()->get()
-        // must yield an Eloquent Collection that sendToPandaDoc accepts.
-        Http::fake([
-            'api.pandadoc.com/*' => Http::response([
-                'id' => 'fake-pandadoc-id',
-                'status' => 'document.draft',
-            ], 201)
-        ]);
-
-        $band = Bands::factory()->create();
-        $booking = Bookings::factory()->forBand($band)->create();
-        $contact = Contacts::factory()->create();
-        $ccContact = Contacts::factory()->create();
-        $booking->contacts()->attach($contact, ['role' => 'Primary', 'is_primary' => true]);
-        $booking->contacts()->attach($ccContact, ['role' => 'CC']);
-
-        $contract = Contracts::factory()->for($booking, 'contractable')->create([
-            'asset_url' => 'https://example.com/fake-contract.pdf',
-            'custom_terms' => [
-                ['title' => 'Term 1', 'content' => 'Content 1'],
-            ],
-        ]);
-
-        // Reproduce exactly how BookingsController::sendContract resolves a
-        // single cc_id into the argument passed to sendToPandaDoc.
-        $ccContacts = $booking->contacts()->whereKey($ccContact->id)->get();
-        $this->assertInstanceOf(\Illuminate\Database\Eloquent\Collection::class, $ccContacts);
-
-        $result = $contract->sendToPandaDoc($contact, $ccContacts);
-
-        Http::assertSent(function ($request) use ($contact, $ccContact)
-        {
-            return $request->url() == 'https://api.pandadoc.com/public/v1/documents' &&
-                $request['recipients'][0]['email'] == $contact->email &&
-                $request['recipients'][1]['email'] == $ccContact->email;
-        });
-
-        $this->assertEquals('fake-pandadoc-id', $result['id']);
-        $this->assertEquals('document.draft', $result['status']);
-    }
-
     public function test_contract_sending_handles_api_error()
     {
         // Override the fake to simulate an API error


### PR DESCRIPTION
Follow-up to #498 (already merged), addressing @copilot-pull-request-reviewer's feedback that the original regression test was tautological.

#498 shipped the actual fix (coerce a single `cc_id` to an Eloquent `Collection` before `sendToPandaDoc`) but merged before this test improvement could be pushed. The controller fix is unchanged and already on `staging`; this PR only strengthens the test.

## What changed

- **Removed** `test_single_cc_id_is_coerced_to_collection_for_pandadoc` from `ContractSendingTest.php`. As Copilot noted, it reproduced the controller's `->whereKey()->get()` resolution inline, so it could not fail on a revert to `->find($cc_id)`, and its `assertInstanceOf(Eloquent\Collection::class, ...)` was tautological (a relation's `->get()` always returns a Collection).
- **Added** `tests/Feature/Api/Mobile/SendContractCcRecipientTest.php`, a real HTTP endpoint test that drives `BookingsController::sendContract()` with a single `cc_id`:
  - authenticates as a band owner and `postJson`s to `/api/mobile/bands/{band}/bookings/{booking}/contract/send`,
  - `Storage::fake('s3')` + a fake band logo asset so `getContractPdf()`/`storeContractPdf()` don't touch a real bucket,
  - binds a stub `PdfGeneratorService` so no headless Chromium (Browsershot) runs,
  - `Http::fake()`s PandaDoc and asserts the outgoing payload includes the CC recipient (`recipient_type: CC`) — proving the single `cc_id` was coerced to a Collection end-to-end.

## Regression verification

- Reverting the controller to `->find($validated['cc_id'])` → the new test **fails** with the original
  `Argument #2 ($ccRecipients) must be of type ?Illuminate\Database\Eloquent\Collection, App\Models\Contacts given` TypeError.
- With the merged fix in place → the test **passes**.

```
   PASS  Tests\Feature\Api\Mobile\SendContractCcRecipientTest
  ✓ send contract with single cc id coerces to collection

   PASS  Tests\Feature\ContractSendingTest
  ✓ contract can be sent to pandadoc
  ✓ cc contacts can be sent to pandadoc
  ✓ contract sending handles api error

  Tests:    4 passed (15 assertions)
```

Fixes TTS-BAND-158

🤖 Generated with [Claude Code](https://claude.com/claude-code)