### PR TITLE
Contract amendment: recall a sent contract for editing

### DIFF
--- a/app/Http/Controllers/Api/Mobile/BookingsController.php
+++ b/app/Http/Controllers/Api/Mobile/BookingsController.php
@@ -21,6 +21,7 @@ use App\Models\EventMember;
 use App\Models\Events;
 use App\Models\Payments;
 use App\Services\BookingActivityService;
+use App\Services\ContractAmendmentService;
 use App\Services\Mobile\BookingFormatter;
 use App\Services\Mobile\BookingService;
 use Illuminate\Http\JsonResponse;
@@ -568,6 +569,27 @@ class BookingsController extends Controller
         } catch (\Exception $e) {
             return response()->json(['message' => 'Failed to send contract: ' . $e->getMessage()], 500);
         }
+    }
+
+    public function amendContract(
+        Request $request,
+        Bands $band,
+        Bookings $booking,
+        ContractAmendmentService $amendmentService
+    ): JsonResponse {
+        try {
+            $amendmentService->amend($booking);
+        } catch (\InvalidArgumentException $e) {
+            return response()->json(['message' => $e->getMessage()], 422);
+        } catch (\Exception $e) {
+            return response()->json(['message' => 'Failed to amend contract: ' . $e->getMessage()], 500);
+        }
+
+        return response()->json([
+            'booking' => $this->formatter->format(
+                $booking->fresh()->load(['contacts', 'events', 'contract', 'payments', 'band'])
+            ),
+        ]);
     }
 
     public function saveContractTerms(

--- a/app/Http/Controllers/ContractsController.php
+++ b/app/Http/Controllers/ContractsController.php
@@ -12,6 +12,7 @@ use Illuminate\Support\Facades\Storage;
 use App\Http\Requests\StoreContractsRequest;
 use App\Http\Requests\UpdateContractsRequest;
 use App\Http\Requests\SendBookingContractRequest;
+use App\Services\ContractAmendmentService;
 
 class ContractsController extends Controller
 {
@@ -239,6 +240,19 @@ class ContractsController extends Controller
                 ->withErrors(['Failed to send contract:' => $e->getMessage()])
                 ->withInput();
         }
+    }
+
+    public function amendBookingContract(Bands $band, Bookings $booking, ContractAmendmentService $amendmentService)
+    {
+        try {
+            $amendmentService->amend($booking);
+        } catch (\InvalidArgumentException $e) {
+            return redirect()->back()->withErrors(['Cannot amend' => $e->getMessage()]);
+        } catch (\Exception $e) {
+            return redirect()->back()->withErrors(['Amend failed' => $e->getMessage()]);
+        }
+
+        return redirect()->back();
     }
 
     /**

--- a/app/Http/Controllers/ContractsController.php
+++ b/app/Http/Controllers/ContractsController.php
@@ -244,15 +244,20 @@ class ContractsController extends Controller
 
     public function amendBookingContract(Bands $band, Bookings $booking, ContractAmendmentService $amendmentService)
     {
-        try {
+        try
+        {
             $amendmentService->amend($booking);
-        } catch (\InvalidArgumentException $e) {
+        }
+        catch (\InvalidArgumentException $e)
+        {
             return redirect()->back()->withErrors(['Cannot amend' => $e->getMessage()]);
-        } catch (\Exception $e) {
+        }
+        catch (\Exception $e)
+        {
             return redirect()->back()->withErrors(['Amend failed' => $e->getMessage()]);
         }
 
-        return redirect()->back();
+        return redirect()->back()->with('successMessage', 'Contract recalled — edit and resend when ready.');
     }
 
     /**

--- a/app/Http/Requests/Mobile/UpdateBookingRequest.php
+++ b/app/Http/Requests/Mobile/UpdateBookingRequest.php
@@ -24,6 +24,17 @@ class UpdateBookingRequest extends FormRequest
             'venue_address' => 'prohibited',
             'notes'         => 'sometimes|nullable|string',
             'status'        => 'sometimes|in:draft,pending,confirmed,cancelled',
+            'contract_option' => [
+                'sometimes', 'in:default,none,external',
+                function ($attribute, $value, $fail)
+                {
+                    $contract = $this->route('booking')?->contract;
+                    if ($contract && in_array($contract->status, ['sent', 'completed'], true))
+                    {
+                        $fail('The contract type cannot be changed after the contract has been sent.');
+                    }
+                },
+            ],
             'deposit_type' => [
                 'sometimes', 'required', 'in:percent,amount',
                 new \App\Http\Requests\Rules\DepositNotLocked($this->route('booking')),

--- a/app/Models/Traits/Signable.php
+++ b/app/Models/Traits/Signable.php
@@ -155,6 +155,38 @@ trait Signable
         }
     }
 
+    /**
+     * Void the PandaDoc document for this contract so it can be amended.
+     *
+     * A 404 means the document was already deleted (e.g. by hand in the
+     * PandaDoc dashboard) — treated as success so amendment is idempotent.
+     * Any other failure throws and the caller must not mutate local state.
+     */
+    public function voidPandaDocDocument(): void
+    {
+        if (!$this->envelope_id)
+        {
+            return;
+        }
+
+        $apiKey = config('services.pandadoc.api_key');
+
+        $response = Http::withHeaders([
+            'Authorization' => 'API-Key ' . $apiKey,
+            'Content-Type' => 'application/json',
+        ])->patch("https://api.pandadoc.com/public/v1/documents/{$this->envelope_id}/status/", [
+            'status' => 11, // document.voided
+        ]);
+
+        if ($response->successful() || $response->status() === 404)
+        {
+            return;
+        }
+
+        Log::error('Failed to void PandaDoc document: ' . $response->body());
+        throw new \Exception('Failed to void the PandaDoc document: ' . $response->body());
+    }
+
     public function auditTrail()
     {
         $pandaDocService = new PandaDocService();

--- a/app/Services/ContractAmendmentService.php
+++ b/app/Services/ContractAmendmentService.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\Bookings;
+use Illuminate\Support\Facades\DB;
+use InvalidArgumentException;
+
+class ContractAmendmentService
+{
+    /**
+     * Recall a booking contract that is out for signature so it can be
+     * edited and resent. Voids the PandaDoc document first (external call,
+     * not rollback-able), then resets contract + booking state so the
+     * contract editor unlocks. Resending later creates a fresh document.
+     */
+    public function amend(Bookings $booking): void
+    {
+        $contract = $booking->contract;
+
+        if ($booking->contract_option !== 'default')
+        {
+            throw new InvalidArgumentException('Only Bandmate-generated contracts can be amended.');
+        }
+
+        if (!$contract || $contract->status !== 'sent')
+        {
+            throw new InvalidArgumentException('Only a contract that is out for signature can be amended.');
+        }
+
+        if ($booking->status !== 'pending')
+        {
+            throw new InvalidArgumentException('Only a pending booking can have its contract amended.');
+        }
+
+        $contract->voidPandaDocDocument();
+
+        DB::transaction(function () use ($booking, $contract)
+        {
+            $contract->update(['status' => 'pending', 'envelope_id' => null]);
+            $booking->update(['status' => 'draft']);
+        });
+    }
+}

--- a/resources/js/Pages/Bookings/Contract.vue
+++ b/resources/js/Pages/Bookings/Contract.vue
@@ -33,12 +33,23 @@
       >
         This contract is confirmed and was created externally. The contract is no longer editable.
       </p>
-      <p
+      <div
         v-if="booking.status === 'pending'"
-        class="text-xl text-center text-gray-700 font-semibold bg-blue-100 py-3 px-4 rounded-lg shadow-sm"
+        class="text-center bg-blue-100 py-3 px-4 rounded-lg shadow-sm space-y-3"
       >
-        This contract is pending. The contract is no longer editable.
-      </p>
+        <p class="text-xl text-gray-700 font-semibold">
+          This contract is pending. The contract is no longer editable.
+        </p>
+        <button
+          v-if="booking.contract_option === 'default'"
+          data-testid="amend-contract"
+          type="button"
+          class="inline-flex items-center px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white text-sm font-semibold rounded-md"
+          @click="amendContract"
+        >
+          Amend contract
+        </button>
+      </div>
       <div class="grid gap-6 lg:grid-cols-3">
         <div
           class="bg-white dark:bg-slate-700 rounded-lg shadow-md overflow-hidden"
@@ -75,7 +86,8 @@
 </template>
 
 <script setup>
-import BookingLayout from './Layout/BookingLayout.vue'  
+import { router } from '@inertiajs/vue3'
+import BookingLayout from './Layout/BookingLayout.vue'
 import ContractEditor from './Components/ContractEditor.vue'
 import ContractNone from './Components/ContractNone.vue';
 import ContractExternal from './Components/ContractExternal.vue';
@@ -89,4 +101,17 @@ const props = defineProps({
   booking: Object,
   band: Object,
 })
+
+const amendContract = () => {
+  if (!window.confirm(
+    'This voids the contract that is out for signature. ' +
+    'You will be able to edit the terms and resend it.'
+  )) {
+    return;
+  }
+  router.post(route('Amend Booking Contract', {
+    band: props.booking.band_id,
+    booking: props.booking.id,
+  }));
+}
 </script>

--- a/resources/js/tests/components/contractamend.test.js
+++ b/resources/js/tests/components/contractamend.test.js
@@ -1,0 +1,64 @@
+import { describe, expect, it, beforeEach, vi } from 'vitest';
+import { mount } from '@vue/test-utils';
+
+// Mock route helper (Ziggy's route() is a bare global in <script setup> components)
+global.route = vi.fn((name, params) => `/${name}/${JSON.stringify(params)}`);
+
+// Mock Inertia - use factory function to avoid hoisting issues
+vi.mock('@inertiajs/vue3', () => ({
+    router: {
+        get: vi.fn(),
+        post: vi.fn(),
+        put: vi.fn(),
+        delete: vi.fn(),
+    },
+}));
+
+import Contract from '@/Pages/Bookings/Contract.vue';
+import { router } from '@inertiajs/vue3';
+
+const pendingBooking = {
+    id: 5,
+    band_id: 1,
+    status: 'pending',
+    contract_option: 'default',
+    contract: { asset_url: null },
+};
+
+const mountPage = (booking) =>
+    mount(Contract, {
+        props: { booking, band: { id: 1, name: 'Band' } },
+        global: {
+            stubs: { ContractNone: true, ContractExternal: true, ContractEditor: true, ContractStatus: true },
+        },
+    });
+
+describe('Contract.vue amend button', () => {
+    beforeEach(() => {
+        vi.mocked(router.post).mockClear();
+    });
+
+    it('shows Amend contract on a pending default contract and posts on confirm', async () => {
+        vi.spyOn(window, 'confirm').mockReturnValue(true);
+        const wrapper = mountPage(pendingBooking);
+
+        expect(wrapper.text()).toContain('Amend contract');
+        await wrapper.find('[data-testid="amend-contract"]').trigger('click');
+
+        expect(router.post).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not post when the confirm dialog is cancelled', async () => {
+        vi.spyOn(window, 'confirm').mockReturnValue(false);
+        vi.mocked(router.post).mockClear();
+        const wrapper = mountPage(pendingBooking);
+
+        await wrapper.find('[data-testid="amend-contract"]').trigger('click');
+        expect(router.post).not.toHaveBeenCalled();
+    });
+
+    it('hides the button when the booking is confirmed', () => {
+        const wrapper = mountPage({ ...pendingBooking, status: 'confirmed' });
+        expect(wrapper.text()).not.toContain('Amend contract');
+    });
+});

--- a/routes/api.php
+++ b/routes/api.php
@@ -254,6 +254,7 @@ Route::prefix('mobile')->group(function () {
             // Booking contract (write)
             Route::post('/bands/{band}/bookings/{booking}/contract/upload', [App\Http\Controllers\Api\Mobile\BookingsController::class, 'uploadContract'])->name('mobile.bookings.contract.upload');
             Route::post('/bands/{band}/bookings/{booking}/contract/send', [App\Http\Controllers\Api\Mobile\BookingsController::class, 'sendContract'])->name('mobile.bookings.contract.send');
+            Route::post('/bands/{band}/bookings/{booking}/contract/amend', [App\Http\Controllers\Api\Mobile\BookingsController::class, 'amendContract'])->name('mobile.bookings.contract.amend');
             Route::post('/bands/{band}/bookings/{booking}/contract/terms', [App\Http\Controllers\Api\Mobile\BookingsController::class, 'saveContractTerms'])->name('mobile.bookings.contract.terms');
 
         });

--- a/routes/booking.php
+++ b/routes/booking.php
@@ -78,6 +78,10 @@ Route::middleware(['auth', 'verified'])->group(function ()
         ->name('Send Booking Contract')
         ->middleware('booking.access');
 
+    Route::post('bands/{band}/booking/{booking}/contract/amend', [ContractsController::class, 'amendBookingContract'])
+        ->name('Amend Booking Contract')
+        ->middleware('booking.access');
+
     Route::post('bands/{band}/booking/{booking}/finances', [BookingsController::class, 'storePayment'])
         ->name('Store Booking Payment')
         ->middleware('booking.access');

--- a/tests/Feature/Api/Mobile/BookingContractAmendTest.php
+++ b/tests/Feature/Api/Mobile/BookingContractAmendTest.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace Tests\Feature\Api\Mobile;
+
+use App\Models\Bands;
+use App\Models\Bookings;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\Http;
+use Tests\TestCase;
+
+class BookingContractAmendTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        Config::set('services.pandadoc.api_key', 'fake-api-key');
+    }
+
+    private function makeBooking(User $user, string $bookingStatus = 'pending', string $contractStatus = 'sent'): Bookings
+    {
+        $band = Bands::factory()->create();
+        $band->owners()->create(['user_id' => $user->id]);
+
+        $booking = Bookings::factory()->create([
+            'band_id'         => $band->id,
+            'status'          => $bookingStatus,
+            'contract_option' => 'default',
+        ]);
+        $booking->contract()->create([
+            'author_id'   => $user->id,
+            'status'      => $contractStatus,
+            'envelope_id' => 'pd-doc-456',
+        ]);
+
+        return $booking;
+    }
+
+    public function test_amend_returns_booking_back_in_draft(): void
+    {
+        Http::fake(['api.pandadoc.com/*' => Http::response([], 200)]);
+
+        $user    = User::factory()->create();
+        $booking = $this->makeBooking($user);
+        $token   = $user->createToken('test-device')->plainTextToken;
+
+        $response = $this->withToken($token)
+            ->withHeaders(['X-Band-ID' => $booking->band_id])
+            ->postJson("/api/mobile/bands/{$booking->band_id}/bookings/{$booking->id}/contract/amend");
+
+        $response->assertOk()
+            ->assertJsonPath('booking.status', 'draft')
+            ->assertJsonPath('booking.contract.status', 'pending')
+            ->assertJsonPath('booking.contract.envelope_id', null);
+    }
+
+    public function test_amend_rejects_unsent_contract_with_422(): void
+    {
+        Http::fake();
+
+        $user    = User::factory()->create();
+        $booking = $this->makeBooking($user, bookingStatus: 'draft', contractStatus: 'pending');
+        $token   = $user->createToken('test-device')->plainTextToken;
+
+        $this->withToken($token)
+            ->withHeaders(['X-Band-ID' => $booking->band_id])
+            ->postJson("/api/mobile/bands/{$booking->band_id}/bookings/{$booking->id}/contract/amend")
+            ->assertStatus(422);
+
+        Http::assertNothingSent();
+    }
+}

--- a/tests/Feature/Api/Mobile/BookingContractOptionUpdateTest.php
+++ b/tests/Feature/Api/Mobile/BookingContractOptionUpdateTest.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace Tests\Feature\Api\Mobile;
+
+use App\Models\Bands;
+use App\Models\Bookings;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class BookingContractOptionUpdateTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function makeBooking(User $user, string $contractStatus = 'pending'): Bookings
+    {
+        $band = Bands::factory()->create();
+        $band->owners()->create(['user_id' => $user->id]);
+
+        $booking = Bookings::factory()->create([
+            'band_id'         => $band->id,
+            'status'          => 'draft',
+            'contract_option' => 'default',
+        ]);
+        $booking->contract()->create(['author_id' => $user->id, 'status' => $contractStatus]);
+
+        return $booking;
+    }
+
+    public function test_contract_option_updates_when_contract_not_sent(): void
+    {
+        $user    = User::factory()->create();
+        $booking = $this->makeBooking($user);
+        $token   = $user->createToken('test-device')->plainTextToken;
+
+        $this->withToken($token)
+            ->withHeaders(['X-Band-ID' => $booking->band_id])
+            ->patchJson("/api/mobile/bands/{$booking->band_id}/bookings/{$booking->id}", [
+                'contract_option' => 'external',
+            ])
+            ->assertOk()
+            ->assertJsonPath('booking.contract_option', 'external');
+
+        $this->assertSame('external', $booking->fresh()->contract_option);
+    }
+
+    public function test_contract_option_rejected_once_contract_sent(): void
+    {
+        $user    = User::factory()->create();
+        $booking = $this->makeBooking($user, contractStatus: 'sent');
+        $token   = $user->createToken('test-device')->plainTextToken;
+
+        $this->withToken($token)
+            ->withHeaders(['X-Band-ID' => $booking->band_id])
+            ->patchJson("/api/mobile/bands/{$booking->band_id}/bookings/{$booking->id}", [
+                'contract_option' => 'none',
+            ])
+            ->assertStatus(422)
+            ->assertJsonValidationErrors(['contract_option']);
+
+        $this->assertSame('default', $booking->fresh()->contract_option);
+    }
+
+    public function test_contract_option_value_validated(): void
+    {
+        $user    = User::factory()->create();
+        $booking = $this->makeBooking($user);
+        $token   = $user->createToken('test-device')->plainTextToken;
+
+        $this->withToken($token)
+            ->withHeaders(['X-Band-ID' => $booking->band_id])
+            ->patchJson("/api/mobile/bands/{$booking->band_id}/bookings/{$booking->id}", [
+                'contract_option' => 'verbal',
+            ])
+            ->assertStatus(422);
+    }
+}

--- a/tests/Feature/BookingContractAmendWebTest.php
+++ b/tests/Feature/BookingContractAmendWebTest.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Bands;
+use App\Models\Bookings;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\Http;
+use Tests\TestCase;
+
+class BookingContractAmendWebTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_web_amend_resets_booking_and_redirects_back(): void
+    {
+        Config::set('services.pandadoc.api_key', 'fake-api-key');
+        Http::fake(['api.pandadoc.com/*' => Http::response([], 200)]);
+
+        $user = User::factory()->create();
+        $band = Bands::factory()->create();
+        $band->owners()->create(['user_id' => $user->id]);
+
+        $booking = Bookings::factory()->create([
+            'band_id'         => $band->id,
+            'status'          => 'pending',
+            'contract_option' => 'default',
+        ]);
+        $booking->contract()->create([
+            'author_id'   => $user->id,
+            'status'      => 'sent',
+            'envelope_id' => 'pd-doc-789',
+        ]);
+
+        $response = $this->actingAs($user)->post(
+            route('Amend Booking Contract', ['band' => $band, 'booking' => $booking])
+        );
+
+        $response->assertRedirect();
+        $this->assertSame('draft', $booking->fresh()->status);
+        $this->assertSame('pending', $booking->fresh()->contract->status);
+    }
+}

--- a/tests/Feature/ContractAmendmentServiceTest.php
+++ b/tests/Feature/ContractAmendmentServiceTest.php
@@ -1,0 +1,126 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Bands;
+use App\Models\Bookings;
+use App\Models\User;
+use App\Services\ContractAmendmentService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\Http;
+use InvalidArgumentException;
+use Tests\TestCase;
+
+class ContractAmendmentServiceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        Config::set('services.pandadoc.api_key', 'fake-api-key');
+    }
+
+    /** Booking in the amendable state: default option, contract sent, booking pending. */
+    private function amendableBooking(): Bookings
+    {
+        $user = User::factory()->create();
+        $band = Bands::factory()->create();
+        $band->owners()->create(['user_id' => $user->id]);
+
+        $booking = Bookings::factory()->create([
+            'band_id'         => $band->id,
+            'status'          => 'pending',
+            'contract_option' => 'default',
+        ]);
+        $booking->contract()->create([
+            'author_id'   => $user->id,
+            'status'      => 'sent',
+            'envelope_id' => 'pd-doc-123',
+            'custom_terms' => [['title' => 'T', 'content' => 'C']],
+        ]);
+
+        return $booking->fresh();
+    }
+
+    public function test_amend_voids_document_and_resets_state(): void
+    {
+        Http::fake(['api.pandadoc.com/*' => Http::response([], 200)]);
+
+        $booking = $this->amendableBooking();
+        app(ContractAmendmentService::class)->amend($booking);
+
+        Http::assertSent(fn ($req) =>
+            $req->url() === 'https://api.pandadoc.com/public/v1/documents/pd-doc-123/status/'
+            && $req->method() === 'PATCH'
+            && ($req['status'] ?? null) === 11
+        );
+
+        $booking->refresh();
+        $this->assertSame('draft', $booking->status);
+        $this->assertSame('pending', $booking->contract->status);
+        $this->assertNull($booking->contract->envelope_id);
+        $this->assertNotEmpty($booking->contract->custom_terms);
+    }
+
+    public function test_amend_tolerates_document_already_deleted(): void
+    {
+        Http::fake(['api.pandadoc.com/*' => Http::response(['detail' => 'Not found'], 404)]);
+
+        $booking = $this->amendableBooking();
+        app(ContractAmendmentService::class)->amend($booking);
+
+        $this->assertSame('draft', $booking->fresh()->status);
+    }
+
+    public function test_amend_aborts_without_db_changes_when_void_fails(): void
+    {
+        Http::fake(['api.pandadoc.com/*' => Http::response(['detail' => 'boom'], 500)]);
+
+        $booking = $this->amendableBooking();
+
+        try {
+            app(ContractAmendmentService::class)->amend($booking);
+            $this->fail('Expected exception');
+        } catch (\Exception $e) {
+            $this->assertStringContainsString('void', strtolower($e->getMessage()));
+        }
+
+        $booking->refresh();
+        $this->assertSame('pending', $booking->status);
+        $this->assertSame('sent', $booking->contract->status);
+        $this->assertSame('pd-doc-123', $booking->contract->envelope_id);
+    }
+
+    public function test_amend_rejects_external_option(): void
+    {
+        Http::fake();
+        $booking = $this->amendableBooking();
+        $booking->update(['contract_option' => 'external']);
+
+        $this->expectException(InvalidArgumentException::class);
+        app(ContractAmendmentService::class)->amend($booking->fresh());
+    }
+
+    public function test_amend_rejects_unsent_contract(): void
+    {
+        Http::fake();
+        $booking = $this->amendableBooking();
+        $booking->contract->update(['status' => 'pending']);
+
+        $this->expectException(InvalidArgumentException::class);
+        app(ContractAmendmentService::class)->amend($booking->fresh());
+    }
+
+    public function test_amend_rejects_completed_contract(): void
+    {
+        Http::fake();
+        $booking = $this->amendableBooking();
+        $booking->contract->update(['status' => 'completed']);
+        $booking->update(['status' => 'confirmed']);
+
+        $this->expectException(InvalidArgumentException::class);
+        app(ContractAmendmentService::class)->amend($booking->fresh());
+    }
+}


### PR DESCRIPTION
## Summary

Amending a contract that's out for signature previously required flipping the booking status by hand, logging into PandaDoc, deleting the document, editing, and resending. This adds a one-click **Amend contract** flow:

- **`ContractAmendmentService::amend()`** — guards (Bandmate-generated option, contract `sent`, booking `pending`), voids the PandaDoc document first (`PATCH /documents/{id}/status/` → voided; a 404 counts as success so amend is idempotent when the doc was already hand-deleted), then in a transaction resets contract → `pending` + `envelope_id` → null and booking → `draft`. A PandaDoc failure aborts with zero DB writes.
- **`Signable::voidPandaDocDocument()`** — the recall primitive next to the existing send path.
- **Mobile API**: `POST /api/mobile/bands/{band}/bookings/{booking}/contract/amend` (write:bookings group) returning the formatted booking; 422 with a human message on guard violations.
- **Web**: `POST bands/{band}/booking/{booking}/contract/amend` ('Amend Booking Contract', booking.access) + an **Amend contract** button on Contract.vue's pending dead-end banner (confirm dialog → post → editor unlocks). Success flashes "Contract recalled — edit and resend when ready."
- **Mobile `UpdateBookingRequest`** now accepts `contract_option` (`default|none|external`) unless the contract is `sent`/`completed` — closes the silently-dropped-field gap found in TTS-App#91 and unblocks the app's contract-type picker.

## Testing

- 12 new feature tests (`Http::fake`): service happy path/guards/404-tolerance/no-DB-writes-on-failure, mobile endpoint, web endpoint, contract_option accept/reject cases; 3 new vitest cases for the Vue button. Full suite 1510/1512 (2 = known CalendarFeedTest parallel flake, sequentially green).
- Verified live against the local stack from both frontends: web button and the companion app both recalled a sent contract (real PandaDoc void call, 404-tolerated), unlocked the editor, and left resend working.

## Deploy note

Backend-first is safe (purely additive). The companion mobile PR can merge anytime, but **promote this to production before the mobile store rollout** — on prod's current code the app's amend button would 404 and the picker PATCH would silently no-op.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YNyzbE8jweH5FLjTMJt1kY