### PR TITLE
Realtime: thin band-scoped change broadcasts

### DIFF
--- a/app/Events/BandDataChanged.php
+++ b/app/Events/BandDataChanged.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace App\Events;
+
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Broadcasting\PrivateChannel;
+use Illuminate\Contracts\Broadcasting\ShouldBroadcast;
+use Illuminate\Contracts\Events\ShouldDispatchAfterCommit;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+/**
+ * Thin band-scoped change signal: tells subscribed band members that a model
+ * changed so they can refetch through the API. Carries no model data — the
+ * API layer stays the single permission-enforcing serializer.
+ *
+ * Queued (ShouldBroadcast, via Horizon) so broadcasting can never slow the
+ * originating write; dispatched after commit so a client refetch can't read
+ * pre-transaction state.
+ */
+class BandDataChanged implements ShouldBroadcast, ShouldDispatchAfterCommit
+{
+    use Dispatchable, InteractsWithSockets, SerializesModels;
+
+    public function __construct(
+        public int $bandId,
+        public string $model,
+        public int $id,
+        public string $action,
+        public ?array $parent = null,
+    ) {}
+
+    public function broadcastOn(): array
+    {
+        return [new PrivateChannel('band.' . $this->bandId)];
+    }
+
+    public function broadcastAs(): string
+    {
+        return 'band.data-changed';
+    }
+
+    public function broadcastWith(): array
+    {
+        $payload = [
+            'model'  => $this->model,
+            'id'     => $this->id,
+            'action' => $this->action,
+        ];
+        if ($this->parent !== null) {
+            $payload['parent'] = $this->parent;
+        }
+
+        return $payload;
+    }
+}

--- a/app/Models/Bookings.php
+++ b/app/Models/Bookings.php
@@ -11,6 +11,7 @@ use App\Formatters\CalendarEventFormatter;
 use App\Http\Traits\BookingTraits;
 use App\Models\Interfaces\Contractable;
 use App\Models\Interfaces\GoogleCalenderable;
+use App\Models\Traits\BroadcastsBandChanges;
 use App\Models\Traits\GoogleCalendarWritable;
 use App\Services\CalendarService;
 use Carbon\Carbon;
@@ -28,6 +29,7 @@ class Bookings extends Model implements Contractable, GoogleCalenderable
     use Searchable;
     use GoogleCalendarWritable;
     use LogsActivity;
+    use BroadcastsBandChanges;
 
     protected $fillable = [
         'band_id',

--- a/app/Models/EventMember.php
+++ b/app/Models/EventMember.php
@@ -2,13 +2,21 @@
 
 namespace App\Models;
 
+use App\Models\Traits\BroadcastsBandChanges;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
 
 class EventMember extends Model
 {
-    use HasFactory, SoftDeletes;
+    use HasFactory, SoftDeletes, BroadcastsBandChanges;
+
+    protected function broadcastParent(): ?array
+    {
+        return $this->event_id
+            ? ['model' => 'events', 'id' => (int) $this->event_id]
+            : null;
+    }
 
     protected static function booted(): void
     {

--- a/app/Models/Events.php
+++ b/app/Models/Events.php
@@ -11,12 +11,20 @@ use App\Models\Interfaces\GoogleCalenderable;
 use App\Models\Traits\GoogleCalendarWritable;
 use Illuminate\Database\Eloquent\Relations\MorphTo;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
+use App\Models\Traits\BroadcastsBandChanges;
 use Spatie\Activitylog\Traits\LogsActivity;
 use Spatie\Activitylog\LogOptions;
 
 class Events extends Model implements GoogleCalenderable
 {
-    use HasFactory, GoogleCalendarWritable, LogsActivity;
+    use HasFactory, GoogleCalendarWritable, LogsActivity, BroadcastsBandChanges;
+
+    protected function broadcastBandId(): ?int
+    {
+        $bandId = $this->eventable?->band_id;
+
+        return $bandId ? (int) $bandId : null;
+    }
 
     protected static function booted()
     {

--- a/app/Models/Rehearsal.php
+++ b/app/Models/Rehearsal.php
@@ -5,6 +5,7 @@ namespace App\Models;
 use App\Formatters\CalendarEventFormatter;
 use App\Models\Interfaces\GoogleCalenderable;
 use App\Models\Traits\GoogleCalendarWritable;
+use App\Models\Traits\BroadcastsBandChanges;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
@@ -17,7 +18,7 @@ use Spatie\Activitylog\LogOptions;
 
 class Rehearsal extends Model implements GoogleCalenderable
 {
-    use HasFactory, SoftDeletes, GoogleCalendarWritable, LogsActivity;
+    use HasFactory, SoftDeletes, GoogleCalendarWritable, LogsActivity, BroadcastsBandChanges;
 
     protected $fillable = [
         'rehearsal_schedule_id',

--- a/app/Models/Roster.php
+++ b/app/Models/Roster.php
@@ -2,13 +2,14 @@
 
 namespace App\Models;
 
+use App\Models\Traits\BroadcastsBandChanges;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
 
 class Roster extends Model
 {
-    use HasFactory, SoftDeletes;
+    use HasFactory, SoftDeletes, BroadcastsBandChanges;
 
     protected $fillable = [
         'band_id',

--- a/app/Models/Traits/BroadcastsBandChanges.php
+++ b/app/Models/Traits/BroadcastsBandChanges.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace App\Models\Traits;
+
+use App\Events\BandDataChanged;
+use Illuminate\Support\Str;
+
+/**
+ * Opt-in realtime signal: any created/updated/deleted on the model dispatches
+ * a thin BandDataChanged broadcast to the model's band channel.
+ *
+ * Models whose band is reached indirectly override broadcastBandId(); child
+ * models whose client-side listing is keyed by a parent (comments, event
+ * members) override broadcastParent().
+ *
+ * Wire model name is Str::snake(class_basename()) — keep the mobile registry
+ * in lib/shared/providers/band_realtime_provider.dart in sync when adding
+ * models.
+ */
+trait BroadcastsBandChanges
+{
+    public static function bootBroadcastsBandChanges(): void
+    {
+        static::created(fn ($model) => $model->broadcastBandChange('created'));
+        static::updated(fn ($model) => $model->broadcastBandChange('updated'));
+        static::deleted(fn ($model) => $model->broadcastBandChange('deleted'));
+    }
+
+    protected function broadcastBandChange(string $action): void
+    {
+        try {
+            $bandId = $this->broadcastBandId();
+            if (! $bandId) {
+                return;
+            }
+
+            BandDataChanged::dispatch(
+                (int) $bandId,
+                Str::snake(class_basename($this)),
+                (int) $this->getKey(),
+                $action,
+                $this->broadcastParent(),
+            );
+        } catch (\Throwable $e) {
+            // A realtime signal must never break the write that caused it.
+            report($e);
+        }
+    }
+
+    protected function broadcastBandId(): ?int
+    {
+        return isset($this->band_id) ? (int) $this->band_id : null;
+    }
+
+    /**
+     * @return array{model: string, id: int}|null
+     */
+    protected function broadcastParent(): ?array
+    {
+        return null;
+    }
+}

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -21,6 +21,7 @@
     <server name="DB_CONNECTION" value="mysql"/>
     <server name="MAIL_MAILER" value="log"/>
     <server name="QUEUE_CONNECTION" value="sync"/>
+    <server name="BROADCAST_DRIVER" value="null"/>
     <server name="SESSION_DRIVER" value="array"/>
     <server name="TELESCOPE_ENABLED" value="false"/>
     <server name="SCOUT_DRIVER" value="collection"/>

--- a/routes/channels.php
+++ b/routes/channels.php
@@ -33,3 +33,11 @@ Broadcast::channel('rehearsal-planner.{sessionId}', function ($user, $sessionId)
     }
     return $user->canRead('rehearsals', $session->band_id);
 });
+
+// Generic band data channel: thin BandDataChanged invalidation signals.
+// Same audience idiom as the setlist/planner channels — any user who can
+// read the band's events (owners, members, subs). Signals carry no data;
+// the API enforces per-resource permissions on the refetch.
+Broadcast::channel('band.{bandId}', function ($user, $bandId) {
+    return $user->canRead('events', (int) $bandId);
+});

--- a/routes/channels.php
+++ b/routes/channels.php
@@ -38,6 +38,12 @@ Broadcast::channel('rehearsal-planner.{sessionId}', function ($user, $sessionId)
 // Same audience idiom as the setlist/planner channels — any user who can
 // read the band's events (owners, members, subs). Signals carry no data;
 // the API enforces per-resource permissions on the refetch.
+//
+// Deliberate trade-off (see the mobile repo's realtime spec): one shared
+// channel per band means subs also receive thin signals for models they
+// cannot read (bookings/rehearsal/roster) — existence + numeric id only,
+// never fields. Their refetch is still denied by the API. Splitting into
+// per-ability channels would multiply subscriptions for no data-level gain.
 Broadcast::channel('band.{bandId}', function ($user, $bandId) {
     return $user->canRead('events', (int) $bandId);
 });

--- a/tests/Feature/Broadcasting/BandChannelAuthTest.php
+++ b/tests/Feature/Broadcasting/BandChannelAuthTest.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Tests\Feature\Broadcasting;
+
+use App\Models\Bands;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Broadcast;
+use Tests\TestCase;
+
+class BandChannelAuthTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // The pusher driver signs auth responses locally (no network) — give
+        // it deterministic creds regardless of the surrounding .env.
+        config([
+            'broadcasting.default'                    => 'pusher',
+            'broadcasting.connections.pusher.key'     => 'test-key',
+            'broadcasting.connections.pusher.secret'  => 'test-secret',
+            'broadcasting.connections.pusher.app_id'  => 'test-app',
+        ]);
+
+        // routes/channels.php registers Broadcast::channel(...) callbacks
+        // against whichever driver is default at app-boot time (phpunit.xml
+        // pins BROADCAST_DRIVER=null). BroadcastManager::driver() caches one
+        // instance per driver name, so switching the default above resolves
+        // to a *new*, channel-less "pusher" broadcaster unless we purge the
+        // cache and replay the channel registrations against it.
+        Broadcast::purge();
+        require base_path('routes/channels.php');
+    }
+
+    private function authAgainstChannel(User $user, int $bandId)
+    {
+        $token = $user->createToken('test-device')->plainTextToken;
+
+        return $this->withToken($token)->postJson('/broadcasting/auth', [
+            'socket_id'    => '123.456',
+            'channel_name' => 'private-band.' . $bandId,
+        ]);
+    }
+
+    public function test_band_owner_can_subscribe_to_their_band_channel(): void
+    {
+        $user = User::factory()->create();
+        $band = Bands::factory()->create();
+        $band->owners()->create(['user_id' => $user->id]);
+
+        $response = $this->authAgainstChannel($user, $band->id);
+
+        $response->assertOk();
+        $this->assertIsString($response->json('auth'));
+    }
+
+    public function test_non_member_is_rejected(): void
+    {
+        $user = User::factory()->create();
+        $band = Bands::factory()->create(); // user has no relation to it
+
+        $this->authAgainstChannel($user, $band->id)->assertForbidden();
+    }
+}

--- a/tests/Feature/Broadcasting/BandChannelAuthTest.php
+++ b/tests/Feature/Broadcasting/BandChannelAuthTest.php
@@ -6,6 +6,7 @@ use App\Models\Bands;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Broadcast;
+use Illuminate\Testing\TestResponse;
 use Tests\TestCase;
 
 class BandChannelAuthTest extends TestCase
@@ -35,7 +36,7 @@ class BandChannelAuthTest extends TestCase
         require base_path('routes/channels.php');
     }
 
-    private function authAgainstChannel(User $user, int $bandId)
+    private function authAgainstChannel(User $user, int $bandId): TestResponse
     {
         $token = $user->createToken('test-device')->plainTextToken;
 

--- a/tests/Feature/Broadcasting/BroadcastsBandChangesTest.php
+++ b/tests/Feature/Broadcasting/BroadcastsBandChangesTest.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Tests\Feature\Broadcasting;
+
+use App\Events\BandDataChanged;
+use App\Models\Bands;
+use App\Models\Bookings;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Event;
+use Tests\TestCase;
+
+class BroadcastsBandChangesTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_booking_create_update_delete_each_broadcast_a_band_signal(): void
+    {
+        Event::fake([BandDataChanged::class]);
+        $band = Bands::factory()->create();
+
+        $booking = Bookings::factory()->create(['band_id' => $band->id]);
+        Event::assertDispatched(
+            BandDataChanged::class,
+            fn (BandDataChanged $e) => $e->bandId === $band->id
+                && $e->model === 'bookings'
+                && $e->id === $booking->id
+                && $e->action === 'created'
+                && $e->parent === null,
+        );
+
+        $booking->update(['name' => 'Renamed booking']);
+        Event::assertDispatched(
+            BandDataChanged::class,
+            fn (BandDataChanged $e) => $e->id === $booking->id && $e->action === 'updated',
+        );
+
+        $booking->delete();
+        Event::assertDispatched(
+            BandDataChanged::class,
+            fn (BandDataChanged $e) => $e->id === $booking->id && $e->action === 'deleted',
+        );
+    }
+}

--- a/tests/Feature/Broadcasting/BroadcastsBandChangesTest.php
+++ b/tests/Feature/Broadcasting/BroadcastsBandChangesTest.php
@@ -5,6 +5,11 @@ namespace Tests\Feature\Broadcasting;
 use App\Events\BandDataChanged;
 use App\Models\Bands;
 use App\Models\Bookings;
+use App\Models\EventMember;
+use App\Models\Events;
+use App\Models\EventTypes;
+use App\Models\Rehearsal;
+use App\Models\Roster;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Event;
 use Tests\TestCase;
@@ -38,6 +43,93 @@ class BroadcastsBandChangesTest extends TestCase
         Event::assertDispatched(
             BandDataChanged::class,
             fn (BandDataChanged $e) => $e->id === $booking->id && $e->action === 'deleted',
+        );
+    }
+
+    public function test_event_resolves_band_through_its_eventable(): void
+    {
+        Event::fake([BandDataChanged::class]);
+        $band = Bands::factory()->create();
+        $booking = Bookings::factory()->create(['band_id' => $band->id]);
+        $eventType = EventTypes::factory()->create();
+
+        $event = Events::factory()->create([
+            'eventable_id'   => $booking->id,
+            'eventable_type' => 'App\\Models\\Bookings',
+            'event_type_id'  => $eventType->id,
+        ]);
+
+        Event::assertDispatched(
+            BandDataChanged::class,
+            fn (BandDataChanged $e) => $e->bandId === $band->id
+                && $e->model === 'events'
+                && $e->id === $event->id
+                && $e->action === 'created',
+        );
+    }
+
+    public function test_event_with_unresolvable_eventable_skips_silently(): void
+    {
+        Event::fake([BandDataChanged::class]);
+        $band = Bands::factory()->create();
+        $booking = Bookings::factory()->create(['band_id' => $band->id]);
+        $eventType = EventTypes::factory()->create();
+        $event = Events::factory()->create([
+            'eventable_id'   => $booking->id,
+            'eventable_type' => 'App\\Models\\Bookings',
+            'event_type_id'  => $eventType->id,
+        ]);
+
+        // Orphan the event, then touch it: no band → no signal, and no throw.
+        $booking->deleteQuietly();
+        $event->refresh();
+
+        Event::fake([BandDataChanged::class]); // reset captured events
+        $event->update(['notes' => 'orphaned update']);
+
+        Event::assertNotDispatched(BandDataChanged::class);
+    }
+
+    public function test_event_member_signal_carries_its_event_as_parent(): void
+    {
+        Event::fake([BandDataChanged::class]);
+        $band = Bands::factory()->create();
+        $booking = Bookings::factory()->create(['band_id' => $band->id]);
+        $eventType = EventTypes::factory()->create();
+        $event = Events::factory()->create([
+            'eventable_id'   => $booking->id,
+            'eventable_type' => 'App\\Models\\Bookings',
+            'event_type_id'  => $eventType->id,
+        ]);
+
+        $member = EventMember::factory()->create([
+            'band_id'  => $band->id,
+            'event_id' => $event->id,
+        ]);
+
+        Event::assertDispatched(
+            BandDataChanged::class,
+            fn (BandDataChanged $e) => $e->model === 'event_member'
+                && $e->id === $member->id
+                && $e->parent === ['model' => 'events', 'id' => $event->id],
+        );
+    }
+
+    public function test_rehearsal_and_roster_broadcast_with_their_band_id(): void
+    {
+        Event::fake([BandDataChanged::class]);
+        $band = Bands::factory()->create();
+
+        $rehearsal = Rehearsal::factory()->create(['band_id' => $band->id]);
+        $roster = Roster::factory()->create(['band_id' => $band->id]);
+
+        Event::assertDispatched(
+            BandDataChanged::class,
+            fn (BandDataChanged $e) => $e->model === 'rehearsal' && $e->id === $rehearsal->id && $e->bandId === $band->id,
+        );
+        Event::assertDispatched(
+            BandDataChanged::class,
+            fn (BandDataChanged $e) => $e->model === 'roster' && $e->id === $roster->id && $e->bandId === $band->id,
         );
     }
 }

--- a/tests/Feature/RehearsalPlanner/PlannerControllerTest.php
+++ b/tests/Feature/RehearsalPlanner/PlannerControllerTest.php
@@ -225,7 +225,7 @@ class PlannerControllerTest extends TestCase
             $this->headers($band)
         )->assertStatus(422)->assertJsonValidationErrors('rehearsal_id');
 
-        Queue::assertNothingPushed();
+        Queue::assertNotPushed(RehearsalPlannerTurnJob::class);
     }
 
     public function test_start_rejects_rehearsal_id_from_another_band(): void
@@ -249,6 +249,6 @@ class PlannerControllerTest extends TestCase
             $this->headers($band)
         )->assertStatus(422)->assertJsonValidationErrors('rehearsal_id');
 
-        Queue::assertNothingPushed();
+        Queue::assertNotPushed(RehearsalPlannerTurnJob::class);
     }
 }

--- a/tests/Unit/Events/BandDataChangedTest.php
+++ b/tests/Unit/Events/BandDataChangedTest.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Tests\Unit\Events;
+
+use App\Events\BandDataChanged;
+use Illuminate\Broadcasting\PrivateChannel;
+use PHPUnit\Framework\TestCase;
+
+class BandDataChangedTest extends TestCase
+{
+    public function test_broadcasts_on_the_band_private_channel(): void
+    {
+        $event = new BandDataChanged(42, 'bookings', 7, 'updated');
+
+        $channels = $event->broadcastOn();
+        $this->assertCount(1, $channels);
+        $this->assertInstanceOf(PrivateChannel::class, $channels[0]);
+        $this->assertSame('private-band.42', $channels[0]->name);
+    }
+
+    public function test_broadcast_alias_and_thin_payload(): void
+    {
+        $event = new BandDataChanged(42, 'bookings', 7, 'created');
+
+        $this->assertSame('band.data-changed', $event->broadcastAs());
+        $this->assertSame(
+            ['model' => 'bookings', 'id' => 7, 'action' => 'created'],
+            $event->broadcastWith(),
+        );
+    }
+
+    public function test_payload_includes_parent_when_given(): void
+    {
+        $event = new BandDataChanged(42, 'event_member', 9, 'deleted', ['model' => 'events', 'id' => 3]);
+
+        $this->assertSame(
+            [
+                'model'  => 'event_member',
+                'id'     => 9,
+                'action' => 'deleted',
+                'parent' => ['model' => 'events', 'id' => 3],
+            ],
+            $event->broadcastWith(),
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- `BandDataChanged` queued broadcast event: thin `{model, id, action[, parent]}` signal on `private-band.{bandId}`
- Opt-in `BroadcastsBandChanges` model trait (Bookings, Events, Rehearsal, Roster, EventMember); Events resolves band via its eventable, EventMember signals carry their event as `parent`
- `band.{bandId}` channel auth (same `canRead('events', …)` idiom as existing channels)
- `phpunit.xml` forces `BROADCAST_DRIVER=null` so factory-heavy suites never attempt real broadcasts
- Planner controller tests: queue fakes scoped to planner jobs (models now push BroadcastEvent jobs)

Consumed by tts_bandmate `feat/band-realtime-invalidation` (provider-invalidation registry). Spec lives in the mobile repo: `docs/superpowers/specs/2026-07-06-band-realtime-invalidation-design.md`.

Full suite: 1518 passed; sole failures were the documented CalendarFeedTest parallel flake (8/8 green sequentially).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YNyzbE8jweH5FLjTMJt1kY