### PR TITLE
fix(realtime): stop loader flashes and repeated reloads from band signals

### DIFF
--- a/app/Models/Traits/BroadcastsBandChanges.php
+++ b/app/Models/Traits/BroadcastsBandChanges.php
@@ -9,6 +9,10 @@ use Illuminate\Support\Str;
  * Opt-in realtime signal: any created/updated/deleted on the model dispatches
  * a thin BandDataChanged broadcast to the model's band channel.
  *
+ * Broadcast toOthers(): the writer's own client already sees the change via
+ * its Inertia response, so the originating socket (X-Socket-ID, attached to
+ * axios by Echo) is excluded to avoid an echo reload on the sender.
+ *
  * Models whose band is reached indirectly override broadcastBandId(); child
  * models whose client-side listing is keyed by a parent (comments, event
  * members) override broadcastParent().
@@ -38,13 +42,13 @@ trait BroadcastsBandChanges
                 return;
             }
 
-            BandDataChanged::dispatch(
+            broadcast(new BandDataChanged(
                 (int) $bandId,
                 Str::snake(class_basename($this)),
                 (int) $this->getKey(),
                 $action,
                 $this->broadcastParent(),
-            );
+            ))->toOthers();
         } catch (\Throwable $e) {
             // A realtime signal must never break the write that caused it.
             report($e);

--- a/package-lock.json
+++ b/package-lock.json
@@ -45,7 +45,6 @@
                 "ziggy-js": "^2.3.0"
             },
             "devDependencies": {
-                "@inertiajs/progress": "^0.2.7",
                 "@tailwindcss/forms": "^0.5.2",
                 "@vue-macros/volar": "^3.1.1",
                 "@vue/compiler-sfc": "^3.0.5",
@@ -481,45 +480,6 @@
                 "axios": "^1.13.2",
                 "lodash-es": "^4.17.21",
                 "qs": "^6.14.0"
-            }
-        },
-        "node_modules/@inertiajs/inertia": {
-            "version": "0.11.1",
-            "resolved": "https://registry.npmjs.org/@inertiajs/inertia/-/inertia-0.11.1.tgz",
-            "integrity": "sha512-btmV53c54oW4Z9XF0YyTdIUnM7ue0ONy3/KJOz6J1C5CYIwimiKfDMpz8ZbGJuxS+SPdOlNsqj2ZhlHslpJRZg==",
-            "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
-            "dev": true,
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "axios": "^0.21.1",
-                "deepmerge": "^4.0.0",
-                "qs": "^6.9.0"
-            }
-        },
-        "node_modules/@inertiajs/inertia/node_modules/axios": {
-            "version": "0.21.4",
-            "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
-            "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
-            "dev": true,
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "follow-redirects": "^1.14.0"
-            }
-        },
-        "node_modules/@inertiajs/progress": {
-            "version": "0.2.7",
-            "resolved": "https://registry.npmjs.org/@inertiajs/progress/-/progress-0.2.7.tgz",
-            "integrity": "sha512-zxadfLlBPIUvTE9g5k71V/Ayzo8P9kEp4hV4UKywCC2kURufxV7bycbZqU1GeMCFGDT+VRrjXNl676Pwwa1HoQ==",
-            "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "nprogress": "^0.2.0"
-            },
-            "peerDependencies": {
-                "@inertiajs/inertia": "^0.6.0 || ^0.7.0 || ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0"
             }
         },
         "node_modules/@inertiajs/vue3": {
@@ -3843,17 +3803,6 @@
             "license": "MIT",
             "peer": true
         },
-        "node_modules/deepmerge": {
-            "version": "4.3.1",
-            "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
-            "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
-            "dev": true,
-            "license": "MIT",
-            "peer": true,
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
         "node_modules/define-data-property": {
             "version": "1.1.4",
             "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
@@ -7114,13 +7063,6 @@
             "engines": {
                 "node": ">=0.10.0"
             }
-        },
-        "node_modules/nprogress": {
-            "version": "0.2.0",
-            "resolved": "https://registry.npmjs.org/nprogress/-/nprogress-0.2.0.tgz",
-            "integrity": "sha512-I19aIingLgR1fmhftnbWWO3dXc0hSxqHQHQb3H8m+K3TnEn/iSeTZZOyvKXWqQESMwuUVnatlCnZdLBZZt2VSA==",
-            "dev": true,
-            "license": "MIT"
         },
         "node_modules/nwsapi": {
             "version": "2.2.13",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
         "build": "vite build"
     },
     "devDependencies": {
-        "@inertiajs/progress": "^0.2.7",
         "@tailwindcss/forms": "^0.5.2",
         "@vue-macros/volar": "^3.1.1",
         "@vue/compiler-sfc": "^3.0.5",

--- a/resources/js/Layouts/Authenticated.vue
+++ b/resources/js/Layouts/Authenticated.vue
@@ -535,8 +535,8 @@ import NavAccordion from "@/Components/NavAccordion.vue";
 import Toast from "primevue/toast";
 import axios from "axios";
 import { mapState, mapActions } from "vuex";
-import { router } from "@inertiajs/vue3";
 import { subscribeBandSignals } from "@/realtime/bandChannel";
+import { queueReload } from "@/realtime/reloadCoalescer";
 import { createBellRefresher } from "@/realtime/bellRefresher";
 import { navigationGroups } from "@/config/navigation.js";
 
@@ -675,12 +675,9 @@ export default {
             if (!bandIds?.length || !window.Echo) return;
 
             this._bellRefresher = createBellRefresher({
-                reloadAuth: (opts) => router.reload({
-                    ...opts,
-                    onSuccess: () => {
-                        this.fetchNotifications();
-                        opts.onSuccess?.();
-                    },
+                reloadAuth: (opts) => queueReload(opts.only, () => {
+                    this.fetchNotifications();
+                    opts.onSuccess?.();
                 }),
                 getUnseenCount: () => this.unseenNotifications,
                 getLatest: () => this.notifications?.[0],

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -3,7 +3,6 @@ import '@/bootstrap';
 // Import modules...
 import { createApp, h } from 'vue';
 import { createInertiaApp, Link } from '@inertiajs/vue3';
-import { InertiaProgress } from '@inertiajs/progress';
 import { createStore } from 'vuex'
 import VueSweetalert2 from 'vue-sweetalert2';
 import { resolvePageComponent } from 'laravel-vite-plugin/inertia-helpers';
@@ -68,6 +67,10 @@ const store = createStore({
 
 createInertiaApp({
     title: (title) => `${title} - ${import.meta.env.VITE_APP_NAME}`,
+    // Inertia's built-in progress bar skips async visits (router.reload from
+    // realtime signals) via showProgress; the legacy @inertiajs/progress
+    // package flashed the bar on every background reload.
+    progress: { color: '#4B5563' },
     resolve: (name) => resolvePageComponent(`./Pages/${name}.vue`, import.meta.glob('./Pages/**/*.vue')),
     setup({ el, App, props, plugin }) {
         const app = createApp({ render: () => h(App, props) });
@@ -159,5 +162,3 @@ createInertiaApp({
 
     }
 });
-
-InertiaProgress.init({ color: '#4B5563' });

--- a/resources/js/composables/useBandRealtime.js
+++ b/resources/js/composables/useBandRealtime.js
@@ -1,8 +1,6 @@
 import { onBeforeUnmount, onMounted } from 'vue';
-import { router } from '@inertiajs/vue3';
 import { subscribeBandSignals } from '../realtime/bandChannel';
-
-const DEBOUNCE_MS = 300;
+import { queueReload, cancelQueuedProps } from '../realtime/reloadCoalescer';
 
 function normalize(entry) {
 	return Array.isArray(entry) ? { props: entry, when: null } : entry;
@@ -10,23 +8,16 @@ function normalize(entry) {
 
 /**
  * Page-level opt-in to band realtime signals: maps wire models to the
- * Inertia props to partial-reload. Signals arriving within the debounce
- * window coalesce into one router.reload with the union of their props.
+ * Inertia props to partial-reload. Reloads go through the shared
+ * reloadCoalescer, so signals landing in the same window — including the
+ * layout bell's auth refresh — coalesce into one router.reload with the
+ * union of their props.
  *
  * useBandRealtime(band.id, { bookings: ['bookings'] })
  * useBandRealtime(band.id, { bookings: { props: ['booking'], when: p => p.id === booking.id } })
  */
 export function useBandRealtime(bandIdOrIds, reloadMap = {}, options = {}) {
 	let unsubscribe = null;
-	let timer = null;
-	const pendingProps = new Set();
-
-	function flush() {
-		timer = null;
-		const only = [...pendingProps];
-		pendingProps.clear();
-		if (only.length) router.reload({ only });
-	}
 
 	function onSignal(payload) {
 		options.onSignal?.(payload);
@@ -36,8 +27,7 @@ export function useBandRealtime(bandIdOrIds, reloadMap = {}, options = {}) {
 		const { props, when } = normalize(entry);
 		if (when && !when(payload)) return;
 
-		props.forEach((p) => pendingProps.add(p));
-		if (!timer) timer = setTimeout(flush, DEBOUNCE_MS);
+		queueReload(props);
 	}
 
 	onMounted(() => {
@@ -46,7 +36,8 @@ export function useBandRealtime(bandIdOrIds, reloadMap = {}, options = {}) {
 
 	onBeforeUnmount(() => {
 		unsubscribe?.();
-		if (timer) clearTimeout(timer);
-		pendingProps.clear();
+		cancelQueuedProps(
+			Object.values(reloadMap).flatMap((entry) => normalize(entry).props),
+		);
 	});
 }

--- a/resources/js/realtime/reloadCoalescer.js
+++ b/resources/js/realtime/reloadCoalescer.js
@@ -1,0 +1,56 @@
+import { router } from '@inertiajs/vue3';
+
+// One shared debounce window for every realtime-driven partial reload.
+//
+// Signals fan out to independent consumers (the page's useBandRealtime, the
+// layout's notification bell) and a single user action broadcasts several
+// queued signals whose arrival is spread by queue latency. Without a shared
+// window each consumer fires its own router.reload back-to-back. Everything
+// funnels through here so one burst becomes one reload with the union of
+// requested props.
+//
+// The window is sized to absorb Horizon queue jitter between the several
+// broadcasts of a single write, not just same-tick fan-out.
+export const COALESCE_MS = 1000;
+
+const pendingProps = new Set();
+let callbacks = [];
+let timer = null;
+
+function flush() {
+	timer = null;
+	const only = [...pendingProps];
+	const cbs = callbacks;
+	pendingProps.clear();
+	callbacks = [];
+	if (!only.length) return;
+	router.reload({
+		only,
+		onSuccess: () => cbs.forEach((fn) => fn()),
+	});
+}
+
+export function queueReload(props, onSuccess) {
+	props.forEach((p) => pendingProps.add(p));
+	if (onSuccess) callbacks.push(onSuccess);
+	if (!timer) timer = setTimeout(flush, COALESCE_MS);
+}
+
+/**
+ * Withdraw props a consumer queued but no longer wants (page unmounting
+ * mid-window). Props other consumers still care about must be re-queued by
+ * them, so only pass props this consumer alone maps.
+ */
+export function cancelQueuedProps(props) {
+	props.forEach((p) => pendingProps.delete(p));
+}
+
+/**
+ * Reset module state (for testing only).
+ */
+export function __resetReloadCoalescer() {
+	pendingProps.clear();
+	callbacks = [];
+	if (timer) clearTimeout(timer);
+	timer = null;
+}

--- a/resources/js/tests/composables/useBandRealtime.test.js
+++ b/resources/js/tests/composables/useBandRealtime.test.js
@@ -3,6 +3,7 @@ import { defineComponent, h } from 'vue';
 import { mount } from '@vue/test-utils';
 import { installEchoMock } from '../mocks/echo';
 import { BAND_EVENT, __resetBandChannelState } from '../../realtime/bandChannel';
+import { COALESCE_MS, queueReload, __resetReloadCoalescer } from '../../realtime/reloadCoalescer';
 import { useBandRealtime } from '../../composables/useBandRealtime';
 
 vi.mock('@inertiajs/vue3', () => ({
@@ -25,6 +26,7 @@ describe('useBandRealtime', () => {
 	beforeEach(() => {
 		vi.useFakeTimers();
 		__resetBandChannelState();
+		__resetReloadCoalescer();
 		echo = installEchoMock();
 		router.reload.mockClear();
 	});
@@ -40,16 +42,27 @@ describe('useBandRealtime', () => {
 		echo.fire('band.1', BAND_EVENT, { model: 'events', id: 3, action: 'created' });
 		expect(router.reload).not.toHaveBeenCalled();
 
-		vi.advanceTimersByTime(300);
+		vi.advanceTimersByTime(COALESCE_MS);
 		expect(router.reload).toHaveBeenCalledTimes(1);
 		const only = router.reload.mock.calls[0][0].only;
 		expect([...only].sort()).toEqual(['bookings', 'events']);
 	});
 
+	it('shares one reload window with other consumers (the layout bell)', () => {
+		mountWith(1, { bookings: ['bookings'] });
+
+		echo.fire('band.1', BAND_EVENT, { model: 'bookings', id: 1, action: 'updated' });
+		queueReload(['auth']);
+
+		vi.advanceTimersByTime(COALESCE_MS);
+		expect(router.reload).toHaveBeenCalledTimes(1);
+		expect([...router.reload.mock.calls[0][0].only].sort()).toEqual(['auth', 'bookings']);
+	});
+
 	it('ignores models missing from the map', () => {
 		mountWith(1, { bookings: ['bookings'] });
 		echo.fire('band.1', BAND_EVENT, { model: 'roster', id: 1, action: 'updated' });
-		vi.advanceTimersByTime(300);
+		vi.advanceTimersByTime(COALESCE_MS);
 		expect(router.reload).not.toHaveBeenCalled();
 	});
 
@@ -59,11 +72,11 @@ describe('useBandRealtime', () => {
 		});
 
 		echo.fire('band.1', BAND_EVENT, { model: 'bookings', id: 7, action: 'updated' });
-		vi.advanceTimersByTime(300);
+		vi.advanceTimersByTime(COALESCE_MS);
 		expect(router.reload).not.toHaveBeenCalled();
 
 		echo.fire('band.1', BAND_EVENT, { model: 'bookings', id: 42, action: 'updated' });
-		vi.advanceTimersByTime(300);
+		vi.advanceTimersByTime(COALESCE_MS);
 		expect(router.reload).toHaveBeenCalledTimes(1);
 		expect(router.reload.mock.calls[0][0].only).toEqual(['booking']);
 	});
@@ -81,7 +94,7 @@ describe('useBandRealtime', () => {
 		echo.fire('band.1', BAND_EVENT, { model: 'bookings', id: 1, action: 'updated' });
 		wrapper.unmount();
 
-		vi.advanceTimersByTime(300);
+		vi.advanceTimersByTime(COALESCE_MS);
 		expect(router.reload).not.toHaveBeenCalled();
 		expect(echo.leaveCalls).toEqual(['band.1']);
 	});

--- a/resources/js/tests/realtime/reloadCoalescer.test.js
+++ b/resources/js/tests/realtime/reloadCoalescer.test.js
@@ -1,0 +1,75 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+vi.mock('@inertiajs/vue3', () => ({
+	router: { reload: vi.fn() },
+}));
+import { router } from '@inertiajs/vue3';
+import {
+	COALESCE_MS,
+	queueReload,
+	cancelQueuedProps,
+	__resetReloadCoalescer,
+} from '../../realtime/reloadCoalescer';
+
+describe('reloadCoalescer', () => {
+	beforeEach(() => {
+		vi.useFakeTimers();
+		__resetReloadCoalescer();
+		router.reload.mockClear();
+	});
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it('coalesces queues from independent consumers into one reload with the union of props', () => {
+		queueReload(['bookings']);
+		queueReload(['auth']);
+		queueReload(['bookings', 'events']);
+		expect(router.reload).not.toHaveBeenCalled();
+
+		vi.advanceTimersByTime(COALESCE_MS);
+		expect(router.reload).toHaveBeenCalledTimes(1);
+		expect([...router.reload.mock.calls[0][0].only].sort()).toEqual(['auth', 'bookings', 'events']);
+	});
+
+	it('runs every queued onSuccess callback after the coalesced reload succeeds', () => {
+		router.reload.mockImplementation((opts) => opts.onSuccess?.());
+		const first = vi.fn();
+		const second = vi.fn();
+
+		queueReload(['auth'], first);
+		queueReload(['bookings'], second);
+		vi.advanceTimersByTime(COALESCE_MS);
+
+		expect(first).toHaveBeenCalledTimes(1);
+		expect(second).toHaveBeenCalledTimes(1);
+	});
+
+	it('starts a fresh window after a flush', () => {
+		queueReload(['bookings']);
+		vi.advanceTimersByTime(COALESCE_MS);
+		queueReload(['events']);
+		vi.advanceTimersByTime(COALESCE_MS);
+
+		expect(router.reload).toHaveBeenCalledTimes(2);
+		expect(router.reload.mock.calls[1][0].only).toEqual(['events']);
+	});
+
+	it('cancelQueuedProps drops pending props; an emptied window reloads nothing', () => {
+		queueReload(['bookings', 'events']);
+		cancelQueuedProps(['bookings', 'events']);
+		vi.advanceTimersByTime(COALESCE_MS);
+
+		expect(router.reload).not.toHaveBeenCalled();
+	});
+
+	it('cancelQueuedProps leaves other consumers props in place', () => {
+		queueReload(['bookings']);
+		queueReload(['auth']);
+		cancelQueuedProps(['bookings']);
+		vi.advanceTimersByTime(COALESCE_MS);
+
+		expect(router.reload).toHaveBeenCalledTimes(1);
+		expect(router.reload.mock.calls[0][0].only).toEqual(['auth']);
+	});
+});

--- a/tests/Feature/Broadcasting/BroadcastsBandChangesTest.php
+++ b/tests/Feature/Broadcasting/BroadcastsBandChangesTest.php
@@ -347,6 +347,33 @@ class BroadcastsBandChangesTest extends TestCase
         Event::assertNotDispatched(BandDataChanged::class);
     }
 
+    public function test_broadcast_carries_the_originating_socket_id_so_the_sender_is_excluded(): void
+    {
+        Event::fake([BandDataChanged::class]);
+        $this->app['request']->headers->set('X-Socket-ID', '1234.5678');
+
+        $band = Bands::factory()->create();
+        Bookings::factory()->create(['band_id' => $band->id]);
+
+        Event::assertDispatched(
+            BandDataChanged::class,
+            fn (BandDataChanged $e) => $e->socket === '1234.5678',
+        );
+    }
+
+    public function test_broadcast_without_a_socket_header_reaches_everyone(): void
+    {
+        Event::fake([BandDataChanged::class]);
+
+        $band = Bands::factory()->create();
+        Bookings::factory()->create(['band_id' => $band->id]);
+
+        Event::assertDispatched(
+            BandDataChanged::class,
+            fn (BandDataChanged $e) => $e->socket === null,
+        );
+    }
+
     public function test_payout_adjustment_resolves_band_through_its_payout(): void
     {
         Event::fake([BandDataChanged::class]);


### PR DESCRIPTION
## Problem

Since the realtime deploy, users see the top progress bar flash when band updates arrive, and sometimes the page visibly reloads several times in a row for a single change.

## Root causes & fixes

**1. Legacy progress package showed the bar for background reloads**
Inertia v2's `router.reload()` is an async visit with `showProgress: false`, so the built-in progress bar deliberately stays hidden for background refreshes. But `app.js` still initialized the legacy `@inertiajs/progress` package, which hooks the raw `inertia:start` event and starts NProgress on *every* visit. Removed the package; progress is now configured via `createInertiaApp({ progress: { color: '#4B5563' } })`. Realtime refreshes are now invisible; real navigations still show the bar.

**2. Broadcasts echoed back to their sender**
`BroadcastsBandChanges` dispatched `BandDataChanged` without socket exclusion, so the user who made a change received their own signals and reloaded again right after their own Inertia response. The trait now uses `broadcast(...)->toOthers()` — Echo already attaches `X-Socket-Id` to the shared axios instance Inertia uses.

**3. Independent debounces turned one write into several reloads**
The page composable (`useBandRealtime`) and the layout notification bell each ran their own 300ms debounce + `router.reload`, and one write emits several queued signals whose arrival is spread by Horizon latency — anything landing >300ms apart started another reload cycle. New `resources/js/realtime/reloadCoalescer.js` gives all consumers one shared 1s window that issues a single `router.reload` with the union of requested props; pages withdraw their props if they unmount mid-window.

## Tests

- New backend tests pin socket exclusion (with and without an originating socket header); full suite passes (1,538 tests, `--parallel`).
- New `reloadCoalescer` Vitest suite (5 tests) plus a cross-consumer coalescing test in `useBandRealtime.test.js`; all main-tree frontend tests pass and `npm run build` succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)