### PR TITLE
Realtime (web): live band-scoped updates + payments/payout broadcasts

### DIFF
--- a/app/Http/Controllers/BookingsController.php
+++ b/app/Http/Controllers/BookingsController.php
@@ -228,37 +228,16 @@ class BookingsController extends Controller
         $activityService = new \App\Services\BookingActivityService();
         $recentActivities = $activityService->getBookingTimeline($booking)->take(10);
         
-        // Payout estimate: mirror the Payout page's selection semantics so both
-        // views agree — the booking's stored config (fallback: the band's
-        // active one) over the adjusted total (fallback: summed event values).
-        // Strictly read-only: never save from here (the payout page's cache
-        // save is what fed the realtime reload loop).
+        // Payout estimate: shared read-only semantics (stored config, adjusted
+        // total) so every surface shows the same band cut — see
+        // App\Services\BookingPayoutEstimator.
         $payoutConfig = null;
         $payoutResult = null;
 
         if ($booking->price > 0) {
-            $payout = $booking->payout;
-
-            if ($payout?->payout_config_id) {
-                $payoutConfig = \App\Models\BandPayoutConfig::where('id', $payout->payout_config_id)
-                    ->where('band_id', $band->id)
-                    ->with(['band.paymentGroups.users'])
-                    ->first();
-            }
-
-            if (! $payoutConfig) {
-                $payoutConfig = \App\Models\BandPayoutConfig::where('band_id', $band->id)
-                    ->where('is_active', true)
-                    ->with(['band.paymentGroups.users'])
-                    ->first();
-            }
-
-            if ($payoutConfig) {
-                $amount = ($payout && $payout->adjusted_amount_float > 0)
-                    ? $payout->adjusted_amount_float
-                    : $booking->total_event_value;
-                $payoutResult = $payoutConfig->calculatePayouts($amount, null, $booking);
-            }
+            $estimate = app(\App\Services\BookingPayoutEstimator::class)->estimate($booking, $band->id);
+            $payoutConfig = $estimate['config'];
+            $payoutResult = $estimate['result'];
         }
         
         $questionnaireInstances = $booking->questionnaireInstances()

--- a/app/Http/Controllers/BookingsController.php
+++ b/app/Http/Controllers/BookingsController.php
@@ -228,20 +228,36 @@ class BookingsController extends Controller
         $activityService = new \App\Services\BookingActivityService();
         $recentActivities = $activityService->getBookingTimeline($booking)->take(10);
         
-        // Load active payout configuration and calculate payouts
+        // Payout estimate: mirror the Payout page's selection semantics so both
+        // views agree — the booking's stored config (fallback: the band's
+        // active one) over the adjusted total (fallback: summed event values).
+        // Strictly read-only: never save from here (the payout page's cache
+        // save is what fed the realtime reload loop).
         $payoutConfig = null;
         $payoutResult = null;
 
         if ($booking->price > 0) {
-            $payoutConfig = \App\Models\BandPayoutConfig::where('band_id', $band->id)
-                ->where('is_active', true)
-                ->with(['band.paymentGroups.users'])
-                ->first();
+            $payout = $booking->payout;
+
+            if ($payout?->payout_config_id) {
+                $payoutConfig = \App\Models\BandPayoutConfig::where('id', $payout->payout_config_id)
+                    ->where('band_id', $band->id)
+                    ->with(['band.paymentGroups.users'])
+                    ->first();
+            }
+
+            if (! $payoutConfig) {
+                $payoutConfig = \App\Models\BandPayoutConfig::where('band_id', $band->id)
+                    ->where('is_active', true)
+                    ->with(['band.paymentGroups.users'])
+                    ->first();
+            }
 
             if ($payoutConfig) {
-                // Calculate payouts with attendance data from all events
-                // Use sum of event values instead of booking price
-                $payoutResult = $payoutConfig->calculatePayouts($booking->total_event_value, null, $booking);
+                $amount = ($payout && $payout->adjusted_amount_float > 0)
+                    ? $payout->adjusted_amount_float
+                    : $booking->total_event_value;
+                $payoutResult = $payoutConfig->calculatePayouts($amount, null, $booking);
             }
         }
         

--- a/app/Http/Controllers/EventsController.php
+++ b/app/Http/Controllers/EventsController.php
@@ -208,11 +208,18 @@ class EventsController extends Controller
             ];
         })->sortBy('name')->values();
 
-        // Get user's payout if they're on the roster
+        // Get user's payout if they're on the roster. Compute a FRESH estimate
+        // (shared stored-config/adjusted-total semantics) instead of reading
+        // the payout's calculation_result cache, which only refreshes when
+        // the Payout page renders and goes stale under realtime updates.
         $userPayout = null;
-        if($event->eventable->payout)
+        if ($event->eventable instanceof \App\Models\Bookings && $event->eventable->payout)
         {
-            $userPayout = $event->eventable->payout->getPayoutAmountForUser(Auth::user());
+            $estimate = app(\App\Services\BookingPayoutEstimator::class)
+                ->estimate($event->eventable, (int) $event->eventable->band_id);
+            if ($estimate['result'] !== null) {
+                $userPayout = \App\Models\Payout::amountForUserInResult($estimate['result'], Auth::user());
+            }
         }
 
         // Fall back to event_subs payout for sub users

--- a/app/Http/Middleware/HandleInertiaRequests.php
+++ b/app/Http/Middleware/HandleInertiaRequests.php
@@ -66,6 +66,7 @@ class HandleInertiaRequests extends Middleware
                     'email' => $webUser->email,
                     'navigation' => $webUser->getNav(),
                     'notifications' => $webUser->notifications,
+                    'band_ids' => $webUser->allBands()->pluck('id')->values()->all(),
                 ] : null,
             ],
             'flash' => [

--- a/app/Http/Middleware/VerifyCsrfToken.php
+++ b/app/Http/Middleware/VerifyCsrfToken.php
@@ -16,5 +16,8 @@ class VerifyCsrfToken extends Middleware
         // Apple's social-login callback arrives cross-site via form_post, so it
         // carries no CSRF token and drops the SameSite=lax session cookie.
         'auth/apple/callback',
+        // Broadcasting auth serves both web (session) and mobile (Bearer)
+        // clients under auth:sanctum; token clients carry no CSRF token.
+        'broadcasting/auth',
     ];
 }

--- a/app/Models/BandPayoutConfig.php
+++ b/app/Models/BandPayoutConfig.php
@@ -2,13 +2,14 @@
 
 namespace App\Models;
 
+use App\Models\Traits\BroadcastsBandChanges;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
 class BandPayoutConfig extends Model
 {
-    use HasFactory;
+    use HasFactory, BroadcastsBandChanges;
 
     protected $fillable = [
         'band_id',

--- a/app/Models/ChartUploads.php
+++ b/app/Models/ChartUploads.php
@@ -7,6 +7,8 @@ use Illuminate\Database\Eloquent\Model;
 
 class ChartUploads extends Model
 {
+    use \App\Models\Traits\BroadcastsBandChanges;
+
     protected $guarded = [];
     protected $table = 'chart_uploads';
     use HasFactory;
@@ -14,6 +16,25 @@ class ChartUploads extends Model
     public function type()
     {
         return $this->belongsTo(UploadTypes::class,'upload_type_id');
+    }
+
+    public function chart()
+    {
+        return $this->belongsTo(Charts::class, 'chart_id');
+    }
+
+    protected function broadcastBandId(): ?int
+    {
+        $bandId = $this->chart?->band_id;
+
+        return $bandId ? (int) $bandId : null;
+    }
+
+    protected function broadcastParent(): ?array
+    {
+        return $this->chart_id
+            ? ['model' => 'charts', 'id' => (int) $this->chart_id]
+            : null;
     }
     
 }

--- a/app/Models/Charts.php
+++ b/app/Models/Charts.php
@@ -10,6 +10,7 @@ class Charts extends Model
 {
     protected $guarded = [];
     use HasFactory, Searchable;
+    use \App\Models\Traits\BroadcastsBandChanges;
 
     protected $with = ['uploads'];
 

--- a/app/Models/MediaFile.php
+++ b/app/Models/MediaFile.php
@@ -9,6 +9,8 @@ use Illuminate\Support\Facades\Storage;
 
 class MediaFile extends Model
 {
+    use \App\Models\Traits\BroadcastsBandChanges;
+
     use HasFactory, SoftDeletes;
 
     protected $fillable = [

--- a/app/Models/Payments.php
+++ b/app/Models/Payments.php
@@ -4,6 +4,7 @@ namespace App\Models;
 
 use App\Casts\Price;
 use App\Enums\PaymentType;
+use App\Models\Traits\BroadcastsBandChanges;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\MorphTo;
@@ -14,7 +15,7 @@ use Spatie\Activitylog\LogOptions;
 
 class Payments extends Model
 {
-    use HasFactory, LogsActivity;
+    use HasFactory, LogsActivity, BroadcastsBandChanges;
 
     protected $table = 'payments';
 
@@ -60,6 +61,13 @@ class Payments extends Model
     public function invoice(): BelongsTo
     {
         return $this->belongsTo(Invoices::class, 'invoices_id');
+    }
+
+    protected function broadcastParent(): ?array
+    {
+        return $this->payable_type === \App\Models\Bookings::class
+            ? ['model' => 'bookings', 'id' => (int) $this->payable_id]
+            : null;
     }
 
     /**

--- a/app/Models/Payout.php
+++ b/app/Models/Payout.php
@@ -41,8 +41,12 @@ class Payout extends Model
      *
      * payout_config_id is deliberately NOT ignored: switching a booking's
      * payout configuration is a user mutation other clients must see. The
-     * GET's one-time adoption of the active config emits a single harmless
-     * signal (the next render is clean), never a cycle.
+     * payout-page GET rewrites it every render, but once converged it
+     * reassigns the SAME id (no dirty diff, no signal) — loop safety rests
+     * on that idempotence, not on the write being one-time. A render only
+     * re-broadcasts when the resolved config genuinely changes (first
+     * adoption, or the stored config vanishing and the fallback adopting
+     * the active one) — a single settling signal, never a cycle.
      */
     protected function broadcastIgnoreDirty(): array
     {

--- a/app/Models/Payout.php
+++ b/app/Models/Payout.php
@@ -33,6 +33,18 @@ class Payout extends Model
 
     protected $with = ['adjustments'];
 
+    /**
+     * These are derived caches rewritten by READ paths (the Payout page GET
+     * recomputes and stores calculation_result on every render). Broadcasting
+     * them creates an infinite loop: signal -> client partial reload ->
+     * controller recomputes + saves -> signal. Only user-meaningful payout
+     * changes (amounts, payable) should reach the band channel.
+     */
+    protected function broadcastIgnoreDirty(): array
+    {
+        return ['calculation_result', 'payout_config_id'];
+    }
+
     public function payable(): MorphTo
     {
         return $this->morphTo();

--- a/app/Models/Payout.php
+++ b/app/Models/Payout.php
@@ -34,15 +34,19 @@ class Payout extends Model
     protected $with = ['adjustments'];
 
     /**
-     * These are derived caches rewritten by READ paths (the Payout page GET
-     * recomputes and stores calculation_result on every render). Broadcasting
-     * them creates an infinite loop: signal -> client partial reload ->
-     * controller recomputes + saves -> signal. Only user-meaningful payout
-     * changes (amounts, payable) should reach the band channel.
+     * calculation_result is a derived cache rewritten by READ paths (the
+     * Payout page GET recomputes and stores it on every render). Broadcasting
+     * it creates an infinite loop: signal -> client partial reload ->
+     * controller recomputes + saves -> signal.
+     *
+     * payout_config_id is deliberately NOT ignored: switching a booking's
+     * payout configuration is a user mutation other clients must see. The
+     * GET's one-time adoption of the active config emits a single harmless
+     * signal (the next render is clean), never a cycle.
      */
     protected function broadcastIgnoreDirty(): array
     {
-        return ['calculation_result', 'payout_config_id'];
+        return ['calculation_result'];
     }
 
     public function payable(): MorphTo

--- a/app/Models/Payout.php
+++ b/app/Models/Payout.php
@@ -107,7 +107,16 @@ class Payout extends Model
      */
     public function getPayoutAmountForUser(User $user): float
     {
-        $payouts = collect($this->calculation_result['member_payouts'] ?? []);
+        return static::amountForUserInResult($this->calculation_result, $user);
+    }
+
+    /**
+     * Same matching rules against an arbitrary (e.g. freshly computed)
+     * calculation result, so read surfaces don't depend on the stored cache.
+     */
+    public static function amountForUserInResult(?array $result, User $user): float
+    {
+        $payouts = collect($result['member_payouts'] ?? []);
 
         $match = $payouts->firstWhere('user_id', $user->id)
             ?? $payouts->first(fn($p) => $p['user_id'] === null && ($p['name'] ?? '') === $user->name);

--- a/app/Models/Payout.php
+++ b/app/Models/Payout.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use App\Models\Traits\BroadcastsBandChanges;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -12,7 +13,7 @@ use App\Casts\Price;
 
 class Payout extends Model
 {
-    use HasFactory, SoftDeletes;
+    use HasFactory, SoftDeletes, BroadcastsBandChanges;
 
     protected $fillable = [
         'payable_type',
@@ -50,6 +51,13 @@ class Payout extends Model
     public function adjustments(): HasMany
     {
         return $this->hasMany(PayoutAdjustment::class);
+    }
+
+    protected function broadcastParent(): ?array
+    {
+        return $this->payable_type === \App\Models\Bookings::class
+            ? ['model' => 'bookings', 'id' => (int) $this->payable_id]
+            : null;
     }
 
     /**

--- a/app/Models/PayoutAdjustment.php
+++ b/app/Models/PayoutAdjustment.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use App\Models\Traits\BroadcastsBandChanges;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -10,7 +11,7 @@ use App\Casts\Price;
 
 class PayoutAdjustment extends Model
 {
-    use HasFactory, SoftDeletes;
+    use HasFactory, SoftDeletes, BroadcastsBandChanges;
 
     protected $fillable = [
         'payout_id',
@@ -34,5 +35,19 @@ class PayoutAdjustment extends Model
     public function creator(): BelongsTo
     {
         return $this->belongsTo(User::class, 'created_by');
+    }
+
+    protected function broadcastBandId(): ?int
+    {
+        $bandId = $this->payout?->band_id;
+
+        return $bandId ? (int) $bandId : null;
+    }
+
+    protected function broadcastParent(): ?array
+    {
+        return $this->payout && $this->payout->payable_type === \App\Models\Bookings::class
+            ? ['model' => 'bookings', 'id' => (int) $this->payout->payable_id]
+            : null;
     }
 }

--- a/app/Models/Song.php
+++ b/app/Models/Song.php
@@ -8,6 +8,8 @@ use Laravel\Scout\Searchable;
 
 class Song extends Model
 {
+    use \App\Models\Traits\BroadcastsBandChanges;
+
     use HasFactory, Searchable;
 
     protected $fillable = [

--- a/app/Models/Traits/BroadcastsBandChanges.php
+++ b/app/Models/Traits/BroadcastsBandChanges.php
@@ -29,6 +29,10 @@ trait BroadcastsBandChanges
     protected function broadcastBandChange(string $action): void
     {
         try {
+            if ($action === 'updated' && ! $this->broadcastHasMeaningfulChanges()) {
+                return;
+            }
+
             $bandId = $this->broadcastBandId();
             if (! $bandId) {
                 return;
@@ -45,6 +49,36 @@ trait BroadcastsBandChanges
             // A realtime signal must never break the write that caused it.
             report($e);
         }
+    }
+
+    /**
+     * An `updated` signal is only worth broadcasting when something beyond
+     * timestamps and the model's declared derived-cache attributes changed.
+     *
+     * This is the loop-breaker for read paths with cache-write side effects
+     * (e.g. a GET that recomputes and stores a calculation): without it,
+     * signal -> client partial reload -> controller re-saves cache -> signal
+     * cycles forever.
+     */
+    protected function broadcastHasMeaningfulChanges(): bool
+    {
+        $ignored = array_merge($this->broadcastIgnoreDirty(), [
+            $this->getUpdatedAtColumn() ?? 'updated_at',
+            $this->getCreatedAtColumn() ?? 'created_at',
+        ]);
+
+        return array_diff(array_keys($this->getChanges()), $ignored) !== [];
+    }
+
+    /**
+     * Attributes whose changes never broadcast (derived caches rewritten on
+     * read paths). Override per model.
+     *
+     * @return list<string>
+     */
+    protected function broadcastIgnoreDirty(): array
+    {
+        return [];
     }
 
     protected function broadcastBandId(): ?int

--- a/app/Providers/BroadcastServiceProvider.php
+++ b/app/Providers/BroadcastServiceProvider.php
@@ -14,7 +14,12 @@ class BroadcastServiceProvider extends ServiceProvider
      */
     public function boot()
     {
-        Broadcast::routes(['middleware' => ['web', 'auth']]);
+        // One registration for BOTH clients: the `web` group starts the
+        // session so browser (Echo) requests can authenticate statefully,
+        // while auth:sanctum also accepts the mobile app's Bearer tokens.
+        // CSRF is exempted for this route (VerifyCsrfToken::$except) since
+        // token clients send none. channels.php must NOT re-register routes.
+        Broadcast::routes(['middleware' => ['web', 'auth:sanctum']]);
 
         require base_path('routes/channels.php');
     }

--- a/app/Services/BookingPayoutEstimator.php
+++ b/app/Services/BookingPayoutEstimator.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\BandPayoutConfig;
+use App\Models\Bookings;
+
+/**
+ * Read-only payout estimation with the SAME selection semantics everywhere:
+ * the booking's stored config (fallback: the band's active one) over the
+ * adjusted total (fallback: summed event values).
+ *
+ * Never writes — the Payout page's render-time cache save is what fed the
+ * realtime reload loop; every other surface must estimate without saving.
+ */
+class BookingPayoutEstimator
+{
+    /**
+     * @return array{config: ?BandPayoutConfig, result: ?array}
+     */
+    public function estimate(Bookings $booking, int $bandId): array
+    {
+        $payout = $booking->payout;
+        $config = null;
+
+        if ($payout?->payout_config_id) {
+            $config = BandPayoutConfig::where('id', $payout->payout_config_id)
+                ->where('band_id', $bandId)
+                ->with(['band.paymentGroups.users'])
+                ->first();
+        }
+
+        if (! $config) {
+            $config = BandPayoutConfig::where('band_id', $bandId)
+                ->where('is_active', true)
+                ->with(['band.paymentGroups.users'])
+                ->first();
+        }
+
+        if (! $config) {
+            return ['config' => null, 'result' => null];
+        }
+
+        $amount = ($payout && $payout->adjusted_amount_float > 0)
+            ? $payout->adjusted_amount_float
+            : $booking->total_event_value;
+
+        return ['config' => $config, 'result' => $config->calculatePayouts($amount, null, $booking)];
+    }
+}

--- a/docs/superpowers/plans/2026-07-07-band-realtime-web.md
+++ b/docs/superpowers/plans/2026-07-07-band-realtime-web.md
@@ -1,0 +1,885 @@
+# Band Realtime Web Consumer Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Web pages silently partial-reload their Inertia props when `band.data-changed` signals arrive, and the notifications bell updates live.
+
+**Architecture:** A refcounted Echo channel module (`resources/js/realtime/bandChannel.js`) + a `useBandRealtime` composable that maps wire models → `router.reload({ only })`, opted into per page; `Authenticated.vue` wires an app-wide bell refresher off the new `auth.user.band_ids` shared prop.
+
+**Tech Stack:** Laravel Inertia shared props (backend, one addition), Vue 3 + laravel-echo (window.Echo) + PrimeVue toast, vitest/jsdom.
+
+**Spec:** `docs/superpowers/specs/2026-07-07-band-realtime-web-design.md`
+
+## Global Constraints
+
+- Repo `/home/eddie/github/TTS`, branch `feat/band-realtime-web` (stacked on `feat/band-realtime-broadcasts`). PR base **staging**, opened only AFTER TTS #516 merges.
+- ALL php/artisan commands via `docker compose exec -T app <cmd>`. JS tests run on the HOST: `npx vitest run <path>`; full CI parity: `npm run test:pipeline`.
+- Wire contract (fixed by the backend): event listened as **`.band.data-changed`** (leading dot — `broadcastAs` convention), channel `band.{bandId}` (Echo `private('band.' + id)` → wire `private-band.{id}`), payload `{model, id, action[, parent]}`, models `bookings|events|rehearsal|roster|event_member`.
+- Debounce window: 300 ms. Echo errors: `console.warn` only — never toast from page consumers; the bell toast is the single loud surface.
+- Vue: new files use `<script setup>`/composition style; Options-API pages being touched get a `setup()` block for the composable call — do not rewrite them.
+- Vitest note: never assert on the `<!--v-if-->` comment marker (differs in CI); assert on text/finds.
+
+---
+
+### Task 1: `auth.user.band_ids` shared prop (backend)
+
+**Files:**
+- Modify: `app/Http/Middleware/HandleInertiaRequests.php` (web-user branch of `share()`)
+- Test: `tests/Feature/InertiaSharedBandIdsTest.php` (create)
+
+**Interfaces:**
+- Produces: shared Inertia prop `auth.user.band_ids` — array of ints, deduped, owner+member+sub bands (`$webUser->allBands()->pluck('id')`). Absent for guests and contact-guard users. Consumed by Tasks 4-6 via `usePage().props.auth.user.band_ids`.
+
+- [ ] **Step 1: Write the failing test**
+
+`tests/Feature/InertiaSharedBandIdsTest.php`:
+
+```php
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Bands;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Inertia\Testing\AssertableInertia;
+use Tests\TestCase;
+
+class InertiaSharedBandIdsTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_shared_props_include_all_band_ids_owner_member_and_sub(): void
+    {
+        $user = User::factory()->create();
+        $owned = Bands::factory()->create();
+        $owned->owners()->create(['user_id' => $user->id]);
+        $memberOf = Bands::factory()->create();
+        $memberOf->members()->create(['user_id' => $user->id]);
+
+        $this->actingAs($user)
+            ->get(route('dashboard'))
+            ->assertInertia(fn (AssertableInertia $page) => $page
+                ->where('auth.user.band_ids', fn ($ids) => collect($ids)
+                    ->sort()->values()->all() === collect([$owned->id, $memberOf->id])
+                    ->sort()->values()->all()));
+    }
+}
+```
+
+Caveat check while writing: confirm `route('dashboard')` exists (it's the app's post-login landing route); if named differently, use the Bookings index route — the assertion only needs any Inertia page rendered through the web middleware.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `docker compose exec -T app php artisan test --filter=InertiaSharedBandIdsTest`
+Expected: FAIL — `auth.user.band_ids` missing from the props.
+
+- [ ] **Step 3: Implement**
+
+In `app/Http/Middleware/HandleInertiaRequests.php`, in the **web** user array (the one already containing `id/name/email/navigation/notifications`), add one line:
+
+```php
+                    'band_ids' => $webUser->allBands()->pluck('id')->values()->all(),
+```
+
+(`allBands()` already exists on `User` — owner+member+sub, deduped by id. Do NOT touch the contact-guard branch.)
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `docker compose exec -T app php artisan test --filter=InertiaSharedBandIdsTest`
+Expected: PASS
+
+- [ ] **Step 5: Sanity-sweep pages that render through the middleware**
+
+Run: `docker compose exec -T app php artisan test --filter=BookingLinkTest`
+Expected: PASS (the existing shared-props assertions must be unaffected).
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /home/eddie/github/TTS && git add app/Http/Middleware/HandleInertiaRequests.php tests/Feature/InertiaSharedBandIdsTest.php && git commit -m "feat(realtime-web): share auth.user.band_ids for layout-level channel subscriptions"
+```
+
+### Task 2: `bandChannel` core module (refcounted Echo subscriptions)
+
+**Files:**
+- Create: `resources/js/realtime/bandChannel.js`
+- Create: `resources/js/tests/mocks/echo.js`
+- Test: `resources/js/tests/realtime/bandChannel.test.js`
+
+**Interfaces:**
+- Produces:
+  ```js
+  export function subscribeBandSignals(bandIds, onSignal) // -> unsubscribe()
+  // bandIds: int | int[] (nullish/empty → no-op, returns () => {})
+  // onSignal(payload) per received `.band.data-changed`
+  export const BAND_EVENT = '.band.data-changed'
+  ```
+  Channels are refcounted module-wide: two subscribers to band 7 share one Echo channel; `Echo.leave` fires only when the last unsubscribes. Task 3's composable and Task 4's bell both consume this.
+
+- [ ] **Step 1: Write the Echo mock**
+
+`resources/js/tests/mocks/echo.js`:
+
+```js
+// Minimal window.Echo stand-in: records private()/leave() calls and lets
+// tests fire events into registered listeners.
+export function installEchoMock() {
+	const channels = new Map(); // name -> { listeners: Map(event -> [cb]) }
+
+	const echo = {
+		privateCalls: [],
+		leaveCalls: [],
+		private(name) {
+			this.privateCalls.push(name);
+			if (!channels.has(name)) channels.set(name, { listeners: new Map() });
+			const entry = channels.get(name);
+			const channel = {
+				listen(event, cb) {
+					if (!entry.listeners.has(event)) entry.listeners.set(event, []);
+					entry.listeners.get(event).push(cb);
+					return channel;
+				},
+				subscribed() { return channel; },
+				error() { return channel; },
+			};
+			return channel;
+		},
+		leave(name) {
+			this.leaveCalls.push(name);
+			channels.delete(name);
+		},
+		fire(name, event, payload) {
+			const entry = channels.get(name);
+			(entry?.listeners.get(event) ?? []).forEach((cb) => cb(payload));
+		},
+	};
+
+	window.Echo = echo;
+	return echo;
+}
+```
+
+- [ ] **Step 2: Write the failing tests**
+
+`resources/js/tests/realtime/bandChannel.test.js`:
+
+```js
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { installEchoMock } from '../mocks/echo';
+import { subscribeBandSignals, BAND_EVENT } from '../../realtime/bandChannel';
+
+describe('subscribeBandSignals', () => {
+	let echo;
+	beforeEach(() => {
+		echo = installEchoMock();
+	});
+
+	it('subscribes each band channel and delivers signals', () => {
+		const seen = [];
+		subscribeBandSignals([1, 2], (p) => seen.push(p));
+
+		expect(echo.privateCalls).toEqual(['band.1', 'band.2']);
+		echo.fire('band.1', BAND_EVENT, { model: 'bookings', id: 5, action: 'updated' });
+		expect(seen).toEqual([{ model: 'bookings', id: 5, action: 'updated' }]);
+	});
+
+	it('accepts a single band id and no-ops on empty input', () => {
+		subscribeBandSignals(7, () => {});
+		expect(echo.privateCalls).toEqual(['band.7']);
+
+		const off = subscribeBandSignals([], () => {});
+		expect(typeof off).toBe('function');
+		off(); // must not throw
+	});
+
+	it('refcounts: overlapping subscribers share a channel; leave only at zero', () => {
+		const offA = subscribeBandSignals(1, () => {});
+		const offB = subscribeBandSignals(1, () => {});
+		expect(echo.privateCalls).toEqual(['band.1']); // one Echo subscription
+
+		offA();
+		expect(echo.leaveCalls).toEqual([]); // B still listening
+
+		offB();
+		expect(echo.leaveCalls).toEqual(['band.1']);
+	});
+
+	it('a resubscribe during overlap (Inertia page transition) keeps the channel live', () => {
+		const offOldPage = subscribeBandSignals(1, () => {});
+		const seen = [];
+		subscribeBandSignals(1, (p) => seen.push(p)); // new page subscribes first
+		offOldPage(); // old page unmounts after
+
+		echo.fire('band.1', BAND_EVENT, { model: 'events', id: 9, action: 'created' });
+		expect(echo.leaveCalls).toEqual([]);
+		expect(seen).toHaveLength(1);
+	});
+
+	it('unsubscribe stops delivery to that subscriber only', () => {
+		const a = [];
+		const b = [];
+		const offA = subscribeBandSignals(1, (p) => a.push(p));
+		subscribeBandSignals(1, (p) => b.push(p));
+		offA();
+
+		echo.fire('band.1', BAND_EVENT, { model: 'roster', id: 3, action: 'deleted' });
+		expect(a).toHaveLength(0);
+		expect(b).toHaveLength(1);
+	});
+
+	it('is a no-op without window.Echo', () => {
+		delete window.Echo;
+		const off = subscribeBandSignals([1], () => {});
+		off(); // must not throw
+	});
+});
+```
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+Run: `npx vitest run resources/js/tests/realtime/bandChannel.test.js`
+Expected: FAIL — module does not exist.
+
+- [ ] **Step 4: Implement the module**
+
+`resources/js/realtime/bandChannel.js`:
+
+```js
+// Refcounted subscriptions to the thin band-data-changed broadcast.
+//
+// Every consumer (page composable, layout bell) goes through here so that
+// overlapping lifecycles — an Inertia page transition where the incoming
+// page subscribes to band N before the outgoing page unmounts — can never
+// Echo.leave() a channel someone still listens to.
+
+export const BAND_EVENT = '.band.data-changed';
+
+// bandId -> { count, handlers: Set<fn> }
+const channels = new Map();
+
+function channelName(bandId) {
+	return `band.${bandId}`;
+}
+
+function ensureChannel(bandId) {
+	let entry = channels.get(bandId);
+	if (entry) return entry;
+
+	entry = { count: 0, handlers: new Set() };
+	channels.set(bandId, entry);
+
+	window.Echo.private(channelName(bandId))
+		.subscribed(() => {})
+		.error((err) => {
+			console.warn(`[bandChannel] auth/subscribe error on ${channelName(bandId)}`, err);
+		})
+		.listen(BAND_EVENT, (payload) => {
+			entry.handlers.forEach((fn) => fn(payload));
+		});
+
+	return entry;
+}
+
+/**
+ * Subscribe onSignal to one or more band channels.
+ * Returns an unsubscribe function (idempotent).
+ */
+export function subscribeBandSignals(bandIds, onSignal) {
+	const ids = (Array.isArray(bandIds) ? bandIds : [bandIds]).filter(
+		(id) => id !== null && id !== undefined,
+	);
+	if (!ids.length || !window.Echo) return () => {};
+
+	const entries = ids.map((id) => {
+		const entry = ensureChannel(id);
+		entry.count += 1;
+		entry.handlers.add(onSignal);
+		return { id, entry };
+	});
+
+	let done = false;
+	return () => {
+		if (done) return;
+		done = true;
+		entries.forEach(({ id, entry }) => {
+			entry.handlers.delete(onSignal);
+			entry.count -= 1;
+			if (entry.count <= 0) {
+				channels.delete(id);
+				window.Echo?.leave(channelName(id));
+			}
+		});
+	};
+}
+```
+
+Note the deliberate handler-set semantics: one `onSignal` function per subscriber; `handlers.delete(onSignal)` on unsubscribe removes only that subscriber. (Same function object subscribed twice for the same band would collapse — consumers always pass fresh closures, and the tests pin the behaviors that matter.)
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `npx vitest run resources/js/tests/realtime/bandChannel.test.js`
+Expected: PASS (6 tests)
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /home/eddie/github/TTS && git add resources/js/realtime/bandChannel.js resources/js/tests/mocks/echo.js resources/js/tests/realtime/bandChannel.test.js && git commit -m "feat(realtime-web): refcounted band channel subscription module"
+```
+
+### Task 3: `useBandRealtime` composable (debounce → partial reload)
+
+**Files:**
+- Create: `resources/js/composables/useBandRealtime.js`
+- Test: `resources/js/tests/composables/useBandRealtime.test.js`
+
+**Interfaces:**
+- Consumes: `subscribeBandSignals`, `BAND_EVENT` (Task 2); `router` from `@inertiajs/vue3`.
+- Produces:
+  ```js
+  useBandRealtime(bandIdOrIds, reloadMap = {}, options = {})
+  // reloadMap entry:  model: ['prop', ...]
+  //               or  model: { props: ['prop'], when: (payload) => bool }
+  // options.onSignal(payload): called (undebounced) for every signal —
+  //   non-reload consumers. Reload behavior: matching signals are coalesced
+  //   for 300ms, then ONE router.reload({ only: [union of props] }).
+  ```
+  Must be called during component setup (uses onMounted/onBeforeUnmount). Tasks 5-6 call this from pages; Task 4's bell uses subscribeBandSignals directly (Options-API layout).
+
+- [ ] **Step 1: Write the failing tests**
+
+`resources/js/tests/composables/useBandRealtime.test.js`:
+
+```js
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { defineComponent, h } from 'vue';
+import { mount } from '@vue/test-utils';
+import { installEchoMock } from '../mocks/echo';
+import { BAND_EVENT } from '../../realtime/bandChannel';
+import { useBandRealtime } from '../../composables/useBandRealtime';
+
+vi.mock('@inertiajs/vue3', () => ({
+	router: { reload: vi.fn() },
+}));
+import { router } from '@inertiajs/vue3';
+
+function mountWith(bandIds, reloadMap, options) {
+	const Host = defineComponent({
+		setup() {
+			useBandRealtime(bandIds, reloadMap, options);
+			return () => h('div');
+		},
+	});
+	return mount(Host);
+}
+
+describe('useBandRealtime', () => {
+	let echo;
+	beforeEach(() => {
+		vi.useFakeTimers();
+		echo = installEchoMock();
+		router.reload.mockClear();
+	});
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it('coalesces a burst into one partial reload with the union of props', () => {
+		mountWith(1, { bookings: ['bookings'], events: ['events'] });
+
+		echo.fire('band.1', BAND_EVENT, { model: 'bookings', id: 1, action: 'updated' });
+		echo.fire('band.1', BAND_EVENT, { model: 'bookings', id: 2, action: 'updated' });
+		echo.fire('band.1', BAND_EVENT, { model: 'events', id: 3, action: 'created' });
+		expect(router.reload).not.toHaveBeenCalled();
+
+		vi.advanceTimersByTime(300);
+		expect(router.reload).toHaveBeenCalledTimes(1);
+		const only = router.reload.mock.calls[0][0].only;
+		expect([...only].sort()).toEqual(['bookings', 'events']);
+	});
+
+	it('ignores models missing from the map', () => {
+		mountWith(1, { bookings: ['bookings'] });
+		echo.fire('band.1', BAND_EVENT, { model: 'roster', id: 1, action: 'updated' });
+		vi.advanceTimersByTime(300);
+		expect(router.reload).not.toHaveBeenCalled();
+	});
+
+	it('honors a when() predicate (detail pages)', () => {
+		mountWith(1, {
+			bookings: { props: ['booking'], when: (p) => p.id === 42 },
+		});
+
+		echo.fire('band.1', BAND_EVENT, { model: 'bookings', id: 7, action: 'updated' });
+		vi.advanceTimersByTime(300);
+		expect(router.reload).not.toHaveBeenCalled();
+
+		echo.fire('band.1', BAND_EVENT, { model: 'bookings', id: 42, action: 'updated' });
+		vi.advanceTimersByTime(300);
+		expect(router.reload).toHaveBeenCalledTimes(1);
+		expect(router.reload.mock.calls[0][0].only).toEqual(['booking']);
+	});
+
+	it('calls options.onSignal for every signal, undebounced', () => {
+		const onSignal = vi.fn();
+		mountWith(1, {}, { onSignal });
+		echo.fire('band.1', BAND_EVENT, { model: 'event_member', id: 1, action: 'created' });
+		echo.fire('band.1', BAND_EVENT, { model: 'rehearsal', id: 2, action: 'deleted' });
+		expect(onSignal).toHaveBeenCalledTimes(2);
+	});
+
+	it('unsubscribes and cancels pending reloads on unmount', () => {
+		const wrapper = mountWith(1, { bookings: ['bookings'] });
+		echo.fire('band.1', BAND_EVENT, { model: 'bookings', id: 1, action: 'updated' });
+		wrapper.unmount();
+
+		vi.advanceTimersByTime(300);
+		expect(router.reload).not.toHaveBeenCalled();
+		expect(echo.leaveCalls).toEqual(['band.1']);
+	});
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npx vitest run resources/js/tests/composables/useBandRealtime.test.js`
+Expected: FAIL — composable does not exist.
+
+- [ ] **Step 3: Implement**
+
+`resources/js/composables/useBandRealtime.js`:
+
+```js
+import { onBeforeUnmount, onMounted } from 'vue';
+import { router } from '@inertiajs/vue3';
+import { subscribeBandSignals } from '../realtime/bandChannel';
+
+const DEBOUNCE_MS = 300;
+
+function normalize(entry) {
+	return Array.isArray(entry) ? { props: entry, when: null } : entry;
+}
+
+/**
+ * Page-level opt-in to band realtime signals: maps wire models to the
+ * Inertia props to partial-reload. Signals arriving within the debounce
+ * window coalesce into one router.reload with the union of their props.
+ *
+ * useBandRealtime(band.id, { bookings: ['bookings'] })
+ * useBandRealtime(band.id, { bookings: { props: ['booking'], when: p => p.id === booking.id } })
+ */
+export function useBandRealtime(bandIdOrIds, reloadMap = {}, options = {}) {
+	let unsubscribe = null;
+	let timer = null;
+	const pendingProps = new Set();
+
+	function flush() {
+		timer = null;
+		const only = [...pendingProps];
+		pendingProps.clear();
+		if (only.length) router.reload({ only });
+	}
+
+	function onSignal(payload) {
+		options.onSignal?.(payload);
+
+		const entry = reloadMap[payload.model];
+		if (!entry) return;
+		const { props, when } = normalize(entry);
+		if (when && !when(payload)) return;
+
+		props.forEach((p) => pendingProps.add(p));
+		if (!timer) timer = setTimeout(flush, DEBOUNCE_MS);
+	}
+
+	onMounted(() => {
+		unsubscribe = subscribeBandSignals(bandIdOrIds, onSignal);
+	});
+
+	onBeforeUnmount(() => {
+		unsubscribe?.();
+		if (timer) clearTimeout(timer);
+		pendingProps.clear();
+	});
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npx vitest run resources/js/tests/composables/useBandRealtime.test.js resources/js/tests/realtime/bandChannel.test.js`
+Expected: PASS (11 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /home/eddie/github/TTS && git add resources/js/composables/useBandRealtime.js resources/js/tests/composables/useBandRealtime.test.js && git commit -m "feat(realtime-web): useBandRealtime composable — debounced signal-to-partial-reload mapping"
+```
+
+### Task 4: Live notifications bell
+
+**Files:**
+- Create: `resources/js/realtime/bellRefresher.js`
+- Modify: `resources/js/Layouts/Authenticated.vue` (`mounted`/`beforeUnmount`/`methods` — Options API, do not restructure)
+- Test: `resources/js/tests/realtime/bellRefresher.test.js`
+
+**Interfaces:**
+- Consumes: `subscribeBandSignals` (Task 2), `auth.user.band_ids` (Task 1).
+- Produces: `createBellRefresher({ reloadAuth, getUnseenCount, getLatest, toast })` → `{ onSignal, dispose }`. The layout wires: `subscribeBandSignals(band_ids, refresher.onSignal)`.
+
+- [ ] **Step 1: Write the failing tests**
+
+`resources/js/tests/realtime/bellRefresher.test.js`:
+
+```js
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { createBellRefresher } from '../../realtime/bellRefresher';
+
+describe('createBellRefresher', () => {
+	beforeEach(() => vi.useFakeTimers());
+	afterEach(() => vi.useRealTimers());
+
+	function make(counts) {
+		let call = 0;
+		const toast = vi.fn();
+		const reloadAuth = vi.fn((opts) => opts.onSuccess?.());
+		const refresher = createBellRefresher({
+			reloadAuth,
+			getUnseenCount: () => counts[Math.min(call++, counts.length - 1)],
+			getLatest: () => ({ data: { text: 'Booking updated' } }),
+			toast,
+		});
+		return { refresher, toast, reloadAuth };
+	}
+
+	it('debounces signals into one auth reload', () => {
+		const { refresher, reloadAuth } = make([0, 0]);
+		refresher.onSignal();
+		refresher.onSignal();
+		refresher.onSignal();
+		expect(reloadAuth).not.toHaveBeenCalled();
+
+		vi.advanceTimersByTime(300);
+		expect(reloadAuth).toHaveBeenCalledTimes(1);
+		expect(reloadAuth.mock.calls[0][0].only).toEqual(['auth']);
+	});
+
+	it('toasts when the unseen count increases across the reload', () => {
+		// count read before reload: 1; after reload: 2
+		const { refresher, toast } = make([1, 2]);
+		refresher.onSignal();
+		vi.advanceTimersByTime(300);
+		expect(toast).toHaveBeenCalledTimes(1);
+		expect(toast.mock.calls[0][0].detail).toBe('Booking updated');
+	});
+
+	it('stays silent when the count does not increase', () => {
+		const { refresher, toast } = make([2, 2]);
+		refresher.onSignal();
+		vi.advanceTimersByTime(300);
+		expect(toast).not.toHaveBeenCalled();
+	});
+
+	it('dispose cancels a pending refresh', () => {
+		const { refresher, reloadAuth } = make([0, 0]);
+		refresher.onSignal();
+		refresher.dispose();
+		vi.advanceTimersByTime(300);
+		expect(reloadAuth).not.toHaveBeenCalled();
+	});
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npx vitest run resources/js/tests/realtime/bellRefresher.test.js`
+Expected: FAIL — module does not exist.
+
+- [ ] **Step 3: Implement the refresher**
+
+`resources/js/realtime/bellRefresher.js`:
+
+```js
+const DEBOUNCE_MS = 300;
+
+/**
+ * Turns band signals into a live notifications bell: debounced reload of
+ * the shared `auth` prop (which carries auth.user.notifications), and a
+ * toast when the unseen count grew — the one loud surface of realtime.
+ *
+ * All effects are injected so the layout stays glue and this stays testable:
+ *   reloadAuth({ only: ['auth'], onSuccess })  — Inertia partial reload
+ *   getUnseenCount()                           — current unseen count
+ *   getLatest()                                — newest notification object
+ *   toast(options)                             — PrimeVue toast add()
+ */
+export function createBellRefresher({ reloadAuth, getUnseenCount, getLatest, toast }) {
+	let timer = null;
+	let disposed = false;
+
+	function refresh() {
+		timer = null;
+		const before = getUnseenCount();
+		reloadAuth({
+			only: ['auth'],
+			onSuccess: () => {
+				if (disposed) return;
+				const after = getUnseenCount();
+				if (after > before) {
+					const latest = getLatest();
+					toast({
+						severity: 'info',
+						summary: 'New notification',
+						detail: latest?.data?.text || 'Something changed in your band.',
+						life: 6000,
+					});
+				}
+			},
+		});
+	}
+
+	return {
+		onSignal() {
+			if (disposed) return;
+			if (!timer) timer = setTimeout(refresh, DEBOUNCE_MS);
+		},
+		dispose() {
+			disposed = true;
+			if (timer) clearTimeout(timer);
+			timer = null;
+		},
+	};
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npx vitest run resources/js/tests/realtime/bellRefresher.test.js`
+Expected: PASS (4 tests)
+
+- [ ] **Step 5: Wire the layout**
+
+In `resources/js/Layouts/Authenticated.vue` (Options API — keep style):
+
+Imports (script block top):
+
+```js
+import { router } from '@inertiajs/vue3';
+import { subscribeBandSignals } from '@/realtime/bandChannel';
+import { createBellRefresher } from '@/realtime/bellRefresher';
+```
+
+In `mounted()` after the existing `this.subscribeToUserChannel();`:
+
+```js
+        this.subscribeToBandSignals();
+```
+
+In `beforeUnmount()` (alongside the existing user-channel leave):
+
+```js
+        this._bandUnsubscribe?.();
+        this._bellRefresher?.dispose();
+```
+
+New method in `methods` (next to `subscribeToUserChannel`):
+
+```js
+        subscribeToBandSignals() {
+            const bandIds = this.$page.props.auth?.user?.band_ids;
+            if (!bandIds?.length || !window.Echo) return;
+
+            this._bellRefresher = createBellRefresher({
+                reloadAuth: (opts) => router.reload(opts),
+                getUnseenCount: () => this.unseenNotifications,
+                getLatest: () => this.notifications?.[0],
+                toast: (opts) => this.$toast?.add(opts),
+            });
+            this._bandUnsubscribe = subscribeBandSignals(bandIds, this._bellRefresher.onSignal);
+        },
+```
+
+One wrinkle to handle while wiring: after `router.reload({ only: ['auth'] })` succeeds, the Vuex store must re-sync from the fresh page props — call `this.fetchNotifications()` inside `reloadAuth`'s `onSuccess` chain. Cleanest: wrap it —
+
+```js
+                reloadAuth: (opts) => router.reload({
+                    ...opts,
+                    onSuccess: () => {
+                        this.fetchNotifications();
+                        opts.onSuccess?.();
+                    },
+                }),
+```
+
+(`fetchNotifications` is already mapped via `mapActions("user", …)` in this component and reads `usePage().props.auth.user.notifications` — the exact prop the partial reload refreshes. Order matters: re-sync the store BEFORE the refresher's own `onSuccess` reads `getUnseenCount()`.)
+
+- [ ] **Step 6: Full JS suite + manual smoke**
+
+Run: `npm run test:pipeline`
+Expected: all green (existing suite + 15 new tests).
+
+- [ ] **Step 7: Commit**
+
+```bash
+cd /home/eddie/github/TTS && git add resources/js/realtime/bellRefresher.js resources/js/tests/realtime/bellRefresher.test.js resources/js/Layouts/Authenticated.vue && git commit -m "feat(realtime-web): live notifications bell — band signals refresh badge and toast new items"
+```
+
+### Task 5: Page opt-ins — bookings pages
+
+**Files (modify only; one import + one composable call each):**
+- `resources/js/Pages/Bookings/Index.vue` (Options API — add `setup()`)
+- `resources/js/Pages/Bookings/Show.vue`
+- `resources/js/Pages/Bookings/Contacts.vue`
+- `resources/js/Pages/Bookings/Finances.vue`
+- `resources/js/Pages/Bookings/Contract.vue`
+- `resources/js/Pages/Bookings/Events.vue`
+- `resources/js/Pages/Bookings/Lineup.vue`
+- `resources/js/Pages/Bookings/Media.vue`
+- `resources/js/Pages/Bookings/Payout.vue`
+- `resources/js/Pages/Bookings/History.vue`
+
+**Interfaces:**
+- Consumes: `useBandRealtime` (Task 3), `auth.user.band_ids` (Task 1), each page's existing props.
+
+- [ ] **Step 1: Bookings/Index.vue (Options API, multi-band)**
+
+Add to its script imports:
+
+```js
+import { usePage } from '@inertiajs/vue3';
+import { useBandRealtime } from '@/composables/useBandRealtime';
+```
+
+Add a `setup()` entry to the existing `export default {` object (before `props`):
+
+```js
+    setup() {
+        useBandRealtime(usePage().props.auth?.user?.band_ids ?? [], {
+            bookings: ['bookings'],
+        });
+    },
+```
+
+- [ ] **Step 2: Bookings/Show.vue (`<script setup>`)**
+
+After the existing `defineProps` (which provides `booking`, `band`, `recentActivities`, …):
+
+```js
+import { useBandRealtime } from '@/composables/useBandRealtime';
+
+useBandRealtime(props.band.id, {
+    bookings: { props: ['booking', 'recentActivities'], when: (p) => p.id === props.booking.id },
+    events: ['events'],
+    event_member: ['events'],
+});
+```
+
+(If the file destructures `defineProps` without assigning to `props`, assign it: `const props = defineProps({...})` — check each file and keep its style otherwise.)
+
+- [ ] **Step 3: The eight sub-pages — same one-liner shape, page-specific maps**
+
+Each `<script setup>` page gets the same import plus one call. Exact maps:
+
+| File | call |
+|---|---|
+| Contacts.vue | `useBandRealtime(props.band.id, { bookings: { props: ['booking'], when: (p) => p.id === props.booking.id } })` |
+| Finances.vue | `useBandRealtime(props.band.id, { bookings: { props: ['booking', 'payments'], when: (p) => p.id === props.booking.id } })` |
+| Contract.vue | `useBandRealtime(props.band.id, { bookings: { props: ['booking'], when: (p) => p.id === props.booking.id } })` |
+| Events.vue | `useBandRealtime(props.booking.band_id, { bookings: { props: ['booking'], when: (p) => p.id === props.booking.id }, events: ['events'], event_member: ['events'] })` |
+| Lineup.vue | `useBandRealtime(props.band.id, { bookings: { props: ['booking'], when: (p) => p.id === props.booking.id }, events: ['events'], event_member: ['events'] })` |
+| Media.vue | `useBandRealtime(props.band.id, { bookings: { props: ['booking'], when: (p) => p.id === props.booking.id } })` |
+| Payout.vue | `useBandRealtime(props.band.id, { bookings: { props: ['booking', 'payoutResult', 'adjustedTotal'], when: (p) => p.id === props.booking.id }, events: ['events', 'payoutResult', 'adjustedTotal'], event_member: ['events', 'payoutResult', 'adjustedTotal'] })` |
+| History.vue | `useBandRealtime(props.booking.band_id, { bookings: { props: ['booking'], when: (p) => p.id === props.booking.id } })` |
+
+Per-file verification while editing: confirm the exact band-id source prop (`props.band.id` vs `props.booking.band_id` — the table above matches the current controllers; if a page lacks the named prop, use the other) and that every prop named in the map appears in that page's `defineProps`/`props`. Drop any prop the page doesn't receive. If a page is Options API (History/Lineup were unverified), use the Bookings/Index `setup()` shape instead.
+
+- [ ] **Step 4: Analyze + suite**
+
+Run: `npx vitest run resources/js/tests/ && npm run build 2>&1 | tail -5`
+Expected: tests green; `vite build` completes (catches bad imports/syntax across the touched pages).
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /home/eddie/github/TTS && git add resources/js/Pages/Bookings && git commit -m "feat(realtime-web): bookings pages live-reload on band signals"
+```
+
+### Task 6: Page opt-ins — dashboard, events, rehearsals, rosters, payout flow
+
+**Files (modify):**
+- `resources/js/Pages/Dashboard.vue`
+- `resources/js/Pages/Events/Index.vue` (Options API — `setup()`)
+- `resources/js/Pages/Events/Show.vue`
+- `resources/js/Pages/Band/Rosters/Index.vue` (Options API — `setup()`)
+- `resources/js/Pages/Finances/PayoutFlowEditor.vue`
+- `resources/js/Pages/Rehearsals/Index.vue`
+- `resources/js/Pages/Rehearsals/ScheduleDetail.vue`
+- `resources/js/Pages/Rehearsals/RehearsalDetail.vue`
+
+**Interfaces:** same as Task 5.
+
+- [ ] **Step 1: Apply the calls**
+
+| File | call |
+|---|---|
+| Dashboard.vue (`<script setup>`) | `useBandRealtime(usePage().props.auth?.user?.band_ids ?? [], { events: ['events'], event_member: ['events'], roster: ['events'], bookings: ['stats'] })` |
+| Events/Index.vue (Options) | `setup() { useBandRealtime(usePage().props.auth?.user?.band_ids ?? [], { events: ['events'], event_member: ['events'], roster: ['events'] }); }` |
+| Events/Show.vue | `useBandRealtime(props.band.id, { events: { props: ['event', 'userPayout'], when: (p) => p.id === props.event.id }, event_member: ['event', 'userPayout'] })` |
+| Band/Rosters/Index.vue (Options) | `setup(props) { useBandRealtime(props.band.id, { roster: ['rosters', 'rosterMembers'] }); }` — Options `setup(props)` receives reactive props; `props.band.id` is available |
+| Finances/PayoutFlowEditor.vue | `useBandRealtime(props.band.id, { roster: ['previewRosterMembers'] })` |
+| Rehearsals/Index.vue | band prop is nullable (multi-band view): `useBandRealtime(props.band ? props.band.id : (props.bands ?? []).map((b) => b.id), { rehearsal: ['schedules'] })` |
+| Rehearsals/ScheduleDetail.vue | `useBandRealtime(props.band.id, { rehearsal: ['schedule'] })` |
+| Rehearsals/RehearsalDetail.vue | `useBandRealtime(props.band.id, { rehearsal: { props: ['rehearsal'], when: (p) => p.id === props.rehearsal.id } })` |
+
+Same per-file verification as Task 5 (band-id source, props exist in `defineProps`, Options vs setup). Note `Rehearsals/RehearsalList` is a dead `Inertia::render` target with no Vue file — do NOT create it; mention it in the PR body as observed dead code.
+
+Deliberate exclusions (record in the PR body, not code): create/edit FORM pages (`Rehearsals/ScheduleForm`, `Rehearsals/RehearsalForm`, and any booking create/edit forms) get NO opt-in — silently reloading the record under an open editor is exactly the clobber the silent-refresh decision accepted everywhere else because Inertia preserves form state; on a form page the props ARE the form's seed, so a reload mid-edit invites confusion for zero benefit.
+
+- [ ] **Step 2: Full verification**
+
+Run: `npm run test:pipeline && npm run build 2>&1 | tail -3`
+Expected: all green, build completes.
+
+Run: `docker compose exec -T app php artisan test`
+Expected: backend unaffected (only the middleware changed, Task 1 tested it); known CalendarFeedTest parallel flake rule applies.
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd /home/eddie/github/TTS && git add resources/js/Pages && git commit -m "feat(realtime-web): dashboard, events, rehearsals, rosters, payout-flow live-reload on band signals"
+```
+
+### Task 7: Live browser verification + PR
+
+**Files:** none new.
+
+- [ ] **Step 1: End-to-end in a real browser**
+
+With local `docker compose up` (Vite dev or fresh `npm run build`): log into `https://localhost:8710` (eddimull@gmail.com / password), open the Bookings index in one browser tab, then rename a band-1 booking via
+`docker compose exec -T app php artisan tinker --execute='\App\Models\Bookings::find(621)->update(["name" => "WEB REALTIME TEST"]);'`
+and confirm (a) the list updates without a manual refresh within ~2s, and (b) the notifications bell badge updates (the booking-updated job creates a TTSNotification). Rename back afterwards. Local broadcasting must be on real Pusher Cloud creds (already configured) — Echo web client uses `VITE_PUSHER_*` from `.env`; if the web client fails to connect, check `VITE_PUSHER_APP_KEY` matches the backend key and rebuild assets (VITE vars are baked at build time).
+
+- [ ] **Step 2: Wait for #516, then push + PR**
+
+TTS #516 (`feat/band-realtime-broadcasts`) must merge first — this branch is stacked on it. Then:
+
+```bash
+cd /home/eddie/github/TTS && git fetch origin staging && git rebase origin/staging && npm run test:pipeline && docker compose exec -T app php artisan test --filter=InertiaSharedBandIdsTest && git push -u origin feat/band-realtime-web && gh pr create --base staging --title "Realtime: web consumes band signals — live pages + notifications bell" --body "$(cat <<'EOF'
+## Summary
+- `auth.user.band_ids` joins Inertia shared props (owner+member+sub, deduped)
+- Refcounted `bandChannel` module + `useBandRealtime` composable: thin `.band.data-changed` signals → debounced `router.reload({ only: [...] })` per page
+- Live notifications bell: band signals refresh the badge/dropdown; toast when unseen count grows
+- Opt-ins across bookings (index/show/8 sub-pages), dashboard, events, rehearsals, rosters, payout-flow editor
+- First Echo tests in the web suite (mock + 15 tests)
+
+Consumes the `BandDataChanged` broadcasts from #516. Web twin of tts_bandmate #94. Spec: `docs/superpowers/specs/2026-07-07-band-realtime-web-design.md`.
+
+Observed dead code (not touched): `RehearsalController::index` renders `Rehearsals/RehearsalList`, which has no Vue file.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+
+https://claude.ai/code/session_01YNyzbE8jweH5FLjTMJt1kY
+EOF
+)"
+```
+
+- [ ] **Step 3: Wait for Copilot review and address its comments** (repo convention).

--- a/docs/superpowers/specs/2026-07-07-band-realtime-web-design.md
+++ b/docs/superpowers/specs/2026-07-07-band-realtime-web-design.md
@@ -1,0 +1,128 @@
+# Band realtime on web (Vue/Inertia consumer) — design
+
+**Date:** 2026-07-07
+**Repo:** TTS (branch `feat/band-realtime-web`, stacked on `feat/band-realtime-broadcasts`)
+**Status:** Approved
+**Companion:** mobile consumer spec lives in tts_bandmate
+`docs/superpowers/specs/2026-07-06-band-realtime-invalidation-design.md`
+
+## Problem
+
+The backend now broadcasts thin `BandDataChanged` signals
+(`.band.data-changed` on `private-band.{bandId}`, payload
+`{model, id, action[, parent]}`) and mobile consumes them. Web pages still go
+stale until a full page load. Web should consume the same signals: silent
+partial-reloads of affected Inertia props, plus a notifications bell that
+updates live and visibly.
+
+## Decisions made
+
+- **Scope:** every page whose Inertia props are fed by the five broadcasting
+  models (`bookings`, `events`, `rehearsal`, `roster`, `event_member`).
+  Pages backed by non-broadcasting models (songs, media, roles, contacts)
+  are out until those models adopt the trait.
+- **Refresh UX:** silent auto-refresh via `router.reload({ only: [...] })`
+  (the app's existing idiom), debounced. Exception: the TTSNotifications
+  bell updates live AND visibly (badge/dropdown refresh + toast on new).
+- **Architecture:** per-page opt-in composable + one always-on layout
+  listener for the bell (approach A). No global convention-based reloads.
+
+## Components
+
+### 1. Shared band context (backend, small)
+
+`HandleInertiaRequests::share` adds `auth.bandIds`: deduped ids of the
+user's owned + member + sub bands (same audience the `band.{bandId}`
+channel authorizes). Absent when unauthenticated.
+
+### 2. `useBandRealtime` composable — the one new moving part
+
+`resources/js/composables/useBandRealtime.js`:
+
+```js
+useBandRealtime(bandIdOrIds, reloadMap, options = {})
+// reloadMap: { bookings: ['bookings'] }                        — model → props
+//        or  { bookings: { props: ['booking'], when: p => p.id === X } }
+// options: { onSignal(payload) }  — non-reload consumers (the bell)
+```
+
+- Subscribes `window.Echo.private('band.' + id)` per id,
+  `.listen('.band.data-changed', ...)` — **leading dot** (`broadcastAs`
+  convention, same as `.SetlistSessionStarted`).
+- Debounce ~300 ms: coalesce arriving signals, then ONE
+  `router.reload({ only: [union of mapped props] })`.
+- `when` predicates gate detail pages (only my booking id).
+- **Module-level channel refcounting:** Inertia page transitions can have
+  the outgoing page `leave()` a channel the incoming page just subscribed;
+  refcount and only `Echo.leave()` at zero (web twin of the mobile
+  generation-guard fix).
+- `.subscribed()` no-op; `.error()` → `console.warn` only (no toast spam
+  for a background feature).
+- Lifecycle: `onMounted`/`onUnmounted` (usable from `<script setup>`; the
+  Options-API layout calls it from a `setup()` block).
+
+### 3. Live bell (Authenticated.vue)
+
+Layout subscribes to all `auth.bandIds` via the composable with an
+`onSignal` handler (no reloadMap): debounced refetch of the shared `auth`
+prop (`router.reload({ only: ['auth'] })`), which feeds the existing Vuex
+notification store → badge + dropdown update in realtime. When the unread
+count increases, surface the newest notification through the existing
+toast mechanism. Backend jobs (`ProcessBookingUpdated` / `ProcessEventUpdated`
+/ invitation services) already create the TTSNotifications; this makes
+them appear without a page load.
+
+### 4. Page opt-ins (the sweep)
+
+One `useBandRealtime(...)` line per page. Initial mapping (plan-time
+controller sweep finalizes the list — any page whose `Inertia::render`
+props come from the five models):
+
+| Page | band id source | models → props |
+|---|---|---|
+| Dashboard | `auth.bandIds` (all) | events, event_member, roster → `events` |
+| Bookings/Index | `auth.bandIds` (multi-band page) | bookings → `bookings` |
+| Bookings/Show + sub-pages (Payout, Contract, Contacts, Media) | `booking.band_id` | bookings (when id matches) → `booking`, `recentActivities` (per page's props) |
+| Events/Index | page band or `auth.bandIds` | events, event_member, roster → `events` |
+| Band rosters management | page band | roster → `rosters` |
+| Rehearsals pages (if Inertia-rendered) | page band | rehearsal → their props |
+
+### 5. Noise & self-echo
+
+Own mutations already reload after POST; the self-signal coalesces into
+the debounce — at worst one redundant partial reload. No `toOthers()`
+(deferred, same as mobile). Timestamp-touch signals are absorbed by the
+debounce.
+
+## Error handling
+
+- Echo/channel failure → silent (console.warn); pages behave exactly as
+  today (stale until navigation).
+- Unauthorized channel (sub without read) → Echo `.error()`, same silence.
+- Reload requests failing → Inertia's normal error handling; no retry loop.
+
+## Testing
+
+First Echo tests in the web suite (vitest + jsdom):
+- `window.Echo` mock in `resources/js/tests/mocks/` (channel registry,
+  fire helper).
+- Composable: refcounting across mount/unmount overlap, debounce
+  coalescing, model→prop union, `when` filter, leading-dot event name,
+  `onSignal` path (mock `router.reload`).
+- Bell handler: signal → auth-prop reload call; count-increase → toast.
+- CI note: assert on rendered text, never the `<!--v-if-->` marker.
+
+## Delivery
+
+Branch `feat/band-realtime-web` (this branch) stacked on
+`feat/band-realtime-broadcasts`; PR targets `staging` after TTS #516
+merges. Backend surface in this PR: only the `HandleInertiaRequests`
+shared-prop addition (+ its test).
+
+## Out of scope
+
+- Broadcasting for songs/media/roles/contacts models (one trait line each,
+  later).
+- `toOthers()` sender suppression (tracked with mobile's deferral).
+- Presence/typing indicators, per-ability channels.
+- The web planner-chat consumer (none exists today; unrelated).

--- a/docs/superpowers/specs/2026-07-07-band-realtime-web-design.md
+++ b/docs/superpowers/specs/2026-07-07-band-realtime-web-design.md
@@ -31,7 +31,7 @@ updates live and visibly.
 
 ### 1. Shared band context (backend, small)
 
-`HandleInertiaRequests::share` adds `auth.bandIds`: deduped ids of the
+`HandleInertiaRequests::share` adds `auth.user.band_ids`: deduped ids of the
 user's owned + member + sub bands (same audience the `band.{bandId}`
 channel authorizes). Absent when unauthenticated.
 
@@ -63,7 +63,7 @@ useBandRealtime(bandIdOrIds, reloadMap, options = {})
 
 ### 3. Live bell (Authenticated.vue)
 
-Layout subscribes to all `auth.bandIds` via the composable with an
+Layout subscribes to all `auth.user.band_ids` via the composable with an
 `onSignal` handler (no reloadMap): debounced refetch of the shared `auth`
 prop (`router.reload({ only: ['auth'] })`), which feeds the existing Vuex
 notification store → badge + dropdown update in realtime. When the unread
@@ -80,10 +80,10 @@ props come from the five models):
 
 | Page | band id source | models → props |
 |---|---|---|
-| Dashboard | `auth.bandIds` (all) | events, event_member, roster → `events` |
-| Bookings/Index | `auth.bandIds` (multi-band page) | bookings → `bookings` |
+| Dashboard | `auth.user.band_ids` (all) | events, event_member, roster → `events` |
+| Bookings/Index | `auth.user.band_ids` (multi-band page) | bookings → `bookings` |
 | Bookings/Show + sub-pages (Payout, Contract, Contacts, Media) | `booking.band_id` | bookings (when id matches) → `booking`, `recentActivities` (per page's props) |
-| Events/Index | page band or `auth.bandIds` | events, event_member, roster → `events` |
+| Events/Index | page band or `auth.user.band_ids` | events, event_member, roster → `events` |
 | Band rosters management | page band | roster → `rosters` |
 | Rehearsals pages (if Inertia-rendered) | page band | rehearsal → their props |
 

--- a/resources/js/Layouts/Authenticated.vue
+++ b/resources/js/Layouts/Authenticated.vue
@@ -536,6 +536,8 @@ import Toast from "primevue/toast";
 import axios from "axios";
 import { mapState, mapActions } from "vuex";
 import { router } from "@inertiajs/vue3";
+import { subscribeBandSignals } from "@/realtime/bandChannel";
+import { createBellRefresher } from "@/realtime/bellRefresher";
 import { navigationGroups } from "@/config/navigation.js";
 
 export default {
@@ -610,12 +612,15 @@ export default {
     },
     mounted() {
         this.subscribeToUserChannel();
+        this.subscribeToBandSignals();
     },
     beforeUnmount() {
         const userId = this.$page.props.auth?.user?.id;
         if (userId && window.Echo) {
             window.Echo.leave(`App.Models.User.${userId}`);
         }
+        this._bandUnsubscribe?.();
+        this._bellRefresher?.dispose();
     },
     onUpdated() {
         this.toast();
@@ -663,6 +668,25 @@ export default {
                 });
 
             console.log('[Layout] Subscribed to App.Models.User.' + userId);
+        },
+
+        subscribeToBandSignals() {
+            const bandIds = this.$page.props.auth?.user?.band_ids;
+            if (!bandIds?.length || !window.Echo) return;
+
+            this._bellRefresher = createBellRefresher({
+                reloadAuth: (opts) => router.reload({
+                    ...opts,
+                    onSuccess: () => {
+                        this.fetchNotifications();
+                        opts.onSuccess?.();
+                    },
+                }),
+                getUnseenCount: () => this.unseenNotifications,
+                getLatest: () => this.notifications?.[0],
+                toast: (opts) => this.$toast?.add(opts),
+            });
+            this._bandUnsubscribe = subscribeBandSignals(bandIds, this._bellRefresher.onSignal);
         },
 
         onSetlistToastClose() {

--- a/resources/js/Pages/Band/Rosters/Index.vue
+++ b/resources/js/Pages/Band/Rosters/Index.vue
@@ -58,6 +58,7 @@
 import BreezeAuthenticatedLayout from '@/Layouts/Authenticated'
 import RosterManager from './Components/RosterManager.vue'
 import CallListsManager from './Components/CallListsManager.vue'
+import { useBandRealtime } from '@/composables/useBandRealtime'
 
 export default {
   components: {
@@ -66,6 +67,11 @@ export default {
   },
   layout: BreezeAuthenticatedLayout,
   pageTitle: 'Rosters',
+  setup(props) {
+    useBandRealtime(props.band.id, {
+      roster: ['rosters', 'rosterMembers'],
+    });
+  },
   props: {
     band: {
       type: Object,

--- a/resources/js/Pages/Bookings/Contacts.vue
+++ b/resources/js/Pages/Bookings/Contacts.vue
@@ -77,6 +77,7 @@ import { useForm } from '@inertiajs/vue3';
 import ContactCard from './Components/ContactCard.vue';
 import BookingLayout from './Layout/BookingLayout.vue';
 import NewContactForm from './Components/NewContactForm.vue';
+import { useBandRealtime } from '@/composables/useBandRealtime';
 
 const props = defineProps({
   booking: {
@@ -87,6 +88,10 @@ const props = defineProps({
     type: Object,
     required: true
   }
+});
+
+useBandRealtime(props.band.id, {
+  bookings: { props: ['booking'], when: (p) => p.id === props.booking.id },
 });
 
 const emit = defineEmits(['update:booking']);

--- a/resources/js/Pages/Bookings/Contract.vue
+++ b/resources/js/Pages/Bookings/Contract.vue
@@ -92,6 +92,7 @@ import ContractEditor from './Components/ContractEditor.vue'
 import ContractNone from './Components/ContractNone.vue';
 import ContractExternal from './Components/ContractExternal.vue';
 import ContractStatus from './Components/ContractStatus.vue';
+import { useBandRealtime } from '@/composables/useBandRealtime'
 
 defineOptions({
   layout: BookingLayout,
@@ -100,6 +101,10 @@ defineOptions({
 const props = defineProps({
   booking: Object,
   band: Object,
+})
+
+useBandRealtime(props.band.id, {
+  bookings: { props: ['booking'], when: (p) => p.id === props.booking.id },
 })
 
 const amendContract = () => {

--- a/resources/js/Pages/Bookings/Events.vue
+++ b/resources/js/Pages/Bookings/Events.vue
@@ -4,6 +4,7 @@
 <script setup>
 import EventList from './Components/EventList.vue';
 import BookingLayout from './Layout/BookingLayout.vue';
+import { useBandRealtime } from '@/composables/useBandRealtime';
 
 
 defineOptions({
@@ -13,5 +14,11 @@ defineOptions({
 const props = defineProps({
     booking: Object,
     events: Object
+})
+
+useBandRealtime(props.booking.band_id, {
+    bookings: { props: ['booking'], when: (p) => p.id === props.booking.id },
+    events: ['events'],
+    event_member: ['events'],
 })
 </script>

--- a/resources/js/Pages/Bookings/Finances.vue
+++ b/resources/js/Pages/Bookings/Finances.vue
@@ -69,6 +69,7 @@ import PaymentList from "./Components/PaymentList.vue";
 import PaymentActions from "./Components/PaymentActions.vue";
 import PaymentSummary from "./Components/PaymentSummary.vue";
 import CreateInvoiceDialog from "./Components/CreateInvoiceDialog.vue";
+import { useBandRealtime } from '@/composables/useBandRealtime';
 
 const props = defineProps({
     booking: {
@@ -87,6 +88,10 @@ const props = defineProps({
         type: Array,
         default: () => [],
     },
+});
+
+useBandRealtime(props.band.id, {
+    bookings: { props: ['booking', 'payments'], when: (p) => p.id === props.booking.id },
 });
 
 //watch for changes in the action

--- a/resources/js/Pages/Bookings/Finances.vue
+++ b/resources/js/Pages/Bookings/Finances.vue
@@ -92,6 +92,7 @@ const props = defineProps({
 
 useBandRealtime(props.band.id, {
     bookings: { props: ['booking', 'payments'], when: (p) => p.id === props.booking.id },
+    payments: { props: ['payments', 'booking'], when: (p) => p.parent?.id === props.booking.id },
 });
 
 //watch for changes in the action

--- a/resources/js/Pages/Bookings/History.vue
+++ b/resources/js/Pages/Bookings/History.vue
@@ -148,6 +148,7 @@ import Container from '@/Components/Container.vue';
 import ActivityTimeline from '@/Components/ActivityTimeline.vue';
 import BreezeAuthenticatedLayout from '@/Layouts/Authenticated.vue';
 import { DateTime } from 'luxon';
+import { useBandRealtime } from '@/composables/useBandRealtime';
 
 defineOptions({
     layout: BreezeAuthenticatedLayout,
@@ -167,6 +168,10 @@ const props = defineProps({
         required: true,
         default: () => [],
     },
+});
+
+useBandRealtime(props.band.id, {
+    bookings: { props: ['booking'], when: (p) => p.id === props.booking.id },
 });
 
 // Helper methods

--- a/resources/js/Pages/Bookings/History.vue
+++ b/resources/js/Pages/Bookings/History.vue
@@ -171,7 +171,7 @@ const props = defineProps({
 });
 
 useBandRealtime(props.band.id, {
-    bookings: { props: ['booking'], when: (p) => p.id === props.booking.id },
+    bookings: { props: ['booking', 'activities'], when: (p) => p.id === props.booking.id },
 });
 
 // Helper methods

--- a/resources/js/Pages/Bookings/Index.vue
+++ b/resources/js/Pages/Bookings/Index.vue
@@ -84,6 +84,8 @@ import BreezeAuthenticatedLayout from "@/Layouts/Authenticated.vue";
 import { DateTime } from "luxon";
 import BookingCard from "./Components/BookingCard.vue";
 import Input from "@/Components/Input.vue";
+import { usePage } from '@inertiajs/vue3';
+import { useBandRealtime } from '@/composables/useBandRealtime';
 
 export default {
     components: {
@@ -91,6 +93,11 @@ export default {
         Input,
     },
     layout: BreezeAuthenticatedLayout,
+    setup() {
+        useBandRealtime(usePage().props.auth?.user?.band_ids ?? [], {
+            bookings: ['bookings'],
+        });
+    },
     props: {
         bookings: Array,
         bands: Object,

--- a/resources/js/Pages/Bookings/Lineup.vue
+++ b/resources/js/Pages/Bookings/Lineup.vue
@@ -25,6 +25,7 @@
 <script setup>
 import BookingLayout from './Layout/BookingLayout.vue';
 import RosterSection from './Components/EventEditor/RosterSection.vue';
+import { useBandRealtime } from '@/composables/useBandRealtime';
 
 defineOptions({ layout: BookingLayout });
 
@@ -32,6 +33,12 @@ const props = defineProps({
   booking: { type: Object, required: true },
   band: { type: Object, required: true },
   events: { type: Array, default: () => [] },
+});
+
+useBandRealtime(props.band.id, {
+  bookings: { props: ['booking'], when: (p) => p.id === props.booking.id },
+  events: ['events'],
+  event_member: ['events'],
 });
 
 const updateEvent = (eventId, updatedEvent) => {

--- a/resources/js/Pages/Bookings/Media.vue
+++ b/resources/js/Pages/Bookings/Media.vue
@@ -197,6 +197,7 @@ import Dialog from 'primevue/dialog'
 import MediaUploadDialog from '@/Components/MediaUploadDialog.vue'
 import MediaGallery from '@/Components/MediaGallery.vue'
 import { useMediaDragDrop } from '@/composables/useMediaDragDrop'
+import { useBandRealtime } from '@/composables/useBandRealtime'
 
 defineOptions({
   layout: BookingLayout,
@@ -227,6 +228,10 @@ const props = defineProps({
     type: Boolean,
     default: true
   }
+})
+
+useBandRealtime(props.band.id, {
+  bookings: { props: ['booking'], when: (p) => p.id === props.booking.id },
 })
 
 const page = usePage()

--- a/resources/js/Pages/Bookings/Media.vue
+++ b/resources/js/Pages/Bookings/Media.vue
@@ -232,6 +232,9 @@ const props = defineProps({
 
 useBandRealtime(props.band.id, {
   bookings: { props: ['booking'], when: (p) => p.id === props.booking.id },
+  // Media→event linkage is by folder path (no FK), so media signals are
+  // band-level; reloading this booking's file list is cheap and debounced.
+  media_file: ['mediaFiles'],
 })
 
 const page = usePage()

--- a/resources/js/Pages/Bookings/Payout.vue
+++ b/resources/js/Pages/Bookings/Payout.vue
@@ -607,7 +607,7 @@ useBandRealtime(props.band.id, {
   events: ['booking', 'payoutResult', 'adjustedTotal'],
   event_member: ['booking', 'payoutResult', 'adjustedTotal'],
   payments: { props: ['adjustedTotal', 'payoutResult'], when: (p) => p.parent?.id === props.booking.id },
-  payout: { props: ['adjustments', 'payoutResult', 'adjustedTotal'], when: (p) => p.parent?.id === props.booking.id },
+  payout: { props: ['payoutConfig', 'adjustments', 'payoutResult', 'adjustedTotal'], when: (p) => p.parent?.id === props.booking.id },
   payout_adjustment: { props: ['adjustments', 'payoutResult', 'adjustedTotal'], when: (p) => p.parent?.id === props.booking.id },
   band_payout_config: ['payoutConfig', 'availableConfigs', 'payoutResult'],
 })

--- a/resources/js/Pages/Bookings/Payout.vue
+++ b/resources/js/Pages/Bookings/Payout.vue
@@ -554,7 +554,7 @@
 </template>
 
 <script setup>
-import { ref, computed, reactive } from 'vue'
+import { ref, computed, reactive, watch } from 'vue'
 import { Link, usePage, useForm, router } from '@inertiajs/vue3'
 import Container from '@/Components/Container.vue'
 import BookingLayout from './Layout/BookingLayout.vue'
@@ -621,6 +621,13 @@ const adjustmentForm = useForm({
 
 // Configuration selector
 const selectedConfigId = ref(props.payoutConfig?.id || null)
+
+// Keep the selector in sync when a realtime partial reload refreshes
+// payoutConfig (e.g. someone else switched the configuration) — the local
+// ref only seeds at mount otherwise and the label would lie.
+watch(() => props.payoutConfig?.id, (id) => {
+  selectedConfigId.value = id ?? null
+})
 
 const page = usePage()
 

--- a/resources/js/Pages/Bookings/Payout.vue
+++ b/resources/js/Pages/Bookings/Payout.vue
@@ -606,6 +606,10 @@ useBandRealtime(props.band.id, {
   bookings: { props: ['booking', 'payoutResult', 'adjustedTotal'], when: (p) => p.id === props.booking.id },
   events: ['booking', 'payoutResult', 'adjustedTotal'],
   event_member: ['booking', 'payoutResult', 'adjustedTotal'],
+  payments: { props: ['adjustedTotal', 'payoutResult'], when: (p) => p.parent?.id === props.booking.id },
+  payout: { props: ['adjustments', 'payoutResult', 'adjustedTotal'], when: (p) => p.parent?.id === props.booking.id },
+  payout_adjustment: { props: ['adjustments', 'payoutResult', 'adjustedTotal'], when: (p) => p.parent?.id === props.booking.id },
+  band_payout_config: ['payoutConfig', 'availableConfigs', 'payoutResult'],
 })
 
 const showAdjustmentDialog = ref(false)

--- a/resources/js/Pages/Bookings/Payout.vue
+++ b/resources/js/Pages/Bookings/Payout.vue
@@ -604,8 +604,8 @@ const props = defineProps({
 
 useBandRealtime(props.band.id, {
   bookings: { props: ['booking', 'payoutResult', 'adjustedTotal'], when: (p) => p.id === props.booking.id },
-  events: ['payoutResult', 'adjustedTotal'],
-  event_member: ['payoutResult', 'adjustedTotal'],
+  events: ['booking', 'payoutResult', 'adjustedTotal'],
+  event_member: ['booking', 'payoutResult', 'adjustedTotal'],
 })
 
 const showAdjustmentDialog = ref(false)

--- a/resources/js/Pages/Bookings/Payout.vue
+++ b/resources/js/Pages/Bookings/Payout.vue
@@ -565,6 +565,7 @@ import InputText from 'primevue/inputtext'
 import Textarea from 'primevue/textarea'
 import Button from 'primevue/button'
 import Dropdown from 'primevue/dropdown'
+import { useBandRealtime } from '@/composables/useBandRealtime'
 
 defineOptions({
   layout: BookingLayout,
@@ -599,6 +600,12 @@ const props = defineProps({
     type: Array,
     default: () => []
   }
+})
+
+useBandRealtime(props.band.id, {
+  bookings: { props: ['booking', 'payoutResult', 'adjustedTotal'], when: (p) => p.id === props.booking.id },
+  events: ['payoutResult', 'adjustedTotal'],
+  event_member: ['payoutResult', 'adjustedTotal'],
 })
 
 const showAdjustmentDialog = ref(false)

--- a/resources/js/Pages/Bookings/Show.vue
+++ b/resources/js/Pages/Bookings/Show.vue
@@ -22,6 +22,7 @@ import { usePage } from '@inertiajs/vue3'
 import BookingLayout from './Layout/BookingLayout.vue'
 import BookingDetails from './Components/BookingDetails.vue'
 import BookingForm from './Components/BookingForm.vue'
+import { useBandRealtime } from '@/composables/useBandRealtime'
 
 defineOptions({
   layout: BookingLayout,
@@ -56,6 +57,10 @@ const props = defineProps({
     type: Array,
     default: () => [],
   },
+})
+
+useBandRealtime(props.band.id, {
+  bookings: { props: ['booking', 'recentActivities'], when: (p) => p.id === props.booking.id },
 })
 
 const page = usePage()

--- a/resources/js/Pages/Bookings/Show.vue
+++ b/resources/js/Pages/Bookings/Show.vue
@@ -61,9 +61,14 @@ const props = defineProps({
 
 useBandRealtime(props.band.id, {
   bookings: { props: ['booking', 'recentActivities'], when: (p) => p.id === props.booking.id },
-  events: ['booking'],
-  event_member: ['booking'],
+  // Event values feed the estimated payout total, so event-family changes
+  // refresh the estimate props alongside the nested booking data.
+  events: ['booking', 'payoutResult'],
+  event_member: ['booking', 'payoutResult'],
   payments: { props: ['booking'], when: (p) => p.parent?.id === props.booking.id },
+  payout: { props: ['payoutResult', 'payoutConfig'], when: (p) => p.parent?.id === props.booking.id },
+  payout_adjustment: { props: ['payoutResult', 'payoutConfig'], when: (p) => p.parent?.id === props.booking.id },
+  band_payout_config: ['payoutResult', 'payoutConfig'],
 })
 
 const page = usePage()

--- a/resources/js/Pages/Bookings/Show.vue
+++ b/resources/js/Pages/Bookings/Show.vue
@@ -63,6 +63,7 @@ useBandRealtime(props.band.id, {
   bookings: { props: ['booking', 'recentActivities'], when: (p) => p.id === props.booking.id },
   events: ['booking'],
   event_member: ['booking'],
+  payments: { props: ['booking'], when: (p) => p.parent?.id === props.booking.id },
 })
 
 const page = usePage()

--- a/resources/js/Pages/Bookings/Show.vue
+++ b/resources/js/Pages/Bookings/Show.vue
@@ -61,6 +61,8 @@ const props = defineProps({
 
 useBandRealtime(props.band.id, {
   bookings: { props: ['booking', 'recentActivities'], when: (p) => p.id === props.booking.id },
+  events: ['booking'],
+  event_member: ['booking'],
 })
 
 const page = usePage()

--- a/resources/js/Pages/Charts/Index.vue
+++ b/resources/js/Pages/Charts/Index.vue
@@ -331,6 +331,8 @@
 </template>
 
 <script>
+import { usePage } from '@inertiajs/vue3';
+import { useBandRealtime } from '@/composables/useBandRealtime';
 import BreezeAuthenticatedLayout from "@/Layouts/Authenticated";
 import InputSwitch from "primevue/inputswitch";
 import IconField from "primevue/iconfield";
@@ -343,6 +345,14 @@ import Card from "primevue/card";
 import Tag from "primevue/tag";
 
 export default {
+    setup() {
+        // Charts page aggregates every band the user can read — subscribe
+        // to all of them; chart uploads roll up into the same charts prop.
+        useBandRealtime(usePage().props.auth?.user?.band_ids ?? [], {
+            charts: ['charts'],
+            chart_uploads: ['charts'],
+        });
+    },
     components: {
         BreezeAuthenticatedLayout,
         Toolbar,
@@ -389,6 +399,13 @@ export default {
             handler(newValue) {
                 this.filterCharts();
             },
+        },
+        // Realtime partial reloads refresh the `charts` prop; re-seed the
+        // local copies (data() only captures the mount-time value) and
+        // re-apply the active search filter.
+        charts(newCharts) {
+            this.chartsData = newCharts;
+            this.filterCharts();
         },
     },
     created() {

--- a/resources/js/Pages/Charts/Show.vue
+++ b/resources/js/Pages/Charts/Show.vue
@@ -402,12 +402,20 @@
 </template>
 
 <script>
+import { usePage } from '@inertiajs/vue3';
+import { useBandRealtime } from '@/composables/useBandRealtime';
 import BreezeAuthenticatedLayout from "@/Layouts/Authenticated";
 import Card from "primevue/card";
 import Tag from "primevue/tag";
 import pdf from "@jbtje/vite-vue3pdf";
 
 export default {
+    setup(props) {
+        useBandRealtime(usePage().props.auth?.user?.band_ids ?? [], {
+            charts: { props: ['chart'], when: (p) => p.id === props.chart?.id },
+            chart_uploads: { props: ['chart'], when: (p) => p.parent?.id === props.chart?.id },
+        });
+    },
     components: {
         BreezeAuthenticatedLayout,
         Card,

--- a/resources/js/Pages/Dashboard.vue
+++ b/resources/js/Pages/Dashboard.vue
@@ -368,7 +368,8 @@
     import RehearsalEditorModal from '../Components/Rehearsal/RehearsalEditorModal.vue'
     import Dialog from 'primevue/dialog';
     import { nextTick, onMounted, onUnmounted, ref } from 'vue';
-    import { router } from '@inertiajs/vue3';
+    import { router, usePage } from '@inertiajs/vue3';
+    import { useBandRealtime } from '@/composables/useBandRealtime';
 
     const props = defineProps({
       events: {
@@ -388,6 +389,13 @@
     defineOptions({
       layout: BreezeAuthenticatedLayout,
     })
+
+    useBandRealtime(usePage().props.auth?.user?.band_ids ?? [], {
+      events: ['events'],
+      event_member: ['events'],
+      roster: ['events'],
+      bookings: ['stats'],
+    });
 
     // Create a local reactive copy of events that we can mutate
     const localEvents = ref([...props.events]);

--- a/resources/js/Pages/Dashboard.vue
+++ b/resources/js/Pages/Dashboard.vue
@@ -367,7 +367,7 @@
     import UpcomingCharts from '../Components/Dashboard/UpcomingCharts.vue'
     import RehearsalEditorModal from '../Components/Rehearsal/RehearsalEditorModal.vue'
     import Dialog from 'primevue/dialog';
-    import { nextTick, onMounted, onUnmounted, ref } from 'vue';
+    import { nextTick, onMounted, onUnmounted, ref, watch } from 'vue';
     import { router, usePage } from '@inertiajs/vue3';
     import { useBandRealtime } from '@/composables/useBandRealtime';
 
@@ -399,6 +399,33 @@
 
     // Create a local reactive copy of events that we can mutate
     const localEvents = ref([...props.events]);
+
+    // Realtime signals (events/event_member/roster) trigger a partial reload of
+    // the `events` prop, but the template renders `localEvents`, not `props.events`
+    // directly — that's what lets loadOlderEvents() page in older events without
+    // Inertia clobbering them on the next unrelated prop refresh. So we must
+    // re-sync localEvents whenever props.events changes underneath us, while
+    // preserving anything the user has paged in that's older than this fresh
+    // window. We keep the paged-in events strictly older than the earliest date
+    // in the refreshed props.events, then splice in the fresh window verbatim,
+    // deduping by id in case of overlap.
+    watch(() => props.events, (freshEvents) => {
+      if (!freshEvents || freshEvents.length === 0) {
+        localEvents.value = [...(freshEvents || [])];
+        return;
+      }
+
+      const earliestFreshDate = freshEvents[0].date;
+      const freshIds = new Set(freshEvents.map(e => e.id || e.key));
+
+      const pagedInOlderEvents = localEvents.value.filter(event => {
+        const isOlder = event.date < earliestFreshDate;
+        const isDuplicate = freshIds.has(event.id || event.key);
+        return isOlder && !isDuplicate;
+      });
+
+      localEvents.value = [...pagedInOlderEvents, ...freshEvents];
+    });
 
     // Rehearsal editor state
     const showRehearsalEditor = ref(false);

--- a/resources/js/Pages/Events/Index.vue
+++ b/resources/js/Pages/Events/Index.vue
@@ -10,12 +10,21 @@
 <script>
     import BreezeAuthenticatedLayout from '@/Layouts/Authenticated'
     import { DateTime } from 'luxon';
+    import { usePage } from '@inertiajs/vue3';
+    import { useBandRealtime } from '@/composables/useBandRealtime';
     import EventList from './EventList.vue';
     export default {
         components: {
             EventList
         },
         layout: BreezeAuthenticatedLayout,
+        setup() {
+            useBandRealtime(usePage().props.auth?.user?.band_ids ?? [], {
+                events: ['events'],
+                event_member: ['events'],
+                roster: ['events'],
+            });
+        },
         props:['events','successMessage','includeAll'],
         methods:{
             formatDate(date){

--- a/resources/js/Pages/Events/Show.vue
+++ b/resources/js/Pages/Events/Show.vue
@@ -493,6 +493,7 @@ import RosterMember from './Show/RosterMember.vue';
 import Times from '@/Components/Event/Card/Components/Times.vue';
 import ImageLightbox from '@/Components/ImageLightbox.vue';
 import SectionHeader from './Show/SectionHeader.vue';
+import { useBandRealtime } from '@/composables/useBandRealtime';
 
 defineOptions({
   layout: BreezeAuthenticatedLayout,
@@ -515,6 +516,11 @@ const props = defineProps({
     type: Number,
     default: null
   }
+});
+
+useBandRealtime(props.band.id, {
+  events: { props: ['event', 'userPayout'], when: (p) => p.id === props.event.id },
+  event_member: ['event', 'userPayout'],
 });
 
 // Computed properties

--- a/resources/js/Pages/Events/Show.vue
+++ b/resources/js/Pages/Events/Show.vue
@@ -521,6 +521,13 @@ const props = defineProps({
 useBandRealtime(props.band.id, {
   events: { props: ['event', 'userPayout'], when: (p) => p.id === props.event.id },
   event_member: ['event', 'userPayout'],
+  // The user's pay derives from the parent booking's payout (config choice,
+  // adjustments) — refresh it on the payout family too. No `when`: the
+  // signals' parent is the BOOKING id, which this page doesn't reliably
+  // carry; a band-wide single-prop reload is cheap and debounced.
+  payout: ['userPayout'],
+  payout_adjustment: ['userPayout'],
+  band_payout_config: ['userPayout'],
 });
 
 // Computed properties

--- a/resources/js/Pages/Finances/PayoutFlowEditor.vue
+++ b/resources/js/Pages/Finances/PayoutFlowEditor.vue
@@ -32,6 +32,7 @@ import AuthenticatedLayout from '@/Layouts/Authenticated.vue'
 import Toast from 'primevue/toast'
 import FlowCanvas from './Components/FlowEditor/FlowCanvas.vue'
 import ConfigurationManager from './Components/FlowEditor/ConfigurationManager.vue'
+import { useBandRealtime } from '@/composables/useBandRealtime'
 
 const props = defineProps({
   band: {
@@ -46,6 +47,10 @@ const props = defineProps({
     type: Array,
     default: () => []
   }
+})
+
+useBandRealtime(props.band.id, {
+  roster: ['previewRosterMembers'],
 })
 
 // Compute initial flow from existing config

--- a/resources/js/Pages/Media/Index.vue
+++ b/resources/js/Pages/Media/Index.vue
@@ -830,6 +830,7 @@ import MediaPreviewDialog from './Components/MediaPreviewDialog.vue';
 import DriveConnectionsPanel from './Components/DriveConnectionsPanel.vue';
 import FolderBreadcrumbs from './Components/FolderBreadcrumbs.vue';
 import { ChunkedUploadService } from '@/services/ChunkedUploadService';
+import { useBandRealtime } from '@/composables/useBandRealtime';
 import { useUploadQueue } from '@/composables/useUploadQueue';
 import { useMediaDragDrop } from '@/composables/useMediaDragDrop';
 import { usePage } from '@inertiajs/vue3';
@@ -917,6 +918,12 @@ export default {
   setup(props) {
     const { addFiles, uploadQueue } = useUploadQueue();
     const page = usePage();
+
+    // Library media + quota refresh when band media changes anywhere
+    // (uploads, deletes, renames — band-level signals, folder-agnostic).
+    useBandRealtime(props.currentBandId, {
+      media_file: ['media', 'quota'],
+    });
 
     // Store band_id globally for upload queue
     if (typeof window !== 'undefined') {

--- a/resources/js/Pages/Rehearsals/Index.vue
+++ b/resources/js/Pages/Rehearsals/Index.vue
@@ -199,6 +199,7 @@
 import { Link } from '@inertiajs/vue3';
 import BreezeAuthenticatedLayout from '@/Layouts/Authenticated.vue';
 import Container from '@/Components/Container.vue';
+import { useBandRealtime } from '@/composables/useBandRealtime';
 
 const props = defineProps({
     band: {
@@ -217,5 +218,9 @@ const props = defineProps({
         type: Boolean,
         default: false,
     },
+});
+
+useBandRealtime(props.band ? props.band.id : (props.bands ?? []).map((b) => b.id), {
+    rehearsal: ['schedules'],
 });
 </script>

--- a/resources/js/Pages/Rehearsals/Index.vue
+++ b/resources/js/Pages/Rehearsals/Index.vue
@@ -220,7 +220,11 @@ const props = defineProps({
     },
 });
 
+// Single-band mode renders from `schedules`; the aggregated multi-band view
+// renders from `bands` (each band carries its own `rehearsal_schedules`).
+// Reload both so a rehearsal signal live-updates either layout — the unused
+// prop is an empty collection in each mode, so reloading it is harmless.
 useBandRealtime(props.band ? props.band.id : (props.bands ?? []).map((b) => b.id), {
-    rehearsal: ['schedules'],
+    rehearsal: ['schedules', 'bands'],
 });
 </script>

--- a/resources/js/Pages/Rehearsals/RehearsalDetail.vue
+++ b/resources/js/Pages/Rehearsals/RehearsalDetail.vue
@@ -276,8 +276,9 @@ import { Link } from '@inertiajs/vue3';
 import { DateTime } from 'luxon';
 import BreezeAuthenticatedLayout from '@/Layouts/Authenticated.vue';
 import Container from '@/Components/Container.vue';
+import { useBandRealtime } from '@/composables/useBandRealtime';
 
-defineProps({
+const props = defineProps({
     band: {
         type: Object,
         required: true,
@@ -294,6 +295,10 @@ defineProps({
         type: Boolean,
         default: false,
     },
+});
+
+useBandRealtime(props.band.id, {
+    rehearsal: { props: ['rehearsal'], when: (p) => p.id === props.rehearsal.id },
 });
 
 const formatDate = (date) => {

--- a/resources/js/Pages/Rehearsals/ScheduleDetail.vue
+++ b/resources/js/Pages/Rehearsals/ScheduleDetail.vue
@@ -244,6 +244,7 @@ import { Link } from '@inertiajs/vue3';
 import { DateTime } from 'luxon';
 import BreezeAuthenticatedLayout from '@/Layouts/Authenticated.vue';
 import Container from '@/Components/Container.vue';
+import { useBandRealtime } from '@/composables/useBandRealtime';
 
 const props = defineProps({
     band: {
@@ -258,6 +259,10 @@ const props = defineProps({
         type: Boolean,
         default: false,
     },
+});
+
+useBandRealtime(props.band.id, {
+    rehearsal: ['schedule'],
 });
 
 const sortedRehearsals = computed(() => {

--- a/resources/js/Pages/Songs/Index.vue
+++ b/resources/js/Pages/Songs/Index.vue
@@ -346,9 +346,16 @@
 </template>
 
 <script>
+import { useBandRealtime } from '@/composables/useBandRealtime';
 import { router } from '@inertiajs/vue3';
 
 export default {
+  setup(props) {
+    // Song catalog live-updates; page renders empty without a band.
+    useBandRealtime(props.band ? props.band.id : [], {
+      song: ['songs'],
+    });
+  },
   props: {
     band: { type: Object, default: null },
     songs: { type: Array, default: () => [] },

--- a/resources/js/composables/useBandRealtime.js
+++ b/resources/js/composables/useBandRealtime.js
@@ -1,0 +1,52 @@
+import { onBeforeUnmount, onMounted } from 'vue';
+import { router } from '@inertiajs/vue3';
+import { subscribeBandSignals } from '../realtime/bandChannel';
+
+const DEBOUNCE_MS = 300;
+
+function normalize(entry) {
+	return Array.isArray(entry) ? { props: entry, when: null } : entry;
+}
+
+/**
+ * Page-level opt-in to band realtime signals: maps wire models to the
+ * Inertia props to partial-reload. Signals arriving within the debounce
+ * window coalesce into one router.reload with the union of their props.
+ *
+ * useBandRealtime(band.id, { bookings: ['bookings'] })
+ * useBandRealtime(band.id, { bookings: { props: ['booking'], when: p => p.id === booking.id } })
+ */
+export function useBandRealtime(bandIdOrIds, reloadMap = {}, options = {}) {
+	let unsubscribe = null;
+	let timer = null;
+	const pendingProps = new Set();
+
+	function flush() {
+		timer = null;
+		const only = [...pendingProps];
+		pendingProps.clear();
+		if (only.length) router.reload({ only });
+	}
+
+	function onSignal(payload) {
+		options.onSignal?.(payload);
+
+		const entry = reloadMap[payload.model];
+		if (!entry) return;
+		const { props, when } = normalize(entry);
+		if (when && !when(payload)) return;
+
+		props.forEach((p) => pendingProps.add(p));
+		if (!timer) timer = setTimeout(flush, DEBOUNCE_MS);
+	}
+
+	onMounted(() => {
+		unsubscribe = subscribeBandSignals(bandIdOrIds, onSignal);
+	});
+
+	onBeforeUnmount(() => {
+		unsubscribe?.();
+		if (timer) clearTimeout(timer);
+		pendingProps.clear();
+	});
+}

--- a/resources/js/realtime/bandChannel.js
+++ b/resources/js/realtime/bandChannel.js
@@ -4,6 +4,8 @@
 // overlapping lifecycles — an Inertia page transition where the incoming
 // page subscribes to band N before the outgoing page unmounts — can never
 // Echo.leave() a channel someone still listens to.
+// Each subscription wraps the handler in a unique closure, preventing
+// accidental deduplication if the same function reference is subscribed twice.
 
 export const BAND_EVENT = '.band.data-changed';
 
@@ -36,6 +38,8 @@ function ensureChannel(bandId) {
 /**
  * Subscribe onSignal to one or more band channels.
  * Returns an unsubscribe function (idempotent).
+ * Each subscription registers a unique wrapper closure, so handler identity
+ * can never collide even if the same function reference is subscribed twice.
  */
 export function subscribeBandSignals(bandIds, onSignal) {
 	const ids = (Array.isArray(bandIds) ? bandIds : [bandIds]).filter(
@@ -46,16 +50,17 @@ export function subscribeBandSignals(bandIds, onSignal) {
 	const entries = ids.map((id) => {
 		const entry = ensureChannel(id);
 		entry.count += 1;
-		entry.handlers.add(onSignal);
-		return { id, entry };
+		const handler = (payload) => onSignal(payload);
+		entry.handlers.add(handler);
+		return { id, entry, handler };
 	});
 
 	let done = false;
 	return () => {
 		if (done) return;
 		done = true;
-		entries.forEach(({ id, entry }) => {
-			entry.handlers.delete(onSignal);
+		entries.forEach(({ id, entry, handler }) => {
+			entry.handlers.delete(handler);
 			entry.count -= 1;
 			if (entry.count <= 0) {
 				channels.delete(id);

--- a/resources/js/realtime/bandChannel.js
+++ b/resources/js/realtime/bandChannel.js
@@ -1,0 +1,73 @@
+// Refcounted subscriptions to the thin band-data-changed broadcast.
+//
+// Every consumer (page composable, layout bell) goes through here so that
+// overlapping lifecycles — an Inertia page transition where the incoming
+// page subscribes to band N before the outgoing page unmounts — can never
+// Echo.leave() a channel someone still listens to.
+
+export const BAND_EVENT = '.band.data-changed';
+
+// bandId -> { count, handlers: Set<fn> }
+const channels = new Map();
+
+function channelName(bandId) {
+	return `band.${bandId}`;
+}
+
+function ensureChannel(bandId) {
+	let entry = channels.get(bandId);
+	if (entry) return entry;
+
+	entry = { count: 0, handlers: new Set() };
+	channels.set(bandId, entry);
+
+	window.Echo.private(channelName(bandId))
+		.subscribed(() => {})
+		.error((err) => {
+			console.warn(`[bandChannel] auth/subscribe error on ${channelName(bandId)}`, err);
+		})
+		.listen(BAND_EVENT, (payload) => {
+			entry.handlers.forEach((fn) => fn(payload));
+		});
+
+	return entry;
+}
+
+/**
+ * Subscribe onSignal to one or more band channels.
+ * Returns an unsubscribe function (idempotent).
+ */
+export function subscribeBandSignals(bandIds, onSignal) {
+	const ids = (Array.isArray(bandIds) ? bandIds : [bandIds]).filter(
+		(id) => id !== null && id !== undefined,
+	);
+	if (!ids.length || !window.Echo) return () => {};
+
+	const entries = ids.map((id) => {
+		const entry = ensureChannel(id);
+		entry.count += 1;
+		entry.handlers.add(onSignal);
+		return { id, entry };
+	});
+
+	let done = false;
+	return () => {
+		if (done) return;
+		done = true;
+		entries.forEach(({ id, entry }) => {
+			entry.handlers.delete(onSignal);
+			entry.count -= 1;
+			if (entry.count <= 0) {
+				channels.delete(id);
+				window.Echo?.leave(channelName(id));
+			}
+		});
+	};
+}
+
+/**
+ * Reset the module state (for testing only).
+ */
+export function __resetBandChannelState() {
+	channels.clear();
+}

--- a/resources/js/realtime/bellRefresher.js
+++ b/resources/js/realtime/bellRefresher.js
@@ -1,0 +1,50 @@
+const DEBOUNCE_MS = 300;
+
+/**
+ * Turns band signals into a live notifications bell: debounced reload of
+ * the shared `auth` prop (which carries auth.user.notifications), and a
+ * toast when the unseen count grew — the one loud surface of realtime.
+ *
+ * All effects are injected so the layout stays glue and this stays testable:
+ *   reloadAuth({ only: ['auth'], onSuccess })  — Inertia partial reload
+ *   getUnseenCount()                           — current unseen count
+ *   getLatest()                                — newest notification object
+ *   toast(options)                             — PrimeVue toast add()
+ */
+export function createBellRefresher({ reloadAuth, getUnseenCount, getLatest, toast }) {
+	let timer = null;
+	let disposed = false;
+
+	function refresh() {
+		timer = null;
+		const before = getUnseenCount();
+		reloadAuth({
+			only: ['auth'],
+			onSuccess: () => {
+				if (disposed) return;
+				const after = getUnseenCount();
+				if (after > before) {
+					const latest = getLatest();
+					toast({
+						severity: 'info',
+						summary: 'New notification',
+						detail: latest?.data?.text || 'Something changed in your band.',
+						life: 6000,
+					});
+				}
+			},
+		});
+	}
+
+	return {
+		onSignal() {
+			if (disposed) return;
+			if (!timer) timer = setTimeout(refresh, DEBOUNCE_MS);
+		},
+		dispose() {
+			disposed = true;
+			if (timer) clearTimeout(timer);
+			timer = null;
+		},
+	};
+}

--- a/resources/js/tests/composables/useBandRealtime.test.js
+++ b/resources/js/tests/composables/useBandRealtime.test.js
@@ -1,0 +1,88 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { defineComponent, h } from 'vue';
+import { mount } from '@vue/test-utils';
+import { installEchoMock } from '../mocks/echo';
+import { BAND_EVENT, __resetBandChannelState } from '../../realtime/bandChannel';
+import { useBandRealtime } from '../../composables/useBandRealtime';
+
+vi.mock('@inertiajs/vue3', () => ({
+	router: { reload: vi.fn() },
+}));
+import { router } from '@inertiajs/vue3';
+
+function mountWith(bandIds, reloadMap, options) {
+	const Host = defineComponent({
+		setup() {
+			useBandRealtime(bandIds, reloadMap, options);
+			return () => h('div');
+		},
+	});
+	return mount(Host);
+}
+
+describe('useBandRealtime', () => {
+	let echo;
+	beforeEach(() => {
+		vi.useFakeTimers();
+		__resetBandChannelState();
+		echo = installEchoMock();
+		router.reload.mockClear();
+	});
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it('coalesces a burst into one partial reload with the union of props', () => {
+		mountWith(1, { bookings: ['bookings'], events: ['events'] });
+
+		echo.fire('band.1', BAND_EVENT, { model: 'bookings', id: 1, action: 'updated' });
+		echo.fire('band.1', BAND_EVENT, { model: 'bookings', id: 2, action: 'updated' });
+		echo.fire('band.1', BAND_EVENT, { model: 'events', id: 3, action: 'created' });
+		expect(router.reload).not.toHaveBeenCalled();
+
+		vi.advanceTimersByTime(300);
+		expect(router.reload).toHaveBeenCalledTimes(1);
+		const only = router.reload.mock.calls[0][0].only;
+		expect([...only].sort()).toEqual(['bookings', 'events']);
+	});
+
+	it('ignores models missing from the map', () => {
+		mountWith(1, { bookings: ['bookings'] });
+		echo.fire('band.1', BAND_EVENT, { model: 'roster', id: 1, action: 'updated' });
+		vi.advanceTimersByTime(300);
+		expect(router.reload).not.toHaveBeenCalled();
+	});
+
+	it('honors a when() predicate (detail pages)', () => {
+		mountWith(1, {
+			bookings: { props: ['booking'], when: (p) => p.id === 42 },
+		});
+
+		echo.fire('band.1', BAND_EVENT, { model: 'bookings', id: 7, action: 'updated' });
+		vi.advanceTimersByTime(300);
+		expect(router.reload).not.toHaveBeenCalled();
+
+		echo.fire('band.1', BAND_EVENT, { model: 'bookings', id: 42, action: 'updated' });
+		vi.advanceTimersByTime(300);
+		expect(router.reload).toHaveBeenCalledTimes(1);
+		expect(router.reload.mock.calls[0][0].only).toEqual(['booking']);
+	});
+
+	it('calls options.onSignal for every signal, undebounced', () => {
+		const onSignal = vi.fn();
+		mountWith(1, {}, { onSignal });
+		echo.fire('band.1', BAND_EVENT, { model: 'event_member', id: 1, action: 'created' });
+		echo.fire('band.1', BAND_EVENT, { model: 'rehearsal', id: 2, action: 'deleted' });
+		expect(onSignal).toHaveBeenCalledTimes(2);
+	});
+
+	it('unsubscribes and cancels pending reloads on unmount', () => {
+		const wrapper = mountWith(1, { bookings: ['bookings'] });
+		echo.fire('band.1', BAND_EVENT, { model: 'bookings', id: 1, action: 'updated' });
+		wrapper.unmount();
+
+		vi.advanceTimersByTime(300);
+		expect(router.reload).not.toHaveBeenCalled();
+		expect(echo.leaveCalls).toEqual(['band.1']);
+	});
+});

--- a/resources/js/tests/mocks/echo.js
+++ b/resources/js/tests/mocks/echo.js
@@ -1,0 +1,36 @@
+// Minimal window.Echo stand-in: records private()/leave() calls and lets
+// tests fire events into registered listeners.
+export function installEchoMock() {
+	const channels = new Map(); // name -> { listeners: Map(event -> [cb]) }
+
+	const echo = {
+		privateCalls: [],
+		leaveCalls: [],
+		private(name) {
+			this.privateCalls.push(name);
+			if (!channels.has(name)) channels.set(name, { listeners: new Map() });
+			const entry = channels.get(name);
+			const channel = {
+				listen(event, cb) {
+					if (!entry.listeners.has(event)) entry.listeners.set(event, []);
+					entry.listeners.get(event).push(cb);
+					return channel;
+				},
+				subscribed() { return channel; },
+				error() { return channel; },
+			};
+			return channel;
+		},
+		leave(name) {
+			this.leaveCalls.push(name);
+			channels.delete(name);
+		},
+		fire(name, event, payload) {
+			const entry = channels.get(name);
+			(entry?.listeners.get(event) ?? []).forEach((cb) => cb(payload));
+		},
+	};
+
+	window.Echo = echo;
+	return echo;
+}

--- a/resources/js/tests/realtime/bandChannel.test.js
+++ b/resources/js/tests/realtime/bandChannel.test.js
@@ -67,4 +67,19 @@ describe('subscribeBandSignals', () => {
 		const off = subscribeBandSignals([1], () => {});
 		off(); // must not throw
 	});
+
+	it('same handler function subscribed twice delivers to both until each unsubscribes', () => {
+		const seen = [];
+		const shared = (p) => seen.push(p);
+		const offA = subscribeBandSignals(1, shared);
+		subscribeBandSignals(1, shared);
+
+		echo.fire('band.1', BAND_EVENT, { model: 'bookings', id: 1, action: 'updated' });
+		expect(seen).toHaveLength(2); // both subscriptions live
+
+		offA();
+		echo.fire('band.1', BAND_EVENT, { model: 'bookings', id: 2, action: 'updated' });
+		expect(seen).toHaveLength(3); // second subscription still delivers
+		expect(echo.leaveCalls).toEqual([]);
+	});
 });

--- a/resources/js/tests/realtime/bandChannel.test.js
+++ b/resources/js/tests/realtime/bandChannel.test.js
@@ -1,0 +1,70 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { installEchoMock } from '../mocks/echo';
+import { subscribeBandSignals, BAND_EVENT, __resetBandChannelState } from '../../realtime/bandChannel';
+
+describe('subscribeBandSignals', () => {
+	let echo;
+	beforeEach(() => {
+		__resetBandChannelState();
+		echo = installEchoMock();
+	});
+
+	it('subscribes each band channel and delivers signals', () => {
+		const seen = [];
+		subscribeBandSignals([1, 2], (p) => seen.push(p));
+
+		expect(echo.privateCalls).toEqual(['band.1', 'band.2']);
+		echo.fire('band.1', BAND_EVENT, { model: 'bookings', id: 5, action: 'updated' });
+		expect(seen).toEqual([{ model: 'bookings', id: 5, action: 'updated' }]);
+	});
+
+	it('accepts a single band id and no-ops on empty input', () => {
+		subscribeBandSignals(7, () => {});
+		expect(echo.privateCalls).toEqual(['band.7']);
+
+		const off = subscribeBandSignals([], () => {});
+		expect(typeof off).toBe('function');
+		off(); // must not throw
+	});
+
+	it('refcounts: overlapping subscribers share a channel; leave only at zero', () => {
+		const offA = subscribeBandSignals(1, () => {});
+		const offB = subscribeBandSignals(1, () => {});
+		expect(echo.privateCalls).toEqual(['band.1']); // one Echo subscription
+
+		offA();
+		expect(echo.leaveCalls).toEqual([]); // B still listening
+
+		offB();
+		expect(echo.leaveCalls).toEqual(['band.1']);
+	});
+
+	it('a resubscribe during overlap (Inertia page transition) keeps the channel live', () => {
+		const offOldPage = subscribeBandSignals(1, () => {});
+		const seen = [];
+		subscribeBandSignals(1, (p) => seen.push(p)); // new page subscribes first
+		offOldPage(); // old page unmounts after
+
+		echo.fire('band.1', BAND_EVENT, { model: 'events', id: 9, action: 'created' });
+		expect(echo.leaveCalls).toEqual([]);
+		expect(seen).toHaveLength(1);
+	});
+
+	it('unsubscribe stops delivery to that subscriber only', () => {
+		const a = [];
+		const b = [];
+		const offA = subscribeBandSignals(1, (p) => a.push(p));
+		subscribeBandSignals(1, (p) => b.push(p));
+		offA();
+
+		echo.fire('band.1', BAND_EVENT, { model: 'roster', id: 3, action: 'deleted' });
+		expect(a).toHaveLength(0);
+		expect(b).toHaveLength(1);
+	});
+
+	it('is a no-op without window.Echo', () => {
+		delete window.Echo;
+		const off = subscribeBandSignals([1], () => {});
+		off(); // must not throw
+	});
+});

--- a/resources/js/tests/realtime/bandChannel.test.js
+++ b/resources/js/tests/realtime/bandChannel.test.js
@@ -82,4 +82,10 @@ describe('subscribeBandSignals', () => {
 		expect(seen).toHaveLength(3); // second subscription still delivers
 		expect(echo.leaveCalls).toEqual([]);
 	});
+
+	it('pins the wire event name to the backend broadcastAs contract', () => {
+		// Must match BandDataChanged::broadcastAs() = 'band.data-changed',
+		// listened with Echo's leading-dot convention for custom names.
+		expect(BAND_EVENT).toBe('.band.data-changed');
+	});
 });

--- a/resources/js/tests/realtime/bellRefresher.test.js
+++ b/resources/js/tests/realtime/bellRefresher.test.js
@@ -1,0 +1,56 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { createBellRefresher } from '../../realtime/bellRefresher';
+
+describe('createBellRefresher', () => {
+	beforeEach(() => vi.useFakeTimers());
+	afterEach(() => vi.useRealTimers());
+
+	function make(counts) {
+		let call = 0;
+		const toast = vi.fn();
+		const reloadAuth = vi.fn((opts) => opts.onSuccess?.());
+		const refresher = createBellRefresher({
+			reloadAuth,
+			getUnseenCount: () => counts[Math.min(call++, counts.length - 1)],
+			getLatest: () => ({ data: { text: 'Booking updated' } }),
+			toast,
+		});
+		return { refresher, toast, reloadAuth };
+	}
+
+	it('debounces signals into one auth reload', () => {
+		const { refresher, reloadAuth } = make([0, 0]);
+		refresher.onSignal();
+		refresher.onSignal();
+		refresher.onSignal();
+		expect(reloadAuth).not.toHaveBeenCalled();
+
+		vi.advanceTimersByTime(300);
+		expect(reloadAuth).toHaveBeenCalledTimes(1);
+		expect(reloadAuth.mock.calls[0][0].only).toEqual(['auth']);
+	});
+
+	it('toasts when the unseen count increases across the reload', () => {
+		// count read before reload: 1; after reload: 2
+		const { refresher, toast } = make([1, 2]);
+		refresher.onSignal();
+		vi.advanceTimersByTime(300);
+		expect(toast).toHaveBeenCalledTimes(1);
+		expect(toast.mock.calls[0][0].detail).toBe('Booking updated');
+	});
+
+	it('stays silent when the count does not increase', () => {
+		const { refresher, toast } = make([2, 2]);
+		refresher.onSignal();
+		vi.advanceTimersByTime(300);
+		expect(toast).not.toHaveBeenCalled();
+	});
+
+	it('dispose cancels a pending refresh', () => {
+		const { refresher, reloadAuth } = make([0, 0]);
+		refresher.onSignal();
+		refresher.dispose();
+		vi.advanceTimersByTime(300);
+		expect(reloadAuth).not.toHaveBeenCalled();
+	});
+});

--- a/routes/channels.php
+++ b/routes/channels.php
@@ -2,8 +2,6 @@
 
 use Illuminate\Support\Facades\Broadcast;
 
-// Allow Sanctum token-authenticated requests (mobile app) to authorize private channels
-Broadcast::routes(['middleware' => ['auth:sanctum']]);
 
 /*
 |--------------------------------------------------------------------------

--- a/tests/Feature/BookingShowPayoutEstimateTest.php
+++ b/tests/Feature/BookingShowPayoutEstimateTest.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\BandPayoutConfig;
+use App\Models\Bands;
+use App\Models\Bookings;
+use App\Models\Payout;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Inertia\Testing\AssertableInertia;
+use Tests\TestCase;
+
+class BookingShowPayoutEstimateTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_show_estimate_uses_the_bookings_stored_config_not_the_active_one(): void
+    {
+        $user = User::factory()->create();
+        $band = Bands::factory()->create();
+        $band->owners()->create(['user_id' => $user->id]);
+        $booking = Bookings::factory()->create(['band_id' => $band->id, 'price' => 1000]);
+
+        $active = BandPayoutConfig::create(['band_id' => $band->id, 'name' => 'Active', 'is_active' => true]);
+        $stored = BandPayoutConfig::create(['band_id' => $band->id, 'name' => 'Chosen', 'is_active' => false]);
+
+        Payout::create([
+            'payable_type' => Bookings::class,
+            'payable_id' => $booking->id,
+            'band_id' => $band->id,
+            'base_amount' => 100000,
+            'adjusted_amount' => 100000,
+            'payout_config_id' => $stored->id,
+        ]);
+
+        // The booking-details estimate must agree with the Payout page: the
+        // stored per-booking config wins over the band's active one.
+        $this->actingAs($user)
+            ->get(route('Booking Details', [$band, $booking]))
+            ->assertInertia(fn (AssertableInertia $page) => $page
+                ->where('payoutConfig.id', $stored->id));
+    }
+
+    public function test_show_estimate_falls_back_to_active_config_without_a_payout(): void
+    {
+        $user = User::factory()->create();
+        $band = Bands::factory()->create();
+        $band->owners()->create(['user_id' => $user->id]);
+        $booking = Bookings::factory()->create(['band_id' => $band->id, 'price' => 1000]);
+
+        $active = BandPayoutConfig::create(['band_id' => $band->id, 'name' => 'Active', 'is_active' => true]);
+
+        $this->actingAs($user)
+            ->get(route('Booking Details', [$band, $booking]))
+            ->assertInertia(fn (AssertableInertia $page) => $page
+                ->where('payoutConfig.id', $active->id));
+    }
+}

--- a/tests/Feature/Broadcasting/BandChannelAuthTest.php
+++ b/tests/Feature/Broadcasting/BandChannelAuthTest.php
@@ -58,6 +58,25 @@ class BandChannelAuthTest extends TestCase
         $this->assertIsString($response->json('auth'));
     }
 
+    public function test_web_session_user_can_subscribe_via_stateful_auth(): void
+    {
+        $user = User::factory()->create();
+        $band = Bands::factory()->create();
+        $band->owners()->create(['user_id' => $user->id]);
+
+        // Browser flow: session auth + stateful referer (no Bearer token).
+        // Sanctum only consults the web guard for stateful first-party hosts.
+        $response = $this->actingAs($user)
+            ->withHeader('Referer', config('app.url'))
+            ->postJson('/broadcasting/auth', [
+                'socket_id'    => '123.456',
+                'channel_name' => 'private-band.' . $band->id,
+            ]);
+
+        $response->assertOk();
+        $this->assertIsString($response->json('auth'));
+    }
+
     public function test_non_member_is_rejected(): void
     {
         $user = User::factory()->create();

--- a/tests/Feature/Broadcasting/BandChannelAuthTest.php
+++ b/tests/Feature/Broadcasting/BandChannelAuthTest.php
@@ -64,8 +64,9 @@ class BandChannelAuthTest extends TestCase
         $band = Bands::factory()->create();
         $band->owners()->create(['user_id' => $user->id]);
 
-        // Browser flow: session auth + stateful referer (no Bearer token).
-        // Sanctum only consults the web guard for stateful first-party hosts.
+        // Browser flow: session auth, no Bearer token. Sanctum's guard falls
+        // back to the web guard, which the `web` middleware group's session
+        // makes available.
         $response = $this->actingAs($user)
             ->withHeader('Referer', config('app.url'))
             ->postJson('/broadcasting/auth', [

--- a/tests/Feature/Broadcasting/BroadcastsBandChangesTest.php
+++ b/tests/Feature/Broadcasting/BroadcastsBandChangesTest.php
@@ -180,6 +180,39 @@ class BroadcastsBandChangesTest extends TestCase
         Event::assertNotDispatched(BandDataChanged::class);
     }
 
+    public function test_switching_payout_configuration_broadcasts(): void
+    {
+        $band = Bands::factory()->create();
+        $booking = Bookings::factory()->create(['band_id' => $band->id]);
+        $config = \App\Models\BandPayoutConfig::create([
+            'band_id' => $band->id,
+            'name' => 'Realtime config',
+            'is_active' => true,
+        ]);
+        $payout = Payout::create([
+            'payable_type' => Bookings::class,
+            'payable_id' => $booking->id,
+            'band_id' => $band->id,
+            'base_amount' => 10000,
+            'adjusted_amount' => 10000,
+        ]);
+
+        // The config-switch POST writes payout_config_id + calculation_result
+        // together; the recomputed cache is ignored but the switch itself
+        // must reach other clients (regression: the first ignore list
+        // silenced this exact mutation).
+        Event::fake([BandDataChanged::class]);
+        $payout->update([
+            'payout_config_id' => $config->id,
+            'calculation_result' => ['total' => 1.0],
+        ]);
+
+        Event::assertDispatched(
+            BandDataChanged::class,
+            fn (BandDataChanged $e) => $e->model === 'payout' && $e->action === 'updated',
+        );
+    }
+
     public function test_meaningful_payout_change_still_broadcasts(): void
     {
         $band = Bands::factory()->create();

--- a/tests/Feature/Broadcasting/BroadcastsBandChangesTest.php
+++ b/tests/Feature/Broadcasting/BroadcastsBandChangesTest.php
@@ -8,8 +8,11 @@ use App\Models\Bookings;
 use App\Models\EventMember;
 use App\Models\Events;
 use App\Models\EventTypes;
+use App\Models\Payout;
+use App\Models\PayoutAdjustment;
 use App\Models\Rehearsal;
 use App\Models\Roster;
+use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Event;
 use Tests\TestCase;
@@ -130,6 +133,60 @@ class BroadcastsBandChangesTest extends TestCase
         Event::assertDispatched(
             BandDataChanged::class,
             fn (BandDataChanged $e) => $e->model === 'roster' && $e->id === $roster->id && $e->bandId === $band->id,
+        );
+    }
+
+    public function test_payment_on_a_booking_broadcasts_with_booking_parent(): void
+    {
+        Event::fake([BandDataChanged::class]);
+        $band = Bands::factory()->create();
+        $booking = Bookings::factory()->create(['band_id' => $band->id]);
+
+        $payment = $booking->payments()->create([
+            'name' => 'Deposit',
+            'amount' => 5000,
+            'date' => now(),
+            'band_id' => $band->id,
+        ]);
+
+        Event::assertDispatched(
+            BandDataChanged::class,
+            fn (BandDataChanged $e) => $e->model === 'payments'
+                && $e->id === $payment->id
+                && $e->bandId === $band->id
+                && $e->action === 'created'
+                && $e->parent === ['model' => 'bookings', 'id' => $booking->id],
+        );
+    }
+
+    public function test_payout_adjustment_resolves_band_through_its_payout(): void
+    {
+        Event::fake([BandDataChanged::class]);
+        $band = Bands::factory()->create();
+        $booking = Bookings::factory()->create(['band_id' => $band->id]);
+        $user = User::factory()->create();
+
+        $payout = Payout::create([
+            'payable_type' => Bookings::class,
+            'payable_id' => $booking->id,
+            'band_id' => $band->id,
+            'base_amount' => 10000,
+            'adjusted_amount' => 10000,
+        ]);
+
+        $adjustment = PayoutAdjustment::create([
+            'payout_id' => $payout->id,
+            'created_by' => $user->id,
+            'amount' => 500,
+            'description' => 'Bonus',
+        ]);
+
+        Event::assertDispatched(
+            BandDataChanged::class,
+            fn (BandDataChanged $e) => $e->model === 'payout_adjustment'
+                && $e->id === $adjustment->id
+                && $e->bandId === $band->id
+                && $e->parent === ['model' => 'bookings', 'id' => $booking->id],
         );
     }
 }

--- a/tests/Feature/Broadcasting/BroadcastsBandChangesTest.php
+++ b/tests/Feature/Broadcasting/BroadcastsBandChangesTest.php
@@ -180,6 +180,33 @@ class BroadcastsBandChangesTest extends TestCase
         Event::assertNotDispatched(BandDataChanged::class);
     }
 
+    public function test_payout_page_renders_are_silent_once_config_converged(): void
+    {
+        $user = User::factory()->create();
+        $band = Bands::factory()->create();
+        $band->owners()->create(['user_id' => $user->id]);
+        $booking = Bookings::factory()->create(['band_id' => $band->id, 'price' => 1000]);
+        \App\Models\BandPayoutConfig::create(['band_id' => $band->id, 'name' => 'Active', 'is_active' => true]);
+        Payout::create([
+            'payable_type' => Bookings::class,
+            'payable_id' => $booking->id,
+            'band_id' => $band->id,
+            'base_amount' => 100000,
+            'adjusted_amount' => 100000,
+        ]);
+
+        // First render adopts the active config — one settling signal is fine.
+        $this->actingAs($user)->get(route('Booking Payout', [$band, $booking]))->assertOk();
+
+        // Once converged, every further render must be broadcast-silent.
+        // This pins the exact cycle of the production reload-loop incident:
+        // signal -> client partial reload -> this GET re-saves its cache.
+        Event::fake([BandDataChanged::class]);
+        $this->actingAs($user)->get(route('Booking Payout', [$band, $booking]))->assertOk();
+
+        Event::assertNotDispatched(BandDataChanged::class);
+    }
+
     public function test_switching_payout_configuration_broadcasts(): void
     {
         $band = Bands::factory()->create();

--- a/tests/Feature/Broadcasting/BroadcastsBandChangesTest.php
+++ b/tests/Feature/Broadcasting/BroadcastsBandChangesTest.php
@@ -180,6 +180,46 @@ class BroadcastsBandChangesTest extends TestCase
         Event::assertNotDispatched(BandDataChanged::class);
     }
 
+    public function test_song_and_chart_assets_broadcast(): void
+    {
+        Event::fake([BandDataChanged::class]);
+        $band = Bands::factory()->create();
+
+        $song = \App\Models\Song::create([
+            'band_id' => $band->id,
+            'title' => 'Realtime Anthem',
+        ]);
+        Event::assertDispatched(
+            BandDataChanged::class,
+            fn (BandDataChanged $e) => $e->model === 'song' && $e->id === $song->id && $e->bandId === $band->id,
+        );
+
+        $chart = \App\Models\Charts::create([
+            'band_id' => $band->id,
+            'title' => 'Realtime Chart',
+        ]);
+        Event::assertDispatched(
+            BandDataChanged::class,
+            fn (BandDataChanged $e) => $e->model === 'charts' && $e->id === $chart->id && $e->bandId === $band->id,
+        );
+
+        $uploadTypeId = \DB::table('upload_types')->insertGetId(['name' => 'pdf']);
+        $upload = \App\Models\ChartUploads::create([
+            'chart_id' => $chart->id,
+            'upload_type_id' => $uploadTypeId,
+            'displayName' => 'Horns.pdf',
+            'url' => 'charts/horns.pdf',
+            'fileType' => 'pdf',
+            'notes' => '',
+        ]);
+        Event::assertDispatched(
+            BandDataChanged::class,
+            fn (BandDataChanged $e) => $e->model === 'chart_uploads'
+                && $e->bandId === $band->id
+                && $e->parent === ['model' => 'charts', 'id' => $chart->id],
+        );
+    }
+
     public function test_media_file_create_and_delete_broadcast(): void
     {
         \Illuminate\Support\Facades\Storage::fake('local');

--- a/tests/Feature/Broadcasting/BroadcastsBandChangesTest.php
+++ b/tests/Feature/Broadcasting/BroadcastsBandChangesTest.php
@@ -159,6 +159,59 @@ class BroadcastsBandChangesTest extends TestCase
         );
     }
 
+    public function test_payout_cache_recalculation_does_not_broadcast(): void
+    {
+        $band = Bands::factory()->create();
+        $booking = Bookings::factory()->create(['band_id' => $band->id]);
+        $payout = Payout::create([
+            'payable_type' => Bookings::class,
+            'payable_id' => $booking->id,
+            'band_id' => $band->id,
+            'base_amount' => 10000,
+            'adjusted_amount' => 10000,
+        ]);
+
+        // The Payout page GET rewrites these derived caches on every render.
+        // If this dispatched, signal -> partial reload -> re-save would loop
+        // the page forever (the production incident this test pins).
+        Event::fake([BandDataChanged::class]);
+        $payout->update(['calculation_result' => ['total' => 100.0]]);
+
+        Event::assertNotDispatched(BandDataChanged::class);
+    }
+
+    public function test_meaningful_payout_change_still_broadcasts(): void
+    {
+        $band = Bands::factory()->create();
+        $booking = Bookings::factory()->create(['band_id' => $band->id]);
+        $payout = Payout::create([
+            'payable_type' => Bookings::class,
+            'payable_id' => $booking->id,
+            'band_id' => $band->id,
+            'base_amount' => 10000,
+            'adjusted_amount' => 10000,
+        ]);
+
+        Event::fake([BandDataChanged::class]);
+        $payout->update(['adjusted_amount' => 12000]);
+
+        Event::assertDispatched(
+            BandDataChanged::class,
+            fn (BandDataChanged $e) => $e->model === 'payout' && $e->action === 'updated',
+        );
+    }
+
+    public function test_timestamp_only_touch_does_not_broadcast(): void
+    {
+        $band = Bands::factory()->create();
+        $booking = Bookings::factory()->create(['band_id' => $band->id]);
+
+        Event::fake([BandDataChanged::class]);
+        $booking->touch();
+
+        Event::assertNotDispatched(BandDataChanged::class);
+    }
+
     public function test_payout_adjustment_resolves_band_through_its_payout(): void
     {
         Event::fake([BandDataChanged::class]);

--- a/tests/Feature/Broadcasting/BroadcastsBandChangesTest.php
+++ b/tests/Feature/Broadcasting/BroadcastsBandChangesTest.php
@@ -180,6 +180,41 @@ class BroadcastsBandChangesTest extends TestCase
         Event::assertNotDispatched(BandDataChanged::class);
     }
 
+    public function test_media_file_create_and_delete_broadcast(): void
+    {
+        \Illuminate\Support\Facades\Storage::fake('local');
+        Event::fake([BandDataChanged::class]);
+        $band = Bands::factory()->create();
+        $user = User::factory()->create();
+
+        $media = \App\Models\MediaFile::create([
+            'band_id' => $band->id,
+            'user_id' => $user->id,
+            'filename' => 'poster.jpg',
+            'stored_filename' => 'media/poster.jpg',
+            'mime_type' => 'image/jpeg',
+            'file_size' => 1024,
+            'disk' => 'local',
+            'media_type' => 'image',
+            'folder_path' => '/',
+        ]);
+
+        Event::assertDispatched(
+            BandDataChanged::class,
+            fn (BandDataChanged $e) => $e->model === 'media_file'
+                && $e->id === $media->id
+                && $e->bandId === $band->id
+                && $e->action === 'created',
+        );
+
+        $media->delete();
+
+        Event::assertDispatched(
+            BandDataChanged::class,
+            fn (BandDataChanged $e) => $e->model === 'media_file' && $e->action === 'deleted',
+        );
+    }
+
     public function test_payout_page_renders_are_silent_once_config_converged(): void
     {
         $user = User::factory()->create();

--- a/tests/Feature/EventShowUserPayoutTest.php
+++ b/tests/Feature/EventShowUserPayoutTest.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\BandPayoutConfig;
+use App\Models\Bands;
+use App\Models\Bookings;
+use App\Models\Events;
+use App\Models\EventTypes;
+use App\Models\Payout;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Inertia\Testing\AssertableInertia;
+use Tests\TestCase;
+
+class EventShowUserPayoutTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_user_payout_is_computed_fresh_not_read_from_the_stale_cache(): void
+    {
+        $user = User::factory()->create();
+        $band = Bands::factory()->create();
+        $band->owners()->create(['user_id' => $user->id]);
+        $booking = Bookings::factory()->create(['band_id' => $band->id, 'price' => 1000]);
+        $config = BandPayoutConfig::create(['band_id' => $band->id, 'name' => 'Chosen', 'is_active' => true]);
+
+        $eventType = EventTypes::factory()->create();
+        $event = Events::factory()->create([
+            'eventable_id' => $booking->id,
+            'eventable_type' => 'App\\Models\\Bookings',
+            'event_type_id' => $eventType->id,
+        ]);
+
+        // Poison the cache: if the page read calculation_result, the user
+        // would see this number. The fresh estimate must win.
+        Payout::create([
+            'payable_type' => Bookings::class,
+            'payable_id' => $booking->id,
+            'band_id' => $band->id,
+            'base_amount' => 100000,
+            'adjusted_amount' => 100000,
+            'payout_config_id' => $config->id,
+            'calculation_result' => [
+                'member_payouts' => [
+                    ['user_id' => $user->id, 'name' => $user->name, 'amount' => 12345.67],
+                ],
+            ],
+        ]);
+
+        // Ground truth: the booking-details estimate (fresh, shared estimator).
+        $bookingPage = $this->actingAs($user)
+            ->get(route('Booking Details', [$band, $booking]));
+        $bookingProps = AssertableInertia::fromTestResponse($bookingPage)->toArray()['props'];
+        $freshAmount = collect($bookingProps['payoutResult']['member_payouts'] ?? [])
+            ->firstWhere('user_id', $user->id)['amount'] ?? 0.0;
+
+        $this->actingAs($user)
+            ->get(route('events.show', $event->key))
+            ->assertInertia(fn (AssertableInertia $page) => $page
+                ->where('userPayout', fn ($v) => (float) $v === round($freshAmount, 2)
+                    && (float) $v !== 12345.67));
+    }
+}

--- a/tests/Feature/InertiaSharedBandIdsTest.php
+++ b/tests/Feature/InertiaSharedBandIdsTest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Bands;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Inertia\Testing\AssertableInertia;
+use Tests\TestCase;
+
+class InertiaSharedBandIdsTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_shared_props_include_all_band_ids_owner_member_and_sub(): void
+    {
+        $user = User::factory()->create();
+        $owned = Bands::factory()->create();
+        $owned->owners()->create(['user_id' => $user->id]);
+        $memberOf = Bands::factory()->create();
+        $memberOf->members()->create(['user_id' => $user->id]);
+
+        $this->actingAs($user)
+            ->get(route('dashboard'))
+            ->assertInertia(fn (AssertableInertia $page) => $page
+                ->where('auth.user.band_ids', fn ($ids) => collect($ids)
+                    ->sort()->values()->all() === collect([$owned->id, $memberOf->id])
+                    ->sort()->values()->all()));
+    }
+}

--- a/tests/Feature/InertiaSharedBandIdsTest.php
+++ b/tests/Feature/InertiaSharedBandIdsTest.php
@@ -19,12 +19,16 @@ class InertiaSharedBandIdsTest extends TestCase
         $owned->owners()->create(['user_id' => $user->id]);
         $memberOf = Bands::factory()->create();
         $memberOf->members()->create(['user_id' => $user->id]);
+        // allBands() is what folds subs into the shared band_ids prop, so the
+        // sub case must be exercised or a regression dropping subs slips through.
+        $subOf = Bands::factory()->create();
+        $user->bandSub()->attach($subOf->id);
 
         $this->actingAs($user)
             ->get(route('dashboard'))
             ->assertInertia(fn (AssertableInertia $page) => $page
                 ->where('auth.user.band_ids', fn ($ids) => collect($ids)
-                    ->sort()->values()->all() === collect([$owned->id, $memberOf->id])
+                    ->sort()->values()->all() === collect([$owned->id, $memberOf->id, $subOf->id])
                     ->sort()->values()->all()));
     }
 }


### PR DESCRIPTION
## Web (Vue/Inertia) realtime consumer for `band.data-changed`

Makes web clients live-update on the thin band-scoped broadcasts introduced by the backend realtime layer (#516 + the payments/payout backend commits included here). Web now mirrors the mobile invalidation layer: a signal arrives, the affected pages silently refetch, and the notifications bell updates live and visibly.

Depends on the broadcast layer in **#516** (already merged to staging). This branch adds the remaining backend broadcasts for **payments/payout** models plus the entire web consumer.

### Backend (additive to #516)
- `Payments`, `Payout`, `PayoutAdjustment`, `BandPayoutConfig` now broadcast `BandDataChanged` (with booking parent where applicable).
- **Asset models** `Song`, `MediaFile`, `Charts`, `ChartUploads` also gain the `BroadcastsBandChanges` trait (each covered by new tests). Runtime effect: every create/update/delete on these dispatches a queued broadcast to `band.{bandId}`, whose audience is anyone with `canRead('events', bandId)` (including subs) — the same audience as all other band signals.
- `BroadcastsBandChanges` gains `broadcastHasMeaningfulChanges()` / `broadcastIgnoreDirty()` — the loop-breaker for read paths that write derived caches (`Payout.calculation_result`). Config-id switches still broadcast; only the calculation cache is ignored.
- `/broadcasting/auth` serves both web sessions and mobile tokens (single `['web','auth:sanctum']` registration + CSRF exempt).

### Web consumer
- **`realtime/bandChannel.js`** — refcounted Echo subscription module, unique wrapper per subscription.
- **`composables/useBandRealtime.js`** — debounced signal → `router.reload({ only: [...] })` per-page map, with `when` predicates and an `onSignal` hook.
- **`realtime/bellRefresher.js`** — the notifications bell refreshes badge + toasts new items live.
- Page maps wired across Bookings (Index/Show/Contacts/Finances/Contract/Events/Lineup/Media/Payout/History), Dashboard, Events, Band/Rosters, Finances/PayoutFlow, Rehearsals, Media, Songs, Charts.
- Prop-vs-local-copy watchers added where pages seed local state from props (Dashboard events, Payout config id, Charts data).

### Bugs fixed during live testing
- **Infinite reload loop** on booking/event pages (GET-writes-cache + broadcast) — fixed via `broadcastIgnoreDirty` loop guard.
- **Band-cut / user-pay mismatches** — booking Show and event page now compute fresh via the shared `BookingPayoutEstimator` (stored-config / adjusted-total semantics), agreeing with the Payout page and updating live.
- **Config switches went silent** after the first loop fix — corrected to ignore only `calculation_result`.

### Tests
- `BroadcastsBandChangesTest` extended (asset/media/payments/payout broadcasts, converged-render-silence regression).
- Web vitest for the composable + affected pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YNyzbE8jweH5FLjTMJt1kY

