### PR TITLE
fix(media): guard non-seekable skip loop against short reads

### DIFF
--- a/app/Http/Traits/ServesByteRanges.php
+++ b/app/Http/Traits/ServesByteRanges.php
@@ -45,9 +45,20 @@ trait ServesByteRanges
                     fseek($stream, $start);
                 } else {
                     $skipped = 0;
-                    while ($skipped < $start) {
-                        $chunk    = min(65536, $start - $skipped);
-                        $skipped += strlen(fread($stream, $chunk));
+                    while ($skipped < $start && !feof($stream)) {
+                        $chunk = fread($stream, min(65536, $start - $skipped));
+                        if ($chunk === false || $chunk === '') {
+                            break;
+                        }
+                        $skipped += strlen($chunk);
+                    }
+
+                    // Stream ended before the range start: the stored size is
+                    // out of sync with the actual object; the range is unservable.
+                    if ($skipped < $start) {
+                        fclose($stream);
+
+                        return response('', 416, ['Content-Range' => "bytes */{$size}"]);
                     }
                 }
             }

--- a/tests/Feature/MediaServeRangeTest.php
+++ b/tests/Feature/MediaServeRangeTest.php
@@ -120,6 +120,38 @@ class MediaServeRangeTest extends TestCase
         $this->assertSame('abcde', $response->streamedContent());
     }
 
+    /**
+     * A non-seekable stream that hits EOF before the requested range start
+     * (stored size out of sync with the actual object) must not spin the
+     * skip loop forever — it should give up with a 416.
+     */
+    public function test_range_on_stream_shorter_than_reported_size_returns_416(): void
+    {
+        [$writer, $reader] = stream_socket_pair(STREAM_PF_UNIX, STREAM_SOCK_STREAM, STREAM_IPPROTO_IP);
+        fwrite($writer, '0123456789'); // 10 real bytes
+        fclose($writer);
+
+        $disk = \Mockery::mock(\Illuminate\Contracts\Filesystem\Filesystem::class);
+        $disk->shouldReceive('size')->andReturn(100); // metadata claims 100
+        $disk->shouldReceive('readStream')->andReturn($reader);
+
+        $server = new class {
+            use \App\Http\Traits\ServesByteRanges;
+
+            public function call($request, $disk)
+            {
+                return $this->streamWithByteRanges($request, $disk, 'whatever', []);
+            }
+        };
+
+        $request = \Illuminate\Http\Request::create('/file', 'GET', server: ['HTTP_RANGE' => 'bytes=50-59']);
+
+        $response = $server->call($request, $disk);
+
+        $this->assertSame(416, $response->getStatusCode());
+        $this->assertSame('bytes */100', $response->headers->get('Content-Range'));
+    }
+
     public function test_contact_portal_serve_honors_range_requests(): void
     {
         $contact = Contacts::factory()->create([


### PR DESCRIPTION
## Problem

Follow-up to #511 — this commit was pushed to the original branch right after it merged, so it missed the PR. It addresses the Copilot review finding there ([comment](https://github.com/eddimull/TTS/pull/511#discussion_r3524506325)).

In `ServesByteRanges`, the skip loop for non-seekable streams had no termination guard. If the stream hits EOF before the requested range start — e.g. the stored `file_size` is out of sync with the actual S3 object — `fread` returns `''`, `$skipped` never advances, and the loop spins forever, pinning a PHP worker at 100% CPU.

## Fix

- Guard the skip loop with `!feof()` / empty-read break, matching the streaming loop below it.
- Return `416` with `Content-Range: bytes */<size>` when the stream ends before the range start (the requested range is beyond the real data).

## Tests

`test_range_on_stream_shorter_than_reported_size_returns_416` — written first against the unguarded loop, where it genuinely hung until killed by timeout; passes in 0.06s with the guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YNyzbE8jweH5FLjTMJt1kY