### PR TITLE
Follow-up: explicit session write for invite landing intended URL

### DIFF
--- a/app/Http/Controllers/Onboarding/InviteLandingController.php
+++ b/app/Http/Controllers/Onboarding/InviteLandingController.php
@@ -31,9 +31,10 @@ class InviteLandingController extends Controller
         if ($invitation) {
             // Remember the key so a guest who registers gets it prefilled on
             // the onboarding join form, and send post-login traffic straight
-            // back to this page.
+            // back to this page ('url.intended' is what the login
+            // controller's redirect()->intended() reads).
             $request->session()->put('pending_invite_key', $key);
-            redirect()->setIntendedUrl(route('invite.landing', $key));
+            $request->session()->put('url.intended', route('invite.landing', $key));
         }
 
         return Inertia::render('Onboarding/InviteLanding', [


### PR DESCRIPTION
## Summary

Follow-up to #502, which was merged while its Copilot review fix was still in flight. Addresses the one review comment: `redirect()->setIntendedUrl(...)` worked only through a discarded side effect and read like a no-op, so a future cleanup could delete it and silently break "login returns to the invite page." Now it's an explicit `$request->session()->put('url.intended', ...)`, matching the `pending_invite_key` write above it.

## Test plan

- [x] `tests/Feature/InviteLandingTest.php` — 9 passed (includes the assertion that `url.intended` lands in the session)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YNyzbE8jweH5FLjTMJt1kY