### PR TITLE
fix(mobile-api): close cross-band permission leak for subs

### DIFF
--- a/app/Http/Controllers/Api/Mobile/MusicController.php
+++ b/app/Http/Controllers/Api/Mobile/MusicController.php
@@ -18,6 +18,17 @@ use Illuminate\Support\Facades\Storage;
 class MusicController extends Controller
 {
     /**
+     * True when the user reaches this band ONLY as a sub (not owner/member).
+     * Such a user is entitled to see charts only for gigs they're assigned to.
+     */
+    private function isSubOnly(\App\Models\User $user, int $bandId): bool
+    {
+        return $user->isSubOfBand($bandId)
+            && !$user->ownsBand($bandId)
+            && !$user->isPartOfBand($bandId);
+    }
+
+    /**
      * List all active songs for a band.
      */
     public function songs(Request $_request, Bands $band): JsonResponse
@@ -45,7 +56,15 @@ class MusicController extends Controller
      */
     public function charts(Request $_request, Bands $band): JsonResponse
     {
-        $charts = Charts::where('band_id', $band->id)
+        $query = Charts::where('band_id', $band->id);
+
+        // A sub (not owner/member) sees only the charts for gigs they're assigned
+        // to, not the band's whole library.
+        if ($this->isSubOnly($_request->user(), $band->id)) {
+            $query->whereIn('id', $_request->user()->assignedChartIdsForBand($band->id));
+        }
+
+        $charts = $query
             ->withCount('uploads')
             ->orderBy('title')
             ->get();
@@ -75,15 +94,33 @@ class MusicController extends Controller
     {
         $user = $request->user();
         $bands = $user->allBands();
-        $bandIds = $bands->pluck('id')->all();
 
-        if (empty($bandIds)) {
+        // Owner/member bands contribute their whole chart library. Bands the user
+        // ONLY subs for contribute only the charts for gigs they're assigned to
+        // (not the full library — see User::assignedChartIdsForBand).
+        $fullLibraryBandIds = $user->bands()->pluck('id')->all();
+        $subOnlyBandIds = array_values(array_diff($bands->pluck('id')->all(), $fullLibraryBandIds));
+
+        $assignedChartIds = [];
+        foreach ($subOnlyBandIds as $subBandId) {
+            $assignedChartIds = array_merge($assignedChartIds, $user->assignedChartIdsForBand($subBandId));
+        }
+        $assignedChartIds = array_values(array_unique($assignedChartIds));
+
+        if (empty($fullLibraryBandIds) && empty($assignedChartIds)) {
             return response()->json(['charts' => []]);
         }
 
         $bandLookup = $bands->keyBy('id');
 
-        $charts = Charts::whereIn('band_id', $bandIds)
+        $charts = Charts::where(function ($q) use ($fullLibraryBandIds, $assignedChartIds) {
+                if (!empty($fullLibraryBandIds)) {
+                    $q->whereIn('band_id', $fullLibraryBandIds);
+                }
+                if (!empty($assignedChartIds)) {
+                    $q->orWhereIn('id', $assignedChartIds);
+                }
+            })
             ->withCount('uploads')
             ->orderBy('title')
             ->get();
@@ -118,6 +155,12 @@ class MusicController extends Controller
     {
         // Ensure the chart belongs to this band
         if ((int) $chart->band_id !== (int) $band->id) {
+            return response()->json(['message' => 'Chart not found.'], 404);
+        }
+
+        // A sub may only view charts for gigs they're assigned to.
+        if ($this->isSubOnly($_request->user(), $band->id)
+            && !in_array((int) $chart->id, $_request->user()->assignedChartIdsForBand($band->id), true)) {
             return response()->json(['message' => 'Chart not found.'], 404);
         }
 
@@ -294,6 +337,12 @@ class MusicController extends Controller
     public function downloadChartUpload(Request $_request, Bands $band, Charts $chart, ChartUploads $upload)
     {
         if ((int) $chart->band_id !== (int) $band->id) {
+            return response()->json(['message' => 'Chart not found.'], 404);
+        }
+
+        // A sub may only download files for charts on gigs they're assigned to.
+        if ($this->isSubOnly($_request->user(), $band->id)
+            && !in_array((int) $chart->id, $_request->user()->assignedChartIdsForBand($band->id), true)) {
             return response()->json(['message' => 'Chart not found.'], 404);
         }
 

--- a/app/Http/Controllers/Api/Mobile/RehearsalsController.php
+++ b/app/Http/Controllers/Api/Mobile/RehearsalsController.php
@@ -63,8 +63,8 @@ class RehearsalsController extends Controller
             abort(404, 'Band not found for this rehearsal.');
         }
 
-        if (!$request->user()->allBands()->contains('id', $band->id)) {
-            abort(403, 'You are not a member of this band.');
+        if (!$request->user()->canRead('rehearsals', $band->id)) {
+            abort(403, 'You do not have permission to view this rehearsal.');
         }
 
         return response()->json([
@@ -94,6 +94,10 @@ class RehearsalsController extends Controller
                 abort(404, 'Band not found for this rehearsal.');
             }
 
+            if (!$request->user()->canRead('rehearsals', $band->id)) {
+                abort(403, 'You do not have permission to view this rehearsal.');
+            }
+
             return response()->json([
                 'rehearsal' => $this->rehearsalService->formatDetail($rehearsalModel),
             ]);
@@ -106,6 +110,10 @@ class RehearsalsController extends Controller
 
         if (!$band) {
             abort(404, 'Band not found for this rehearsal.');
+        }
+
+        if (!$request->user()->canRead('rehearsals', $band->id)) {
+            abort(403, 'You do not have permission to view this rehearsal.');
         }
 
         $rehearsalModel = $this->rehearsalService->findOrCreateStub($schedule, $date, $key);
@@ -127,6 +135,10 @@ class RehearsalsController extends Controller
 
         if (!$band) {
             abort(404, 'Band not found for this rehearsal.');
+        }
+
+        if (!$request->user()->canWrite('rehearsals', $band->id)) {
+            abort(403, 'You do not have permission to edit this rehearsal.');
         }
 
         $validated = $request->validated();

--- a/app/Http/Controllers/Api/Mobile/SetlistController.php
+++ b/app/Http/Controllers/Api/Mobile/SetlistController.php
@@ -13,7 +13,6 @@ use App\Models\LiveSetlistSession;
 use App\Models\User;
 use App\Services\LiveSetlistSessionService;
 use Illuminate\Http\JsonResponse;
-use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 
 class SetlistController extends Controller
@@ -26,6 +25,10 @@ class SetlistController extends Controller
     {
         $event->loadMissing('eventable.band');
         $band = $event->eventable->band;
+
+        if (!$band || !Auth::user()->canRead('events', $band->id)) {
+            abort(403);
+        }
 
         $session = $event->liveSetlistSession()
             ->with(['queue.song.leadSinger', 'captains.user', 'startedBy'])
@@ -64,6 +67,10 @@ class SetlistController extends Controller
     {
         $event->loadMissing('eventable.band');
         $band = $event->eventable->band;
+
+        if (!$band || !Auth::user()->canWrite('events', $band->id)) {
+            abort(403);
+        }
 
         if ($event->liveSetlistSession()->whereIn('status', ['active', 'paused', 'break'])->exists()) {
             return response()->json(['error' => 'A session is already in progress.'], 422);

--- a/app/Http/Middleware/EnsureUserInBand.php
+++ b/app/Http/Middleware/EnsureUserInBand.php
@@ -50,6 +50,30 @@ class EnsureUserInBand
             ], 403);
         }
 
+        // Token abilities are band-agnostic: a user who has, say, read:bookings on
+        // ANY of their bands carries a bare "read:bookings" ability, which the
+        // tokenCan() check above cannot tie back to THIS band. Re-check the
+        // ability against the resolved band so a sub (who is in allBands() but
+        // lacks the per-band permission) can't reach another band's resources.
+        // canRead()/canWrite() are band-scoped and already encode the owner
+        // shortcut and the sub-can-read-events exception.
+        if ($ability && str_contains($ability, ':')) {
+            [$action, $resource] = explode(':', $ability, 2);
+
+            $allowed = match ($action) {
+                'read'  => $user->canRead($resource, $band->id),
+                'write' => $user->canWrite($resource, $band->id),
+                default => true, // unrecognised action shape: leave to tokenCan()
+            };
+
+            if (!$allowed) {
+                return response()->json([
+                    'error' => 'Forbidden.',
+                    'message' => 'You do not have permission for this resource in this band.',
+                ], 403);
+            }
+        }
+
         $request->merge(['mobile_band' => $band]);
 
         // Substitute the resolved model back into the route parameter so that

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -81,6 +81,59 @@ class User extends Authenticatable
     }
 
     /**
+     * Chart IDs a sub is entitled to see for a given band: the charts referenced
+     * in the additional_data of events the user is assigned to (accepted
+     * event_subs, or event_members rows filling a sub slot). A sub does NOT get
+     * the band's whole chart library — only the charts for gigs they play.
+     *
+     * @return array<int>
+     */
+    public function assignedChartIdsForBand($bandId): array
+    {
+        // Events in this band the user is assigned to as a sub.
+        $assignedEventIds = array_values(array_unique(array_merge(
+            \DB::table('event_subs')
+                ->where('user_id', $this->id)
+                ->where('pending', false)
+                ->pluck('event_id')
+                ->toArray(),
+            \DB::table('event_members')
+                ->where('user_id', $this->id)
+                ->whereNull('roster_member_id')
+                ->whereNull('deleted_at')
+                ->pluck('event_id')
+                ->toArray(),
+        )));
+
+        if (empty($assignedEventIds)) {
+            return [];
+        }
+
+        // Restrict to events that belong to this band, then pull chart ids out of
+        // their additional_data->performance->charts[].id references.
+        $events = \App\Models\Events::whereIn('id', $assignedEventIds)
+            ->whereHasMorph('eventable', [\App\Models\Bookings::class, \App\Models\Rehearsal::class], function ($q) use ($bandId) {
+                $q->where('band_id', $bandId);
+            })
+            ->pluck('additional_data');
+
+        $chartIds = [];
+        foreach ($events as $additionalData) {
+            $charts = $additionalData->performance->charts ?? null;
+            if (is_array($charts)) {
+                foreach ($charts as $chart) {
+                    $id = is_object($chart) ? ($chart->id ?? null) : ($chart['id'] ?? null);
+                    if ($id !== null) {
+                        $chartIds[] = (int) $id;
+                    }
+                }
+            }
+        }
+
+        return array_values(array_unique($chartIds));
+    }
+
+    /**
      * Return this user's calendar feed token, minting one on first access.
      *
      * The token authenticates the unauthenticated ICS subscription URL
@@ -139,7 +192,12 @@ class User extends Authenticatable
             return true;
         }
 
-        if ($resource === 'events' && $this->isSubOfBand($bandId)) {
+        // Subs may READ events and charts for bands they sub for, but the
+        // controller must scope the results to the gigs they're assigned to
+        // (their assigned events / the charts on those events) — a sub does not
+        // get the band's full library. Any other resource (bookings, finances,
+        // media, rehearsals) is NOT readable by a sub without an explicit grant.
+        if (in_array($resource, ['events', 'charts'], true) && $this->isSubOfBand($bandId)) {
             return true;
         }
 

--- a/tests/Feature/Api/Mobile/FinanceRevenueTest.php
+++ b/tests/Feature/Api/Mobile/FinanceRevenueTest.php
@@ -25,9 +25,14 @@ class FinanceRevenueTest extends TestCase
         $this->member = User::factory()->create();
         $this->band = Bands::factory()->create();
 
-        // Band member with the read:bookings ability — the finances routes are
-        // gated by `mobile.band:read:bookings`.
+        // Band member with the read:bookings permission — the finances routes are
+        // gated by `mobile.band:read:bookings`, which re-checks the per-band
+        // permission (not just the token ability), so the member must actually
+        // hold read:bookings for this band.
         BandMembers::create(['band_id' => $this->band->id, 'user_id' => $this->member->id]);
+        setPermissionsTeamId($this->band->id);
+        $this->member->givePermissionTo('read:bookings');
+        setPermissionsTeamId(0);
         $this->memberToken = $this->member
             ->createToken('test-device', ['read:bookings'])
             ->plainTextToken;

--- a/tests/Feature/Api/Mobile/FinanceTrendsTest.php
+++ b/tests/Feature/Api/Mobile/FinanceTrendsTest.php
@@ -27,9 +27,14 @@ class FinanceTrendsTest extends TestCase
         $this->member = User::factory()->create();
         $this->band = Bands::factory()->create();
 
-        // Band member with the read:bookings ability — the finances routes are
-        // gated by `mobile.band:read:bookings`.
+        // Band member with the read:bookings permission — the finances routes are
+        // gated by `mobile.band:read:bookings`, which re-checks the per-band
+        // permission (not just the token ability), so the member must actually
+        // hold read:bookings for this band.
         BandMembers::create(['band_id' => $this->band->id, 'user_id' => $this->member->id]);
+        setPermissionsTeamId($this->band->id);
+        $this->member->givePermissionTo('read:bookings');
+        setPermissionsTeamId(0);
         $this->memberToken = $this->member
             ->createToken('test-device', ['read:bookings'])
             ->plainTextToken;

--- a/tests/Feature/Api/Mobile/MobileChartsAggregateTest.php
+++ b/tests/Feature/Api/Mobile/MobileChartsAggregateTest.php
@@ -85,19 +85,39 @@ class MobileChartsAggregateTest extends TestCase
         $this->assertContains('Member Chart', $titles);
     }
 
-    public function test_band_sub_also_sees_charts(): void
+    public function test_band_sub_sees_only_assigned_gig_charts(): void
     {
+        // A sub sees charts for gigs they're assigned to, but NOT the sub band's
+        // whole chart library (which can include pricing they shouldn't see).
         $user = User::factory()->create();
         $band = $this->makeBand('Sub Band');
         BandSubs::create(['user_id' => $user->id, 'band_id' => $band->id]);
-        Charts::create(['band_id' => $band->id, 'title' => 'Sub Chart']);
+
+        $assigned   = Charts::create(['band_id' => $band->id, 'title' => 'Assigned Sub Chart']);
+        Charts::create(['band_id' => $band->id, 'title' => 'Unassigned Sub Chart']);
+
+        $booking = \App\Models\Bookings::factory()->create(['band_id' => $band->id]);
+        $event   = \App\Models\Events::factory()->create([
+            'eventable_id'    => $booking->id,
+            'eventable_type'  => \App\Models\Bookings::class,
+            'date'            => now()->addDays(5)->format('Y-m-d'),
+            'additional_data' => ['performance' => ['charts' => [['id' => $assigned->id, 'title' => 'Assigned Sub Chart']]]],
+        ]);
+        \App\Models\EventMember::create([
+            'event_id'         => $event->id,
+            'band_id'          => $band->id,
+            'user_id'          => $user->id,
+            'roster_member_id' => null,
+            'name'             => $user->name,
+        ]);
 
         $token = $user->createToken('test')->plainTextToken;
         $response = $this->withToken($token)->getJson('/api/mobile/charts');
 
         $response->assertOk();
         $titles = collect($response->json('charts'))->pluck('title');
-        $this->assertContains('Sub Chart', $titles);
+        $this->assertContains('Assigned Sub Chart', $titles);
+        $this->assertNotContains('Unassigned Sub Chart', $titles);
     }
 
     public function test_each_chart_includes_band_block(): void

--- a/tests/Feature/Api/Mobile/PayoutFlowMobileTest.php
+++ b/tests/Feature/Api/Mobile/PayoutFlowMobileTest.php
@@ -39,6 +39,13 @@ class PayoutFlowMobileTest extends TestCase
         // routes can assert a non-owner member is allowed.
         BandMembers::create(['band_id' => $this->band->id, 'user_id' => $this->member->id]);
 
+        // The payout-flow read routes are gated by `mobile.band:read:bookings`,
+        // which re-checks the per-band permission — grant it so the non-owner
+        // member is genuinely allowed on the read-gated routes.
+        setPermissionsTeamId($this->band->id);
+        $this->member->givePermissionTo('read:bookings');
+        setPermissionsTeamId(0);
+
         $this->ownerToken = $this->owner->createToken('test-device')->plainTextToken;
         $this->memberToken = $this->member->createToken('test-device')->plainTextToken;
     }

--- a/tests/Feature/Api/Mobile/SubCrossBandPermissionTest.php
+++ b/tests/Feature/Api/Mobile/SubCrossBandPermissionTest.php
@@ -1,0 +1,226 @@
+<?php
+
+namespace Tests\Feature\Api\Mobile;
+
+use App\Models\BandOwners;
+use App\Models\BandSubs;
+use App\Models\Bands;
+use App\Models\Bookings;
+use App\Models\User;
+use App\Services\Mobile\TokenService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+/**
+ * Regression tests for the cross-band privilege-escalation bug:
+ *
+ * Mobile token abilities are built band-agnostically (a flat set of
+ * "read:bookings"/"write:events" strings across ALL the user's bands). The
+ * EnsureUserInBand middleware then gates a band-scoped route on
+ * `allBands()->contains($band)` (which includes bands the user only SUBS for)
+ * plus a band-agnostic `tokenCan('read:bookings')`. So a user who owns one band
+ * (and therefore holds a global read:bookings ability) could read a DIFFERENT
+ * band's bookings where they are only a sub.
+ *
+ * These tests mint the token via the real TokenService::buildAbilities() flow
+ * (NOT the default ['*'] token) so the middleware's ability check is actually
+ * exercised the way it is in production.
+ */
+class SubCrossBandPermissionTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private User $user;
+    private Bands $ownedBand;
+    private Bands $subBand;
+    private string $token;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->user      = User::factory()->create();
+        $this->ownedBand = Bands::factory()->create();
+        $this->subBand   = Bands::factory()->create();
+
+        // The user OWNS ownedBand → buildAbilities grants a global read:bookings.
+        BandOwners::create([
+            'user_id' => $this->user->id,
+            'band_id' => $this->ownedBand->id,
+        ]);
+
+        // The user is only a SUB for subBand.
+        BandSubs::create([
+            'user_id' => $this->user->id,
+            'band_id' => $this->subBand->id,
+        ]);
+
+        // Mint the token with REAL abilities, exactly as the login flow does.
+        $abilities   = (new TokenService())->buildAbilities($this->user);
+        $this->token = $this->user->createToken('test-device', $abilities)->plainTextToken;
+    }
+
+    public function test_owner_token_carries_global_read_bookings_ability(): void
+    {
+        // Sanity check on the precondition: owning one band leaks a bare,
+        // band-agnostic read:bookings ability into the token.
+        $abilities = (new TokenService())->buildAbilities($this->user);
+        $this->assertContains('read:bookings', $abilities);
+    }
+
+    public function test_sub_cannot_read_bookings_of_band_they_only_sub_for(): void
+    {
+        Bookings::factory()->create(['band_id' => $this->subBand->id]);
+
+        $this->withToken($this->token)
+            ->withHeaders(['X-Band-ID' => $this->subBand->id])
+            ->getJson("/api/mobile/bands/{$this->subBand->id}/bookings")
+            ->assertStatus(403);
+    }
+
+    public function test_sub_cannot_read_finances_of_band_they_only_sub_for(): void
+    {
+        $this->withToken($this->token)
+            ->withHeaders(['X-Band-ID' => $this->subBand->id])
+            ->getJson("/api/mobile/bands/{$this->subBand->id}/finances")
+            ->assertStatus(403);
+    }
+
+    public function test_sub_sees_only_assigned_gig_charts_not_whole_library(): void
+    {
+        // Subs may reach the per-band charts route (like events), but must only
+        // see charts for gigs they're assigned to — NOT the band's whole library.
+        $assignedChart   = \App\Models\Charts::create(['band_id' => $this->subBand->id, 'title' => 'Assigned Chart']);
+        $unassignedChart = \App\Models\Charts::create(['band_id' => $this->subBand->id, 'title' => 'Secret Chart']);
+
+        // A booking + event in the sub band, referencing $assignedChart, that the
+        // user is assigned to via event_members (sub slot: roster_member_id NULL).
+        $booking = Bookings::factory()->create(['band_id' => $this->subBand->id]);
+        $event   = \App\Models\Events::factory()->create([
+            'eventable_id'    => $booking->id,
+            'eventable_type'  => \App\Models\Bookings::class,
+            'date'            => now()->addDays(5)->format('Y-m-d'),
+            'additional_data' => ['performance' => ['charts' => [['id' => $assignedChart->id, 'title' => 'Assigned Chart']]]],
+        ]);
+        \App\Models\EventMember::create([
+            'event_id'         => $event->id,
+            'band_id'          => $this->subBand->id,
+            'user_id'          => $this->user->id,
+            'roster_member_id' => null,
+            'name'             => $this->user->name,
+        ]);
+
+        $titles = collect(
+            $this->withToken($this->token)
+                ->withHeaders(['X-Band-ID' => $this->subBand->id])
+                ->getJson("/api/mobile/bands/{$this->subBand->id}/charts")
+                ->assertOk()
+                ->json('charts')
+        )->pluck('title');
+
+        $this->assertContains('Assigned Chart', $titles);
+        $this->assertNotContains('Secret Chart', $titles);
+    }
+
+    public function test_owner_can_still_read_own_bands_bookings(): void
+    {
+        // The fix must NOT break the legitimate case: reading bookings of a band
+        // you actually own.
+        Bookings::factory()->create(['band_id' => $this->ownedBand->id]);
+
+        $this->withToken($this->token)
+            ->withHeaders(['X-Band-ID' => $this->ownedBand->id])
+            ->getJson("/api/mobile/bands/{$this->ownedBand->id}/bookings")
+            ->assertOk();
+    }
+
+    public function test_sub_can_still_read_events_of_sub_band(): void
+    {
+        // Events are intentionally readable by subs — the fix must preserve this.
+        $this->withToken($this->token)
+            ->withHeaders(['X-Band-ID' => $this->subBand->id])
+            ->getJson("/api/mobile/bands/{$this->subBand->id}/events")
+            ->assertOk();
+    }
+
+    // -------------------------------------------------------------------------
+    // Tier 0: endpoints that previously had NO band authorization at all
+    // (any authenticated user could reach any band's data by object id).
+    // -------------------------------------------------------------------------
+
+    public function test_stranger_cannot_read_rehearsal_by_key(): void
+    {
+        $schedule = \App\Models\RehearsalSchedule::factory()->create([
+            'band_id' => $this->subBand->id,
+        ]);
+
+        // A user with no relationship to subBand at all.
+        $stranger      = User::factory()->create();
+        $strangerToken = $stranger->createToken('test-device')->plainTextToken;
+
+        $key = "virtual-rehearsal-{$schedule->id}-" . now()->addDays(3)->format('Y-m-d');
+
+        $this->withToken($strangerToken)
+            ->withHeaders(['X-Band-ID' => $this->subBand->id])
+            ->getJson('/api/mobile/rehearsals/by-key/' . $key)
+            ->assertStatus(403);
+    }
+
+    public function test_stranger_cannot_update_rehearsal_notes(): void
+    {
+        $schedule = \App\Models\RehearsalSchedule::factory()->create([
+            'band_id' => $this->subBand->id,
+        ]);
+        $rehearsal = \App\Models\Rehearsal::factory()->create([
+            'rehearsal_schedule_id' => $schedule->id,
+            'notes'                 => 'original notes',
+        ]);
+
+        $stranger      = User::factory()->create();
+        $strangerToken = $stranger->createToken('test-device')->plainTextToken;
+
+        $this->withToken($strangerToken)
+            ->withHeaders(['X-Band-ID' => $this->subBand->id])
+            ->patchJson("/api/mobile/rehearsals/{$rehearsal->id}/notes", ['notes' => 'pwned'])
+            ->assertStatus(403);
+
+        // The blocked write must not have mutated the notes.
+        $this->assertSame('original notes', $rehearsal->fresh()->notes);
+    }
+
+    public function test_stranger_cannot_view_live_setlist_session(): void
+    {
+        $booking = Bookings::factory()->create(['band_id' => $this->subBand->id]);
+        $event   = \App\Models\Events::factory()->create([
+            'eventable_id'   => $booking->id,
+            'eventable_type' => \App\Models\Bookings::class,
+            'date'           => now()->addDays(2)->format('Y-m-d'),
+        ]);
+
+        $stranger      = User::factory()->create();
+        $strangerToken = $stranger->createToken('test-device')->plainTextToken;
+
+        $this->withToken($strangerToken)
+            ->withHeaders(['X-Band-ID' => $this->subBand->id])
+            ->getJson("/api/mobile/setlist/events/{$event->key}/session")
+            ->assertStatus(403);
+    }
+
+    public function test_sub_cannot_start_live_setlist_session(): void
+    {
+        // A sub holds read:events (and via the leaked token, write:events from
+        // their owned band) but must not be able to START a session on a band
+        // they only sub for — start requires canWrite('events', band).
+        $booking = Bookings::factory()->create(['band_id' => $this->subBand->id]);
+        $event   = \App\Models\Events::factory()->create([
+            'eventable_id'   => $booking->id,
+            'eventable_type' => \App\Models\Bookings::class,
+            'date'           => now()->addDays(2)->format('Y-m-d'),
+        ]);
+
+        $this->withToken($this->token)
+            ->withHeaders(['X-Band-ID' => $this->subBand->id])
+            ->postJson("/api/mobile/setlist/events/{$event->key}/session")
+            ->assertStatus(403);
+    }
+}


### PR DESCRIPTION
## Problem

A substitute user reported seeing **all bookings** for a band they only sub for. Root cause: mobile Sanctum **token abilities are band-agnostic**.

- `TokenService::buildAbilities()` loops over *all* the user's bands and emits bare abilities like `read:bookings` — with no band ID attached. A user who owns their own (solo) band therefore carries a global `read:bookings`.
- `EnsureUserInBand` gated band-scoped routes on `allBands()->contains($band)` (which **includes** bands the user only subs for) plus a band-agnostic `tokenCan()`. Both pass for a sub who owns any other band.

Net effect: **any user with a permission on *any one* band could exercise it against *every* band they can reach — including bands where they're only a sub** (bookings, finances, contracts, payout configs, charts, media).

## Fix

1. **`EnsureUserInBand`** now re-checks the ability against the resolved route band via `User::canRead/canWrite($resource, $band->id)` (band-scoped and already sub-aware) instead of trusting the flat token ability. This closes every middleware-gated endpoint in one place.

2. **Four endpoints had *no* band authorization at all** (IDOR — any authenticated user could reach any band's data by object id). Added explicit guards:
   - `SetlistController::show` / `start` → `canRead` / `canWrite('events', band)`
   - `RehearsalsController::showByKey` → `canRead('rehearsals', band)`
   - `RehearsalsController::updateNotes` → `canWrite('rehearsals', band)` (previously **any** user could overwrite **any** band's rehearsal notes)
   - `RehearsalsController::show` tightened from `allBands()` to `canRead()`

3. **Charts** — subs now see **only the charts for gigs they're assigned to**, not the band's whole library (which exposes pricing). New `User::assignedChartIdsForBand()`; the `canRead` sub-exception is extended to `charts`; the aggregate `/charts` and per-band charts/detail/download endpoints are scoped.

## Notes

- `owner`-gated routes (settings, rosters, subs, payout-flow writes) were already safe — `Owner` middleware re-verifies `isOwner($routeBand)`.
- Endpoints that already re-checked `canRead/canWrite` or `bands()->contains()` (EventsController, the payout screen, `/me/bookings`, search) were unaffected.
- Three existing Finance/Payout tests set up a member with a **token ability but no real per-band permission** — they passed only because of the bug. Updated to grant the actual `read:bookings` permission.

## Tests

New `tests/Feature/Api/Mobile/SubCrossBandPermissionTest.php` (10 tests) reproduces the leak and locks in every fix. Full mobile suite green (344 passing); full backend suite: 1418 passing. The only failures are pre-existing `CalendarFeedTest` timezone flakes from parallel test pollution (confirmed unrelated — they fail worse on the clean base).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GM9efefnX4xsn3NBXrJ5bC