### PR TITLE
feat: unified comments & chat backend (conversations, messages, realtime, push)

### DIFF
--- a/app/Events/ConversationChanged.php
+++ b/app/Events/ConversationChanged.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace App\Events;
+
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Broadcasting\PrivateChannel;
+use Illuminate\Contracts\Broadcasting\ShouldBroadcast;
+use Illuminate\Contracts\Events\ShouldDispatchAfterCommit;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+/**
+ * Thin per-user change signal for DM conversations — the DM analogue of
+ * BandDataChanged (DMs have no band channel to ride). One event per
+ * participant, on their standard App.Models.User.{id} private channel.
+ */
+class ConversationChanged implements ShouldBroadcast, ShouldDispatchAfterCommit
+{
+    use Dispatchable, InteractsWithSockets, SerializesModels;
+
+    public function __construct(
+        public int $userId,
+        public int $conversationId,
+        public int $messageId,
+        public string $action,
+    ) {}
+
+    public function broadcastOn(): array
+    {
+        return [new PrivateChannel('App.Models.User.' . $this->userId)];
+    }
+
+    public function broadcastAs(): string
+    {
+        return 'user.data-changed';
+    }
+
+    public function broadcastWith(): array
+    {
+        return [
+            'model'  => 'message',
+            'id'     => $this->messageId,
+            'action' => $this->action,
+            'parent' => ['model' => 'conversation', 'id' => $this->conversationId],
+        ];
+    }
+}

--- a/app/Events/ConversationStreamEvent.php
+++ b/app/Events/ConversationStreamEvent.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace App\Events;
+
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Broadcasting\PrivateChannel;
+use Illuminate\Contracts\Broadcasting\ShouldBroadcastNow;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+/**
+ * Full-payload live event for an OPEN conversation screen: instant message
+ * append/edit/delete, read receipts, and typing — no refetch round-trip.
+ * ShouldBroadcastNow: latency matters more than queue smoothing here.
+ *
+ * One class, FIVE wire events — broadcastAs() returns the type itself, so
+ * clients bind to five distinct event names with no envelope:
+ *   message.created {message} | message.updated {message}
+ *   message.deleted {message_id} | conversation.read {user_id, last_read_at}
+ *   conversation.typing {user_id, name}
+ */
+class ConversationStreamEvent implements ShouldBroadcastNow
+{
+    use Dispatchable, InteractsWithSockets, SerializesModels;
+
+    /** @param array<string,mixed> $data */
+    public function __construct(
+        public int $conversationId,
+        public string $type,
+        public array $data = [],
+    ) {}
+
+    public function broadcastOn(): array
+    {
+        return [new PrivateChannel('conversation.' . $this->conversationId)];
+    }
+
+    public function broadcastAs(): string
+    {
+        return $this->type;
+    }
+
+    public function broadcastWith(): array
+    {
+        return $this->data;
+    }
+}

--- a/app/Http/Controllers/Api/Mobile/BandSettingsController.php
+++ b/app/Http/Controllers/Api/Mobile/BandSettingsController.php
@@ -141,6 +141,7 @@ class BandSettingsController extends Controller
             'read:invoices', 'write:invoices',
             'read:proposals', 'write:proposals',
             'read:colors', 'write:colors',
+            'moderate:chat',
         ];
     }
 }

--- a/app/Http/Controllers/Api/Mobile/ConversationsController.php
+++ b/app/Http/Controllers/Api/Mobile/ConversationsController.php
@@ -387,14 +387,16 @@ class ConversationsController extends Controller
         ]);
 
         // Never move the marker backwards (out-of-order client calls).
+        // Broadcast only when the marker actually advances — duplicate or
+        // out-of-order read POSTs must not re-emit conversation.read.
         if (!$participant->last_read_at || $participant->last_read_at->lt($message->created_at)) {
             $participant->forceFill(['last_read_at' => $message->created_at])->save();
-        }
 
-        broadcast(new ConversationStreamEvent($conversation->id, 'conversation.read', [
-            'user_id'      => $request->user()->id,
-            'last_read_at' => $participant->last_read_at->toIso8601String(),
-        ]))->toOthers();
+            broadcast(new ConversationStreamEvent($conversation->id, 'conversation.read', [
+                'user_id'      => $request->user()->id,
+                'last_read_at' => $participant->last_read_at->toIso8601String(),
+            ]))->toOthers();
+        }
 
         return response()->json(null, 204);
     }
@@ -402,7 +404,7 @@ class ConversationsController extends Controller
     /** POST /api/mobile/conversations/{conversation}/typing — ephemeral, nothing stored. */
     public function typing(Request $request, Conversation $conversation): JsonResponse
     {
-        $this->authorize('view', $conversation);
+        $this->authorize('post', $conversation);
 
         broadcast(new ConversationStreamEvent($conversation->id, 'conversation.typing', [
             'user_id' => $request->user()->id,

--- a/app/Http/Controllers/Api/Mobile/ConversationsController.php
+++ b/app/Http/Controllers/Api/Mobile/ConversationsController.php
@@ -16,6 +16,7 @@ use App\Services\Chat\MessageFormatter;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Str;
 
 class ConversationsController extends Controller
@@ -312,13 +313,12 @@ class ConversationsController extends Controller
             'images.*' => ['image', 'mimes:jpeg,jpg,png,webp,heic', 'max:10240'],
         ]);
 
-        $user    = $request->user();
-        $message = $conversation->messages()->create([
-            'user_id' => $user->id,
-            'body'    => $validated['body'] ?? null,
-        ]);
-
+        $user = $request->user();
         $disk = config('filesystems.default');
+
+        // Store binaries BEFORE opening the transaction so the DB writes
+        // (message + attachment rows) stay atomic; collect metadata first.
+        $stored = [];
         foreach ($request->file('images', []) as $file) {
             $path = $file->storeAs(
                 'chat/' . $conversation->id,
@@ -326,14 +326,36 @@ class ConversationsController extends Controller
                 $disk,
             );
             $dimensions = @getimagesize($file->getRealPath()) ?: [null, null];
-            $message->attachments()->create([
+            $stored[]   = [
                 'path'       => $path,
                 'disk'       => $disk,
                 'mime'       => $file->getMimeType(),
                 'width'      => $dimensions[0],
                 'height'     => $dimensions[1],
                 'size_bytes' => $file->getSize(),
-            ]);
+            ];
+        }
+
+        try {
+            $message = DB::transaction(function () use ($conversation, $user, $validated, $stored) {
+                $message = $conversation->messages()->create([
+                    'user_id' => $user->id,
+                    'body'    => $validated['body'] ?? null,
+                ]);
+
+                foreach ($stored as $attributes) {
+                    $message->attachments()->create($attributes);
+                }
+
+                return $message;
+            });
+        } catch (\Throwable $e) {
+            // Rows rolled back — remove the just-stored blobs so none orphan.
+            foreach ($stored as $attributes) {
+                Storage::disk($attributes['disk'])->delete($attributes['path']);
+            }
+
+            throw $e;
         }
 
         // Sending implies having read everything up to your own message.

--- a/app/Http/Controllers/Api/Mobile/ConversationsController.php
+++ b/app/Http/Controllers/Api/Mobile/ConversationsController.php
@@ -3,11 +3,16 @@
 namespace App\Http\Controllers\Api\Mobile;
 
 use App\Http\Controllers\Controller;
+use App\Models\Bands;
+use App\Models\Bookings;
 use App\Models\Conversation;
 use App\Models\ConversationParticipant;
+use App\Models\Events;
 use App\Models\Message;
+use App\Models\Rehearsal;
 use App\Models\User;
 use App\Services\Chat\ConversationService;
+use App\Services\Chat\MessageFormatter;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
@@ -16,6 +21,7 @@ class ConversationsController extends Controller
 {
     public function __construct(
         private readonly ConversationService $conversations,
+        private readonly MessageFormatter $formatter,
     ) {}
 
     /**
@@ -206,5 +212,81 @@ class ConversationsController extends Controller
             'unread_count'         => $unread,
             'can_moderate'         => $user->can('moderate', $conversation),
         ];
+    }
+
+    /** GET /api/mobile/events/{event}/conversation */
+    public function forEvent(Request $request, Events $event): JsonResponse
+    {
+        return $this->topicResponse($request, $this->conversations->topicFor($event));
+    }
+
+    /** GET /api/mobile/rehearsals/{rehearsal}/conversation */
+    public function forRehearsal(Request $request, Rehearsal $rehearsal): JsonResponse
+    {
+        return $this->topicResponse($request, $this->conversations->topicFor($rehearsal));
+    }
+
+    /** GET /api/mobile/bands/{band}/bookings/{booking}/conversation */
+    public function forBooking(Request $request, Bands $band, Bookings $booking): JsonResponse
+    {
+        return $this->topicResponse($request, $this->conversations->topicFor($booking));
+    }
+
+    private function topicResponse(Request $request, Conversation $conversation): JsonResponse
+    {
+        $this->authorize('view', $conversation);
+
+        // Opening a thread registers the viewer and marks it read.
+        $this->conversations->touchParticipant($conversation, $request->user());
+
+        return $this->threadPage($request, $conversation);
+    }
+
+    /**
+     * The shared ThreadPage shape: also returned by the messages index
+     * (Task 6). Messages come back oldest→newest; `channel` is what the
+     * client subscribes to for live updates.
+     */
+    private function threadPage(Request $request, Conversation $conversation, ?int $before = null): JsonResponse
+    {
+        $user  = $request->user();
+        $limit = 50;
+
+        $page = $conversation->messages()->withTrashed()
+            ->with(['user', 'attachments'])
+            ->when($before, fn ($q) => $q->where('id', '<', $before))
+            ->latest('id')->limit($limit + 1)->get();
+
+        $hasMore  = $page->count() > $limit;
+        $messages = $page->take($limit)->reverse()->values()
+            ->map(fn ($m) => $this->formatter->format($m));
+
+        $participants = $conversation->participants()->with('user')->get()
+            ->map(fn ($p) => [
+                'user_id'      => (int) $p->user_id,
+                'name'         => $p->user?->name,
+                'avatar_url'   => null,
+                'last_read_at' => $p->last_read_at?->toIso8601String(),
+            ])->values();
+
+        // Build conversation summary for topic thread (no last message preview needed for topic threads)
+        $conversationData = [
+            'id'                   => $conversation->id,
+            'type'                 => $conversation->type,
+            'band_id'              => $conversation->band_id ? (int) $conversation->band_id : null,
+            'title'                => $conversation->conversable_type ? 'Thread' : 'Conversation',
+            'last_message_preview' => null,
+            'last_message_at'      => null,
+            'unread_count'         => 0,
+            'can_moderate'         => $user->can('moderate', $conversation),
+        ];
+
+        return response()->json([
+            'conversation' => $conversationData,
+            'messages'     => $messages,
+            'participants' => $participants,
+            'channel'      => 'private-conversation.' . $conversation->id,
+            'has_more'     => $hasMore,
+        ]);
     }
 }

--- a/app/Http/Controllers/Api/Mobile/ConversationsController.php
+++ b/app/Http/Controllers/Api/Mobile/ConversationsController.php
@@ -331,10 +331,12 @@ class ConversationsController extends Controller
     {
         $this->authorize('view', $conversation);
 
+        $validated = $request->validate(['before' => 'sometimes|integer|min:1']);
+
         return $this->threadPage(
             $request,
             $conversation,
-            $request->filled('before') ? (int) $request->input('before') : null,
+            $validated['before'] ?? null,
         );
     }
 
@@ -346,7 +348,12 @@ class ConversationsController extends Controller
         $validated = $request->validate([
             'body'     => ['nullable', 'string', 'max:4000', 'required_without:images'],
             'images'   => ['nullable', 'array', 'max:4'],
-            'images.*' => ['image', 'mimes:jpeg,jpg,png,webp,heic', 'max:10240'],
+            // heic/heif deliberately excluded: PHP's getimagesize() can't
+            // read HEIC, which would leave width/height null — but the
+            // Flutter ChatAttachment contract types those as non-nullable
+            // ints. The mobile client re-encodes camera images to jpeg
+            // before upload anyway.
+            'images.*' => ['image', 'mimes:jpeg,jpg,png,webp', 'max:10240'],
         ]);
 
         $user = $request->user();

--- a/app/Http/Controllers/Api/Mobile/ConversationsController.php
+++ b/app/Http/Controllers/Api/Mobile/ConversationsController.php
@@ -8,7 +8,6 @@ use App\Models\ConversationParticipant;
 use App\Models\Message;
 use App\Models\User;
 use App\Services\Chat\ConversationService;
-use App\Services\Chat\MessageFormatter;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
@@ -17,7 +16,6 @@ class ConversationsController extends Controller
 {
     public function __construct(
         private readonly ConversationService $conversations,
-        private readonly MessageFormatter $formatter,
     ) {}
 
     /**
@@ -38,16 +36,63 @@ class ConversationsController extends Controller
             ->get();
 
         $all = $channels->concat($dms);
+        $ids = $all->pluck('id');
 
         $lastReads = ConversationParticipant::where('user_id', $user->id)
-            ->whereIn('conversation_id', $all->pluck('id'))
+            ->whereIn('conversation_id', $ids)
             ->pluck('last_read_at', 'conversation_id');
 
-        $rows = $all->map(fn (Conversation $c) => $this->summarize($c, $user, $lastReads->get($c->id)))
+        $prefetch = $this->prefetchSummaryData($ids, $user, $lastReads);
+
+        $rows = $all->map(fn (Conversation $c) => $this->summarize($c, $user, $prefetch))
             ->sortByDesc(fn ($row) => $row['last_message_at'] ?? '')
             ->values();
 
         return response()->json(['conversations' => $rows]);
+    }
+
+    /**
+     * Bulk-load everything summarize() needs for a set of conversations so
+     * index() runs a constant number of queries instead of ~3 per row.
+     *
+     * @return array{last: \Illuminate\Support\Collection, unread: \Illuminate\Support\Collection, dmOther: \Illuminate\Support\Collection}
+     */
+    private function prefetchSummaryData($ids, User $user, $lastReads): array
+    {
+        $latestIds = Message::withTrashed()
+            ->whereIn('conversation_id', $ids)
+            ->selectRaw('MAX(id) as id')
+            ->groupBy('conversation_id')
+            ->pluck('id');
+
+        $last = Message::withTrashed()
+            ->whereIn('id', $latestIds)
+            ->with('attachments')
+            ->get()
+            ->keyBy('conversation_id');
+
+        // Grouped count of "not mine" messages per conversation that are
+        // newer than that conversation's own last_read_at, in one query via
+        // a per-row conditional (each conversation's threshold differs).
+        $unread = Message::whereIn('conversation_id', $ids)
+            ->where('user_id', '!=', $user->id)
+            ->get(['conversation_id', 'created_at'])
+            ->groupBy('conversation_id')
+            ->map(function ($messages, $conversationId) use ($lastReads) {
+                $lastReadAt = $lastReads->get($conversationId);
+
+                return $lastReadAt
+                    ? $messages->filter(fn ($m) => $m->created_at->gt($lastReadAt))->count()
+                    : $messages->count();
+            });
+
+        $dmOther = ConversationParticipant::whereIn('conversation_id', $ids)
+            ->where('user_id', '!=', $user->id)
+            ->with('user')
+            ->get()
+            ->keyBy('conversation_id');
+
+        return ['last' => $last, 'unread' => $unread, 'dmOther' => $dmOther];
     }
 
     /** POST /api/mobile/conversations/dm {user_id} — find-or-create the global pair thread. */
@@ -62,7 +107,9 @@ class ConversationsController extends Controller
 
         $conversation = $this->conversations->dmBetween($me, $other);
 
-        return response()->json(['conversation' => $this->summarize($conversation, $me, null)]);
+        $prefetch = $this->prefetchSummaryData(collect([$conversation->id]), $me, collect());
+
+        return response()->json(['conversation' => $this->summarize($conversation, $me, $prefetch)]);
     }
 
     /** GET /api/mobile/chat/contacts — who the current user may start a DM with. */
@@ -122,10 +169,15 @@ class ConversationsController extends Controller
         return response()->json(['contacts' => $contacts]);
     }
 
-    /** Conversation JSON — the one wire shape for a conversation everywhere. */
-    private function summarize(Conversation $conversation, User $user, $lastReadAt): array
+    /**
+     * Conversation JSON — the one wire shape for a conversation everywhere.
+     *
+     * @param array{last: \Illuminate\Support\Collection, unread: \Illuminate\Support\Collection, dmOther: \Illuminate\Support\Collection} $prefetch
+     *        Bulk-loaded data from prefetchSummaryData(), keyed by conversation_id.
+     */
+    private function summarize(Conversation $conversation, User $user, array $prefetch): array
     {
-        $last = $conversation->messages()->withTrashed()->latest('id')->with('attachments')->first();
+        $last = $prefetch['last']->get($conversation->id);
 
         $preview = null;
         $lastAt  = null;
@@ -136,15 +188,11 @@ class ConversationsController extends Controller
                 : (($last->body !== null && $last->body !== '') ? $last->body : '📷 Photo');
         }
 
-        $unread = Message::where('conversation_id', $conversation->id)
-            ->where('user_id', '!=', $user->id)
-            ->when($lastReadAt, fn ($q) => $q->where('created_at', '>', $lastReadAt))
-            ->count();
+        $unread = $prefetch['unread']->get($conversation->id, 0);
 
         $title = match ($conversation->type) {
             Conversation::TYPE_BAND => $conversation->band?->name ?? 'Band',
-            Conversation::TYPE_DM   => $conversation->participants()
-                ->where('user_id', '!=', $user->id)->with('user')->first()?->user?->name ?? 'Direct message',
+            Conversation::TYPE_DM   => $prefetch['dmOther']->get($conversation->id)?->user?->name ?? 'Direct message',
             default => 'Conversation',
         };
 

--- a/app/Http/Controllers/Api/Mobile/ConversationsController.php
+++ b/app/Http/Controllers/Api/Mobile/ConversationsController.php
@@ -197,8 +197,9 @@ class ConversationsController extends Controller
         $unread = $prefetch['unread']->get($conversation->id, 0);
 
         $title = match ($conversation->type) {
-            Conversation::TYPE_BAND => $conversation->band?->name ?? 'Band',
-            Conversation::TYPE_DM   => $prefetch['dmOther']->get($conversation->id)?->user?->name ?? 'Direct message',
+            Conversation::TYPE_BAND  => $conversation->band?->name ?? 'Band',
+            Conversation::TYPE_DM    => $prefetch['dmOther']->get($conversation->id)?->user?->name ?? 'Direct message',
+            Conversation::TYPE_TOPIC => 'Thread',
             default => 'Conversation',
         };
 
@@ -269,20 +270,17 @@ class ConversationsController extends Controller
                 'last_read_at' => $p->last_read_at?->toIso8601String(),
             ])->values();
 
-        // Build conversation summary for topic thread (no last message preview needed for topic threads)
-        $conversationData = [
-            'id'                   => $conversation->id,
-            'type'                 => $conversation->type,
-            'band_id'              => $conversation->band_id ? (int) $conversation->band_id : null,
-            'title'                => $conversation->conversable_type ? 'Thread' : 'Conversation',
-            'last_message_preview' => null,
-            'last_message_at'      => null,
-            'unread_count'         => 0,
-            'can_moderate'         => $user->can('moderate', $conversation),
-        ];
+        // Reuse the one Conversation JSON shape via summarize(). touchParticipant()
+        // just ran, so unread_count is legitimately 0 — but the last-message
+        // preview and timestamp are real.
+        $ids       = collect([$conversation->id]);
+        $lastReads = ConversationParticipant::where('user_id', $user->id)
+            ->whereIn('conversation_id', $ids)
+            ->pluck('last_read_at', 'conversation_id');
+        $prefetch = $this->prefetchSummaryData($ids, $user, $lastReads);
 
         return response()->json([
-            'conversation' => $conversationData,
+            'conversation' => $this->summarize($conversation, $user, $prefetch),
             'messages'     => $messages,
             'participants' => $participants,
             'channel'      => 'private-conversation.' . $conversation->id,

--- a/app/Http/Controllers/Api/Mobile/ConversationsController.php
+++ b/app/Http/Controllers/Api/Mobile/ConversationsController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers\Api\Mobile;
 
 use App\Events\ConversationStreamEvent;
 use App\Http\Controllers\Controller;
+use App\Jobs\ProcessChatMessagePush;
 use App\Models\Bands;
 use App\Models\Bookings;
 use App\Models\Conversation;
@@ -367,6 +368,8 @@ class ConversationsController extends Controller
         broadcast(new ConversationStreamEvent($conversation->id, 'message.created', [
             'message' => $this->formatter->format($message),
         ]))->toOthers();
+
+        ProcessChatMessagePush::dispatch($message->id);
 
         return response()->json(['message' => $this->formatter->format($message)], 201);
     }

--- a/app/Http/Controllers/Api/Mobile/ConversationsController.php
+++ b/app/Http/Controllers/Api/Mobile/ConversationsController.php
@@ -16,6 +16,7 @@ use App\Services\Chat\MessageFormatter;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
 
 class ConversationsController extends Controller
 {
@@ -286,5 +287,83 @@ class ConversationsController extends Controller
             'channel'      => 'private-conversation.' . $conversation->id,
             'has_more'     => $hasMore,
         ]);
+    }
+
+    /** GET /api/mobile/conversations/{conversation}/messages?before={messageId} — ThreadPage. */
+    public function messages(Request $request, Conversation $conversation): JsonResponse
+    {
+        $this->authorize('view', $conversation);
+
+        return $this->threadPage(
+            $request,
+            $conversation,
+            $request->filled('before') ? (int) $request->input('before') : null,
+        );
+    }
+
+    /** POST /api/mobile/conversations/{conversation}/messages — multipart body and/or images[]. */
+    public function storeMessage(Request $request, Conversation $conversation): JsonResponse
+    {
+        $this->authorize('post', $conversation);
+
+        $validated = $request->validate([
+            'body'     => ['nullable', 'string', 'max:4000', 'required_without:images'],
+            'images'   => ['nullable', 'array', 'max:4'],
+            'images.*' => ['image', 'mimes:jpeg,jpg,png,webp,heic', 'max:10240'],
+        ]);
+
+        $user    = $request->user();
+        $message = $conversation->messages()->create([
+            'user_id' => $user->id,
+            'body'    => $validated['body'] ?? null,
+        ]);
+
+        $disk = config('filesystems.default');
+        foreach ($request->file('images', []) as $file) {
+            $path = $file->storeAs(
+                'chat/' . $conversation->id,
+                Str::uuid() . '.' . $file->extension(),
+                $disk,
+            );
+            $dimensions = @getimagesize($file->getRealPath()) ?: [null, null];
+            $message->attachments()->create([
+                'path'       => $path,
+                'disk'       => $disk,
+                'mime'       => $file->getMimeType(),
+                'width'      => $dimensions[0],
+                'height'     => $dimensions[1],
+                'size_bytes' => $file->getSize(),
+            ]);
+        }
+
+        // Sending implies having read everything up to your own message.
+        $this->conversations->touchParticipant($conversation, $user);
+
+        $message->load(['user', 'attachments']);
+
+        return response()->json(['message' => $this->formatter->format($message)], 201);
+    }
+
+    /** POST /api/mobile/conversations/{conversation}/read {last_read_message_id} → 204. */
+    public function read(Request $request, Conversation $conversation): JsonResponse
+    {
+        $this->authorize('view', $conversation);
+
+        $validated = $request->validate(['last_read_message_id' => 'required|integer']);
+
+        $message = $conversation->messages()->withTrashed()
+            ->findOrFail($validated['last_read_message_id']);
+
+        $participant = ConversationParticipant::firstOrCreate([
+            'conversation_id' => $conversation->id,
+            'user_id'         => $request->user()->id,
+        ]);
+
+        // Never move the marker backwards (out-of-order client calls).
+        if (!$participant->last_read_at || $participant->last_read_at->lt($message->created_at)) {
+            $participant->forceFill(['last_read_at' => $message->created_at])->save();
+        }
+
+        return response()->json(null, 204);
     }
 }

--- a/app/Http/Controllers/Api/Mobile/ConversationsController.php
+++ b/app/Http/Controllers/Api/Mobile/ConversationsController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers\Api\Mobile;
 
+use App\Events\ConversationStreamEvent;
 use App\Http\Controllers\Controller;
 use App\Models\Bands;
 use App\Models\Bookings;
@@ -363,6 +364,10 @@ class ConversationsController extends Controller
 
         $message->load(['user', 'attachments']);
 
+        broadcast(new ConversationStreamEvent($conversation->id, 'message.created', [
+            'message' => $this->formatter->format($message),
+        ]))->toOthers();
+
         return response()->json(['message' => $this->formatter->format($message)], 201);
     }
 
@@ -385,6 +390,24 @@ class ConversationsController extends Controller
         if (!$participant->last_read_at || $participant->last_read_at->lt($message->created_at)) {
             $participant->forceFill(['last_read_at' => $message->created_at])->save();
         }
+
+        broadcast(new ConversationStreamEvent($conversation->id, 'conversation.read', [
+            'user_id'      => $request->user()->id,
+            'last_read_at' => $participant->last_read_at->toIso8601String(),
+        ]))->toOthers();
+
+        return response()->json(null, 204);
+    }
+
+    /** POST /api/mobile/conversations/{conversation}/typing — ephemeral, nothing stored. */
+    public function typing(Request $request, Conversation $conversation): JsonResponse
+    {
+        $this->authorize('view', $conversation);
+
+        broadcast(new ConversationStreamEvent($conversation->id, 'conversation.typing', [
+            'user_id' => $request->user()->id,
+            'name'    => $request->user()->name,
+        ]))->toOthers();
 
         return response()->json(null, 204);
     }

--- a/app/Http/Controllers/Api/Mobile/ConversationsController.php
+++ b/app/Http/Controllers/Api/Mobile/ConversationsController.php
@@ -1,0 +1,162 @@
+<?php
+
+namespace App\Http\Controllers\Api\Mobile;
+
+use App\Http\Controllers\Controller;
+use App\Models\Conversation;
+use App\Models\ConversationParticipant;
+use App\Models\Message;
+use App\Models\User;
+use App\Services\Chat\ConversationService;
+use App\Services\Chat\MessageFormatter;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+
+class ConversationsController extends Controller
+{
+    public function __construct(
+        private readonly ConversationService $conversations,
+        private readonly MessageFormatter $formatter,
+    ) {}
+
+    /**
+     * GET /api/mobile/conversations — the Messages screen: the user's DMs
+     * plus a band channel per owned/member band (lazily created so it is
+     * always present). Topic threads are NOT listed; they surface on their
+     * event/rehearsal/booking screens.
+     */
+    public function index(Request $request): JsonResponse
+    {
+        $user = $request->user();
+
+        $channels = $user->bands()->unique('id')->values()
+            ->map(fn ($band) => $this->conversations->bandChannelFor($band));
+
+        $dms = Conversation::where('type', Conversation::TYPE_DM)
+            ->whereHas('participants', fn ($q) => $q->where('user_id', $user->id))
+            ->get();
+
+        $all = $channels->concat($dms);
+
+        $lastReads = ConversationParticipant::where('user_id', $user->id)
+            ->whereIn('conversation_id', $all->pluck('id'))
+            ->pluck('last_read_at', 'conversation_id');
+
+        $rows = $all->map(fn (Conversation $c) => $this->summarize($c, $user, $lastReads->get($c->id)))
+            ->sortByDesc(fn ($row) => $row['last_message_at'] ?? '')
+            ->values();
+
+        return response()->json(['conversations' => $rows]);
+    }
+
+    /** POST /api/mobile/conversations/dm {user_id} — find-or-create the global pair thread. */
+    public function storeDm(Request $request): JsonResponse
+    {
+        $validated = $request->validate(['user_id' => 'required|integer|exists:users,id']);
+
+        $me    = $request->user();
+        $other = User::findOrFail($validated['user_id']);
+
+        abort_unless($this->conversations->canDm($me, $other), 403, 'You do not share a band with this user.');
+
+        $conversation = $this->conversations->dmBetween($me, $other);
+
+        return response()->json(['conversation' => $this->summarize($conversation, $me, null)]);
+    }
+
+    /** GET /api/mobile/chat/contacts — who the current user may start a DM with. */
+    public function contacts(Request $request): JsonResponse
+    {
+        $user = $request->user();
+
+        /** @var array<int, array{bands: list<string>, is_sub: bool}> $entries */
+        $entries = [];
+
+        $add = function ($userId, string $bandName, bool $isSub) use (&$entries, $user) {
+            $userId = (int) $userId;
+            if ($userId === $user->id) {
+                return;
+            }
+            $entries[$userId] ??= ['bands' => [], 'is_sub' => $isSub];
+            if (!in_array($bandName, $entries[$userId]['bands'], true)) {
+                $entries[$userId]['bands'][] = $bandName;
+            }
+            // Any non-sub relationship wins over sub.
+            $entries[$userId]['is_sub'] = $entries[$userId]['is_sub'] && $isSub;
+        };
+
+        // Bands I own or play in: owners + members, plus that band's subs.
+        foreach ($user->bands()->unique('id') as $band) {
+            foreach ($band->owners()->pluck('user_id')->merge($band->members()->pluck('user_id')) as $id) {
+                $add($id, $band->name, false);
+            }
+            foreach (DB::table('band_subs')->where('band_id', $band->id)->pluck('user_id') as $id) {
+                $add($id, $band->name, true);
+            }
+        }
+
+        // Bands I sub for: their owners and members (not fellow subs).
+        foreach ($user->bandSub as $band) {
+            foreach ($band->owners()->pluck('user_id')->merge($band->members()->pluck('user_id')) as $id) {
+                $add($id, $band->name, false);
+            }
+        }
+
+        $names = User::whereIn('id', array_keys($entries))->pluck('name', 'id');
+
+        $contacts = collect($entries)
+            ->map(function ($entry, $userId) use ($names) {
+                $bandList = implode(', ', $entry['bands']);
+
+                return [
+                    'id'         => (int) $userId,
+                    'name'       => (string) ($names[$userId] ?? ''),
+                    'avatar_url' => null,
+                    'context'    => $entry['is_sub'] ? 'Sub — ' . $bandList : $bandList,
+                    'is_sub'     => $entry['is_sub'],
+                ];
+            })
+            ->sortBy('name')->values();
+
+        return response()->json(['contacts' => $contacts]);
+    }
+
+    /** Conversation JSON — the one wire shape for a conversation everywhere. */
+    private function summarize(Conversation $conversation, User $user, $lastReadAt): array
+    {
+        $last = $conversation->messages()->withTrashed()->latest('id')->with('attachments')->first();
+
+        $preview = null;
+        $lastAt  = null;
+        if ($last) {
+            $lastAt  = $last->created_at->toIso8601String();
+            $preview = $last->trashed()
+                ? null
+                : (($last->body !== null && $last->body !== '') ? $last->body : '📷 Photo');
+        }
+
+        $unread = Message::where('conversation_id', $conversation->id)
+            ->where('user_id', '!=', $user->id)
+            ->when($lastReadAt, fn ($q) => $q->where('created_at', '>', $lastReadAt))
+            ->count();
+
+        $title = match ($conversation->type) {
+            Conversation::TYPE_BAND => $conversation->band?->name ?? 'Band',
+            Conversation::TYPE_DM   => $conversation->participants()
+                ->where('user_id', '!=', $user->id)->with('user')->first()?->user?->name ?? 'Direct message',
+            default => 'Conversation',
+        };
+
+        return [
+            'id'                   => $conversation->id,
+            'type'                 => $conversation->type,
+            'band_id'              => $conversation->band_id ? (int) $conversation->band_id : null,
+            'title'                => $title,
+            'last_message_preview' => $preview,
+            'last_message_at'      => $lastAt,
+            'unread_count'         => $unread,
+            'can_moderate'         => $user->can('moderate', $conversation),
+        ];
+    }
+}

--- a/app/Http/Controllers/Api/Mobile/ConversationsController.php
+++ b/app/Http/Controllers/Api/Mobile/ConversationsController.php
@@ -82,19 +82,53 @@ class ConversationsController extends Controller
             ->keyBy('conversation_id');
 
         // Grouped count of "not mine" messages per conversation that are
-        // newer than that conversation's own last_read_at, in one query via
-        // a per-row conditional (each conversation's threshold differs).
-        $unread = Message::whereIn('conversation_id', $ids)
-            ->where('user_id', '!=', $user->id)
-            ->get(['conversation_id', 'created_at'])
-            ->groupBy('conversation_id')
-            ->map(function ($messages, $conversationId) use ($lastReads) {
-                $lastReadAt = $lastReads->get($conversationId);
+        // newer than that conversation's own last_read_at. Thresholds differ
+        // per conversation, so this is two aggregate queries instead of one:
+        // conversations where the user has a read marker (join + threshold
+        // filter) and conversations where they don't (no floor, count all).
+        // Either way it's O(1) queries, never O(messages) rows into PHP.
+        // A participant row can exist with a NULL last_read_at (registered
+        // but never marked anything read) — that must fall into the
+        // "no floor, count everything" bucket, same as having no row at all.
+        $withMarkerIds    = $lastReads->filter(fn ($v) => $v !== null)->keys();
+        $withoutMarkerIds = collect($ids)->diff($withMarkerIds);
 
-                return $lastReadAt
-                    ? $messages->filter(fn ($m) => $m->created_at->gt($lastReadAt))->count()
-                    : $messages->count();
-            });
+        // Both queries key their result by conversation_id, which pluck()
+        // returns as PHP integer keys — Collection::merge() re-indexes
+        // (appends) integer-keyed collections instead of merging by key, so
+        // union() is required here to preserve the conversation_id keying.
+        $unread = collect();
+
+        if ($withMarkerIds->isNotEmpty()) {
+            $unread = $unread->union(
+                Message::query()
+                    ->whereIn('messages.conversation_id', $withMarkerIds)
+                    ->where(fn ($q) => $q->where('messages.user_id', '!=', $user->id)
+                        ->orWhereNull('messages.user_id'))
+                    ->join('conversation_participants', function ($join) use ($user) {
+                        $join->on('conversation_participants.conversation_id', '=', 'messages.conversation_id')
+                            ->where('conversation_participants.user_id', '=', $user->id);
+                    })
+                    ->whereColumn('messages.created_at', '>', 'conversation_participants.last_read_at')
+                    ->selectRaw('messages.conversation_id as conversation_id, COUNT(*) as unread')
+                    ->groupBy('messages.conversation_id')
+                    ->pluck('unread', 'conversation_id')
+                    ->map(fn ($n) => (int) $n)
+            );
+        }
+
+        if ($withoutMarkerIds->isNotEmpty()) {
+            $unread = $unread->union(
+                Message::query()
+                    ->whereIn('conversation_id', $withoutMarkerIds->values())
+                    ->where(fn ($q) => $q->where('user_id', '!=', $user->id)
+                        ->orWhereNull('user_id'))
+                    ->selectRaw('conversation_id, COUNT(*) as unread')
+                    ->groupBy('conversation_id')
+                    ->pluck('unread', 'conversation_id')
+                    ->map(fn ($n) => (int) $n)
+            );
+        }
 
         $dmOther = ConversationParticipant::whereIn('conversation_id', $ids)
             ->where('user_id', '!=', $user->id)

--- a/app/Http/Controllers/Api/Mobile/MessagesController.php
+++ b/app/Http/Controllers/Api/Mobile/MessagesController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers\Api\Mobile;
 
+use App\Events\ConversationStreamEvent;
 use App\Http\Controllers\Controller;
 use App\Models\Message;
 use App\Models\MessageAttachment;
@@ -25,6 +26,10 @@ class MessagesController extends Controller
         $message->update(['body' => $validated['body'], 'edited_at' => now()]);
         $message->load(['user', 'attachments']);
 
+        broadcast(new ConversationStreamEvent($message->conversation_id, 'message.updated', [
+            'message' => $this->formatter->format($message),
+        ]))->toOthers();
+
         return response()->json(['message' => $this->formatter->format($message)]);
     }
 
@@ -38,6 +43,10 @@ class MessagesController extends Controller
         }
 
         $message->delete();
+
+        broadcast(new ConversationStreamEvent($message->conversation_id, 'message.deleted', [
+            'message_id' => $message->id,
+        ]))->toOthers();
 
         return response()->json(null, 204);
     }

--- a/app/Http/Controllers/Api/Mobile/MessagesController.php
+++ b/app/Http/Controllers/Api/Mobile/MessagesController.php
@@ -43,7 +43,7 @@ class MessagesController extends Controller
     }
 
     /** GET /api/mobile/messages/{message}/attachments/{attachment} — authenticated binary. */
-    public function attachment(Request $request, Message $message, MessageAttachment $attachment): StreamedResponse
+    public function attachment(Message $message, MessageAttachment $attachment): StreamedResponse
     {
         // Route binding excludes soft-deleted messages, so a deleted
         // message's attachments 404 without an explicit check.

--- a/app/Http/Controllers/Api/Mobile/MessagesController.php
+++ b/app/Http/Controllers/Api/Mobile/MessagesController.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace App\Http\Controllers\Api\Mobile;
+
+use App\Http\Controllers\Controller;
+use App\Models\Message;
+use App\Models\MessageAttachment;
+use App\Services\Chat\MessageFormatter;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Storage;
+use Symfony\Component\HttpFoundation\StreamedResponse;
+
+class MessagesController extends Controller
+{
+    public function __construct(private readonly MessageFormatter $formatter) {}
+
+    /** PATCH /api/mobile/messages/{message} — author only, always. */
+    public function update(Request $request, Message $message): JsonResponse
+    {
+        abort_unless($message->user_id === $request->user()->id, 403, 'Only the author may edit a message.');
+
+        $validated = $request->validate(['body' => 'required|string|max:4000']);
+
+        $message->update(['body' => $validated['body'], 'edited_at' => now()]);
+        $message->load(['user', 'attachments']);
+
+        return response()->json(['message' => $this->formatter->format($message)]);
+    }
+
+    /** DELETE /api/mobile/messages/{message} — author, or moderator on band/topic threads. */
+    public function destroy(Request $request, Message $message): JsonResponse
+    {
+        $user = $request->user();
+
+        if ($message->user_id !== $user->id && !$user->can('moderate', $message->conversation)) {
+            abort(403);
+        }
+
+        $message->delete();
+
+        return response()->json(null, 204);
+    }
+
+    /** GET /api/mobile/messages/{message}/attachments/{attachment} — authenticated binary. */
+    public function attachment(Request $request, Message $message, MessageAttachment $attachment): StreamedResponse
+    {
+        // Route binding excludes soft-deleted messages, so a deleted
+        // message's attachments 404 without an explicit check.
+        abort_if($attachment->message_id !== $message->id, 404);
+        $this->authorize('view', $message->conversation);
+
+        return Storage::disk($attachment->disk)->response(
+            $attachment->path,
+            null,
+            ['Content-Type' => $attachment->mime],
+        );
+    }
+}

--- a/app/Jobs/ProcessChatMessagePush.php
+++ b/app/Jobs/ProcessChatMessagePush.php
@@ -30,10 +30,11 @@ class ProcessChatMessagePush implements ShouldQueue
         }
 
         $conversation = $message->conversation;
-        $body  = $message->body !== null && $message->body !== '' ? $message->body : '📷 Photo';
-        $title = $conversation->type === Conversation::TYPE_DM
-            ? $message->user->name
-            : ($conversation->band?->name ?? 'Band') . ' — ' . $message->user->name;
+        $body       = $message->body !== null && $message->body !== '' ? $message->body : '📷 Photo';
+        $senderName = $message->user->name ?? 'Deleted user';
+        $title      = $conversation->type === Conversation::TYPE_DM
+            ? $senderName
+            : ($conversation->band?->name ?? 'Band') . ' — ' . $senderName;
 
         // FCM data messages carry strings only; conversationId is stringified.
         $data = [

--- a/app/Jobs/ProcessChatMessagePush.php
+++ b/app/Jobs/ProcessChatMessagePush.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace App\Jobs;
+
+use App\Models\Conversation;
+use App\Models\Message;
+use App\Models\User;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+
+/**
+ * Resolves a message's audience ("push everything" per the spec) and fans
+ * out one SendUserPush per recipient. Queued so the per-user permission
+ * checks never sit on the send-message request path.
+ */
+class ProcessChatMessagePush implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    public function __construct(public int $messageId) {}
+
+    public function handle(): void
+    {
+        $message = Message::with(['conversation.band', 'user'])->find($this->messageId);
+        if (!$message || $message->trashed()) {
+            return;
+        }
+
+        $conversation = $message->conversation;
+        $body  = $message->body !== null && $message->body !== '' ? $message->body : '📷 Photo';
+        $title = $conversation->type === Conversation::TYPE_DM
+            ? $message->user->name
+            : ($conversation->band?->name ?? 'Band') . ' — ' . $message->user->name;
+
+        // FCM data messages carry strings only; conversationId is stringified.
+        $data = [
+            'type'           => 'chat_message',
+            'conversationId' => (string) $conversation->id,
+            'title'          => $title,
+            'body'           => $body,
+        ];
+
+        foreach ($this->recipients($conversation) as $userId) {
+            if ((int) $userId === (int) $message->user_id) {
+                continue;
+            }
+            SendUserPush::dispatch((int) $userId, $data, 'chat_message:' . $message->id);
+        }
+    }
+
+    /** @return list<int> */
+    private function recipients(Conversation $conversation): array
+    {
+        if ($conversation->type === Conversation::TYPE_DM) {
+            return $conversation->participants()->pluck('user_id')->map(fn ($id) => (int) $id)->all();
+        }
+
+        $band = $conversation->band;
+        if (!$band) {
+            return [];
+        }
+
+        $memberIds = $band->owners()->pluck('user_id')
+            ->merge($band->members()->pluck('user_id'))
+            ->unique();
+
+        if ($conversation->type === Conversation::TYPE_BAND) {
+            return $memberIds->map(fn ($id) => (int) $id)->values()->all();
+        }
+
+        // Topic: audience == everyone the policy admits. Reuse the policy so
+        // recipients can never drift from visibility (incl. entitled subs).
+        $subIds = \DB::table('band_subs')->where('band_id', $band->id)->pluck('user_id');
+
+        return $memberIds->merge($subIds)->unique()
+            ->filter(function ($userId) use ($conversation) {
+                $user = User::find($userId);
+
+                return $user && $user->can('view', $conversation);
+            })
+            ->map(fn ($id) => (int) $id)->values()->all();
+    }
+}

--- a/app/Models/Conversation.php
+++ b/app/Models/Conversation.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\MorphTo;
+
+class Conversation extends Model
+{
+    use HasFactory;
+
+    public const TYPE_DM    = 'dm';
+    public const TYPE_BAND  = 'band';
+    public const TYPE_TOPIC = 'topic';
+
+    protected $fillable = ['type', 'band_id', 'conversable_type', 'conversable_id', 'unique_key'];
+
+    public static function dmKeyFor(int $userA, int $userB): string
+    {
+        return 'dm:' . min($userA, $userB) . ':' . max($userA, $userB);
+    }
+
+    public static function bandKeyFor(int $bandId): string
+    {
+        return 'band:' . $bandId;
+    }
+
+    public static function topicKeyFor(Model $conversable): string
+    {
+        return 'topic:' . get_class($conversable) . ':' . $conversable->getKey();
+    }
+
+    public function conversable(): MorphTo
+    {
+        return $this->morphTo();
+    }
+
+    public function band()
+    {
+        return $this->belongsTo(Bands::class, 'band_id');
+    }
+
+    public function participants()
+    {
+        return $this->hasMany(ConversationParticipant::class);
+    }
+
+    public function messages()
+    {
+        return $this->hasMany(Message::class);
+    }
+}

--- a/app/Models/ConversationParticipant.php
+++ b/app/Models/ConversationParticipant.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class ConversationParticipant extends Model
+{
+    protected $fillable = ['conversation_id', 'user_id', 'last_read_at'];
+
+    protected $casts = ['last_read_at' => 'datetime'];
+
+    public function conversation()
+    {
+        return $this->belongsTo(Conversation::class);
+    }
+
+    public function user()
+    {
+        return $this->belongsTo(User::class);
+    }
+}

--- a/app/Models/Message.php
+++ b/app/Models/Message.php
@@ -2,17 +2,39 @@
 
 namespace App\Models;
 
+use App\Events\ConversationChanged;
+use App\Models\Traits\BroadcastsBandChanges;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
 
 class Message extends Model
 {
-    use HasFactory, SoftDeletes;
+    use HasFactory, SoftDeletes, BroadcastsBandChanges;
 
     protected $fillable = ['conversation_id', 'user_id', 'body', 'edited_at'];
 
     protected $casts = ['edited_at' => 'datetime'];
+
+    protected static function booted(): void
+    {
+        // DM threads have no band — signal each participant's user channel
+        // instead. Band/topic threads are covered by BroadcastsBandChanges.
+        $signalDm = function (self $message, string $action) {
+            $conversation = $message->conversation;
+            if (!$conversation || $conversation->type !== Conversation::TYPE_DM) {
+                return;
+            }
+            foreach ($conversation->participants()->pluck('user_id') as $userId) {
+                broadcast(new ConversationChanged((int) $userId, $conversation->id, $message->id, $action))
+                    ->toOthers();
+            }
+        };
+
+        static::created(fn (self $m) => $signalDm($m, 'created'));
+        static::updated(fn (self $m) => $signalDm($m, 'updated'));
+        static::deleted(fn (self $m) => $signalDm($m, 'deleted'));
+    }
 
     public function conversation()
     {
@@ -27,5 +49,16 @@ class Message extends Model
     public function attachments()
     {
         return $this->hasMany(MessageAttachment::class);
+    }
+
+    protected function broadcastBandId(): ?int
+    {
+        // Null for DMs → the band-channel trait skips them silently.
+        return $this->conversation?->band_id ? (int) $this->conversation->band_id : null;
+    }
+
+    protected function broadcastParent(): ?array
+    {
+        return ['model' => 'conversation', 'id' => (int) $this->conversation_id];
     }
 }

--- a/app/Models/Message.php
+++ b/app/Models/Message.php
@@ -18,9 +18,21 @@ class Message extends Model
 
     protected static function booted(): void
     {
-        // DM threads have no band — signal each participant's user channel
-        // instead. Band/topic threads are covered by BroadcastsBandChanges.
-        $signalDm = function (self $message, string $action) {
+        static::created(fn (self $m) => static::signalDmParticipants($m, 'created'));
+        static::updated(fn (self $m) => static::signalDmParticipants($m, 'updated'));
+        static::deleted(fn (self $m) => static::signalDmParticipants($m, 'deleted'));
+    }
+
+    /**
+     * DM threads have no band — signal each participant's user channel
+     * instead. Band/topic threads are covered by BroadcastsBandChanges.
+     *
+     * Mirrors BroadcastsBandChanges::broadcastBandChange(): a realtime
+     * signal must never break the write that caused it.
+     */
+    protected static function signalDmParticipants(self $message, string $action): void
+    {
+        try {
             $conversation = $message->conversation;
             if (!$conversation || $conversation->type !== Conversation::TYPE_DM) {
                 return;
@@ -29,11 +41,9 @@ class Message extends Model
                 broadcast(new ConversationChanged((int) $userId, $conversation->id, $message->id, $action))
                     ->toOthers();
             }
-        };
-
-        static::created(fn (self $m) => $signalDm($m, 'created'));
-        static::updated(fn (self $m) => $signalDm($m, 'updated'));
-        static::deleted(fn (self $m) => $signalDm($m, 'deleted'));
+        } catch (\Throwable $e) {
+            report($e);
+        }
     }
 
     public function conversation()

--- a/app/Models/Message.php
+++ b/app/Models/Message.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
+
+class Message extends Model
+{
+    use HasFactory, SoftDeletes;
+
+    protected $fillable = ['conversation_id', 'user_id', 'body', 'edited_at'];
+
+    protected $casts = ['edited_at' => 'datetime'];
+
+    public function conversation()
+    {
+        return $this->belongsTo(Conversation::class);
+    }
+
+    public function user()
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    public function attachments()
+    {
+        return $this->hasMany(MessageAttachment::class);
+    }
+}

--- a/app/Models/MessageAttachment.php
+++ b/app/Models/MessageAttachment.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class MessageAttachment extends Model
+{
+    protected $fillable = ['message_id', 'path', 'disk', 'mime', 'width', 'height', 'size_bytes'];
+
+    public function message()
+    {
+        return $this->belongsTo(Message::class);
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -224,6 +224,43 @@ class User extends Authenticatable
         return $result;
     }
 
+    /**
+     * Is this user assigned to the given event as a sub — via an accepted
+     * event_subs invitation or an event_members row filling a sub slot?
+     * Mirrors the entitlement join in UserEventsService/assignedChartIdsForBand.
+     */
+    public function isEntitledToEvent(int $eventId): bool
+    {
+        return \DB::table('event_subs')
+                ->where('user_id', $this->id)
+                ->where('pending', false)
+                ->where('event_id', $eventId)
+                ->exists()
+            || \DB::table('event_members')
+                ->where('user_id', $this->id)
+                ->whereNull('roster_member_id')
+                ->whereNull('deleted_at')
+                ->where('event_id', $eventId)
+                ->exists();
+    }
+
+    /**
+     * May this user delete OTHER people's messages in band/topic threads?
+     * Owners always; members via the team-scoped `moderate:chat` permission.
+     */
+    public function canModerateChat($bandId): bool
+    {
+        if ($this->ownsBand($bandId)) {
+            return true;
+        }
+
+        setPermissionsTeamId($bandId);
+        $result = $this->hasPermissionTo('moderate:chat');
+        setPermissionsTeamId(0);
+
+        return $result;
+    }
+
     public function charts()
     {
         // return $this->hasManyThrough(Charts::class,Bands::class,'band_members','user_id','band_id');

--- a/app/Policies/ConversationPolicy.php
+++ b/app/Policies/ConversationPolicy.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace App\Policies;
+
+use App\Models\Bookings;
+use App\Models\Conversation;
+use App\Models\Events;
+use App\Models\Rehearsal;
+use App\Models\User;
+
+class ConversationPolicy
+{
+    public function view(User $user, Conversation $conversation): bool
+    {
+        return match ($conversation->type) {
+            Conversation::TYPE_DM => $conversation->participants()
+                ->where('user_id', $user->id)->exists(),
+
+            // Owners + members only. Deliberately NOT canRead('events'):
+            // that returns true for subs, who are excluded from the channel.
+            Conversation::TYPE_BAND => $user->ownsBand($conversation->band_id)
+                || $user->isPartOfBand($conversation->band_id),
+
+            Conversation::TYPE_TOPIC => $this->viewTopic($user, $conversation),
+
+            default => false,
+        };
+    }
+
+    /** Everyone who can see a thread can post in it. */
+    public function post(User $user, Conversation $conversation): bool
+    {
+        return $this->view($user, $conversation);
+    }
+
+    /** Delete others' messages: band/topic only, owner or moderate:chat. */
+    public function moderate(User $user, Conversation $conversation): bool
+    {
+        if ($conversation->type === Conversation::TYPE_DM) {
+            return false;
+        }
+
+        return $user->canModerateChat($conversation->band_id);
+    }
+
+    private function viewTopic(User $user, Conversation $conversation): bool
+    {
+        $bandId = (int) $conversation->band_id;
+        $target = $conversation->conversable;
+
+        if (!$target) {
+            return false;
+        }
+
+        $isOwnerOrMember = $user->ownsBand($bandId) || $user->isPartOfBand($bandId);
+
+        if ($target instanceof Bookings) {
+            // canRead('bookings') has no sub shortcut, so subs are excluded here.
+            return $isOwnerOrMember && $user->canRead('bookings', $bandId);
+        }
+
+        if ($target instanceof Rehearsal) {
+            if ($isOwnerOrMember) {
+                return $user->canRead('rehearsals', $bandId);
+            }
+
+            // Sub path: entitled to ANY Events row wrapping this rehearsal.
+            return $target->events()->pluck('id')
+                ->contains(fn ($eventId) => $user->isEntitledToEvent((int) $eventId));
+        }
+
+        if ($target instanceof Events) {
+            if ($isOwnerOrMember) {
+                return $user->canRead('events', $bandId);
+            }
+
+            return $user->isEntitledToEvent($target->id);
+        }
+
+        return false;
+    }
+}

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -5,9 +5,11 @@ namespace App\Providers;
 use Illuminate\Foundation\Support\Providers\AuthServiceProvider as ServiceProvider;
 use Illuminate\Support\Facades\Gate;
 use App\Models\Bookings;
+use App\Models\Conversation;
 use App\Models\Events;
 use App\Models\Questionnaires;
 use App\Policies\BookingsPolicy;
+use App\Policies\ConversationPolicy;
 use App\Policies\EventsPolicy;
 use App\Policies\QuestionnairePolicy;
 
@@ -21,6 +23,7 @@ class AuthServiceProvider extends ServiceProvider
     protected $policies = [
         // 'App\Models\Model' => 'App\Policies\ModelPolicy',
         Bookings::class => BookingsPolicy::class,
+        Conversation::class => ConversationPolicy::class,
         Events::class => EventsPolicy::class,
         Questionnaires::class => QuestionnairePolicy::class,
     ];

--- a/app/Providers/RouteServiceProvider.php
+++ b/app/Providers/RouteServiceProvider.php
@@ -88,5 +88,12 @@ class RouteServiceProvider extends ServiceProvider
         {
             return Limit::perMinute(60)->by(optional($request->user())->id ?: $request->ip());
         });
+
+        // Typing pings are frequent and ephemeral; keep them off the shared
+        // 'api' budget so a chatty typing indicator can't 429 message sends.
+        RateLimiter::for('chat-typing', function (Request $request)
+        {
+            return Limit::perMinute(30)->by(optional($request->user())->id ?: $request->ip());
+        });
     }
 }

--- a/app/Services/Chat/ConversationService.php
+++ b/app/Services/Chat/ConversationService.php
@@ -1,0 +1,127 @@
+<?php
+
+namespace App\Services\Chat;
+
+use App\Models\Bands;
+use App\Models\Bookings;
+use App\Models\Conversation;
+use App\Models\ConversationParticipant;
+use App\Models\Events;
+use App\Models\Rehearsal;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\UniqueConstraintViolationException;
+
+class ConversationService
+{
+    /**
+     * Canonicalization rule (spec): an Events row wrapping a Rehearsal shares
+     * the rehearsal's thread, so the event screen and rehearsal screen reach
+     * ONE conversation. Bookings are NOT collapsed — a booking's thread is a
+     * different discussion context than its performance events'.
+     */
+    public function canonicalTarget(Model $target): Model
+    {
+        if ($target instanceof Events && $target->eventable instanceof Rehearsal) {
+            return $target->eventable;
+        }
+
+        return $target;
+    }
+
+    public function topicFor(Model $target): Conversation
+    {
+        $target = $this->canonicalTarget($target);
+
+        $bandId = match (true) {
+            $target instanceof Events => $target->eventable?->band_id,
+            $target instanceof Rehearsal, $target instanceof Bookings => $target->band_id,
+            default => null,
+        };
+
+        abort_if($bandId === null, 404, 'Band not found for this topic.');
+
+        return $this->firstOrCreateByKey([
+            'type'             => Conversation::TYPE_TOPIC,
+            'band_id'          => (int) $bandId,
+            'conversable_type' => get_class($target),
+            'conversable_id'   => $target->getKey(),
+            'unique_key'       => Conversation::topicKeyFor($target),
+        ]);
+    }
+
+    public function bandChannelFor(Bands $band): Conversation
+    {
+        return $this->firstOrCreateByKey([
+            'type'       => Conversation::TYPE_BAND,
+            'band_id'    => $band->id,
+            'unique_key' => Conversation::bandKeyFor($band->id),
+        ]);
+    }
+
+    public function dmBetween(User $a, User $b): Conversation
+    {
+        $conversation = $this->firstOrCreateByKey([
+            'type'       => Conversation::TYPE_DM,
+            'unique_key' => Conversation::dmKeyFor($a->id, $b->id),
+        ]);
+
+        // DM participant rows are explicit (they ARE the access list).
+        foreach ([$a->id, $b->id] as $userId) {
+            ConversationParticipant::firstOrCreate([
+                'conversation_id' => $conversation->id,
+                'user_id'         => $userId,
+            ]);
+        }
+
+        return $conversation;
+    }
+
+    /**
+     * Two users may DM when they share at least one band in any role
+     * (owner/member/sub). Self-DM is not allowed.
+     */
+    public function canDm(User $a, User $b): bool
+    {
+        if ($a->id === $b->id) {
+            return false;
+        }
+
+        $aBandIds = $a->allBands()->pluck('id');
+        $bBandIds = $b->allBands()->pluck('id');
+
+        return $aBandIds->intersect($bBandIds)->isNotEmpty();
+    }
+
+    /**
+     * Lazily record that $user is in the thread and mark it read now.
+     * Access itself is derived by ConversationPolicy — this row only powers
+     * unread counts and read receipts.
+     */
+    public function touchParticipant(Conversation $conversation, User $user): ConversationParticipant
+    {
+        $participant = ConversationParticipant::firstOrCreate([
+            'conversation_id' => $conversation->id,
+            'user_id'         => $user->id,
+        ]);
+
+        $participant->forceFill(['last_read_at' => now()])->save();
+
+        return $participant;
+    }
+
+    /** firstOrCreate with the unique_key race resolved by re-fetch. */
+    private function firstOrCreateByKey(array $attributes): Conversation
+    {
+        $existing = Conversation::where('unique_key', $attributes['unique_key'])->first();
+        if ($existing) {
+            return $existing;
+        }
+
+        try {
+            return Conversation::create($attributes);
+        } catch (UniqueConstraintViolationException) {
+            return Conversation::where('unique_key', $attributes['unique_key'])->firstOrFail();
+        }
+    }
+}

--- a/app/Services/Chat/MessageFormatter.php
+++ b/app/Services/Chat/MessageFormatter.php
@@ -19,8 +19,10 @@ class MessageFormatter
         return [
             'id'              => $message->id,
             'conversation_id' => $message->conversation_id,
-            'user_id'         => $message->user_id,
-            'user_name'       => $message->user->name,
+            // The Flutter contract types user_id as a non-nullable int; a
+            // tombstoned author (account deleted, FK nulled) reports 0.
+            'user_id'         => $message->user_id ?? 0,
+            'user_name'       => $message->user->name ?? 'Deleted user',
             'user_avatar_url' => null,
             'body'            => $deleted ? null : $message->body,
             'attachments'     => $deleted ? [] : $message->attachments->map(fn ($a) => [

--- a/app/Services/Chat/MessageFormatter.php
+++ b/app/Services/Chat/MessageFormatter.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Services\Chat;
+
+use App\Models\Message;
+
+class MessageFormatter
+{
+    /**
+     * Single FLAT wire shape for a message everywhere (thread page, stream).
+     * Attachment binaries are fetched by the client-constructed URL
+     * GET /api/mobile/messages/{message_id}/attachments/{id} — the payload
+     * deliberately carries only what layout needs (id + dimensions).
+     */
+    public function format(Message $message): array
+    {
+        $deleted = $message->trashed();
+
+        return [
+            'id'              => $message->id,
+            'conversation_id' => $message->conversation_id,
+            'user_id'         => $message->user_id,
+            'user_name'       => $message->user->name,
+            'user_avatar_url' => null,
+            'body'            => $deleted ? null : $message->body,
+            'attachments'     => $deleted ? [] : $message->attachments->map(fn ($a) => [
+                'id'     => $a->id,
+                'width'  => $a->width,
+                'height' => $a->height,
+            ])->values()->all(),
+            'edited_at'  => $message->edited_at?->toIso8601String(),
+            'is_deleted' => $deleted,
+            'created_at' => $message->created_at->toIso8601String(),
+        ];
+    }
+}

--- a/app/Services/Mobile/TokenService.php
+++ b/app/Services/Mobile/TokenService.php
@@ -11,7 +11,11 @@ class TokenService
 
     public function buildAbilities(User $user): array
     {
-        $abilities = ['mobile'];
+        // `chat` is structural, not permission-derived: every band role
+        // (owner/member/sub) can use SOME slice of chat, and
+        // ConversationPolicy is the per-conversation authority. A bare
+        // ability keeps the door open for coarse route gating later.
+        $abilities = ['mobile', 'chat'];
 
         // Delegate to User::canRead()/canWrite() rather than re-checking Spatie
         // permissions directly. Those methods already encode the owner shortcut

--- a/database/factories/ConversationFactory.php
+++ b/database/factories/ConversationFactory.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Conversation;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Str;
+
+class ConversationFactory extends Factory
+{
+    protected $model = Conversation::class;
+
+    public function definition(): array
+    {
+        return [
+            'type'       => Conversation::TYPE_BAND,
+            'band_id'    => null,
+            'unique_key' => 'test:' . Str::uuid(),
+        ];
+    }
+}

--- a/database/factories/MessageFactory.php
+++ b/database/factories/MessageFactory.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Conversation;
+use App\Models\Message;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class MessageFactory extends Factory
+{
+    protected $model = Message::class;
+
+    public function definition(): array
+    {
+        return [
+            'conversation_id' => Conversation::factory(),
+            'user_id'         => User::factory(),
+            'body'            => $this->faker->sentence(),
+        ];
+    }
+}

--- a/database/migrations/2026_07_12_000001_create_chat_tables.php
+++ b/database/migrations/2026_07_12_000001_create_chat_tables.php
@@ -1,0 +1,67 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('conversations', function (Blueprint $table) {
+            $table->id();
+            $table->string('type', 16); // dm | band | topic
+            $table->foreignId('band_id')->nullable()->constrained('bands')->cascadeOnDelete();
+            $table->string('conversable_type')->nullable();
+            $table->unsignedBigInteger('conversable_id')->nullable();
+            // Deterministic identity: "dm:{lo}:{hi}" | "band:{bandId}" |
+            // "topic:{morphClass}:{id}" — DB-level one-conversation-per-target
+            // for all three types with a single unique column.
+            $table->string('unique_key')->unique();
+            $table->timestamps();
+            $table->index(['conversable_type', 'conversable_id']);
+            $table->index('band_id');
+        });
+
+        Schema::create('conversation_participants', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('conversation_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('user_id')->constrained()->cascadeOnDelete();
+            $table->timestamp('last_read_at')->nullable();
+            $table->timestamps();
+            $table->unique(['conversation_id', 'user_id']);
+            $table->index('user_id');
+        });
+
+        Schema::create('messages', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('conversation_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('user_id')->constrained();
+            $table->text('body')->nullable(); // nullable: image-only messages
+            $table->timestamp('edited_at')->nullable();
+            $table->softDeletes();
+            $table->timestamps();
+            $table->index(['conversation_id', 'id']);
+        });
+
+        Schema::create('message_attachments', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('message_id')->constrained()->cascadeOnDelete();
+            $table->string('path');
+            $table->string('disk', 32);
+            $table->string('mime', 64);
+            $table->unsignedInteger('width')->nullable();
+            $table->unsignedInteger('height')->nullable();
+            $table->unsignedBigInteger('size_bytes');
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('message_attachments');
+        Schema::dropIfExists('messages');
+        Schema::dropIfExists('conversation_participants');
+        Schema::dropIfExists('conversations');
+    }
+};

--- a/database/migrations/2026_07_12_000001_create_chat_tables.php
+++ b/database/migrations/2026_07_12_000001_create_chat_tables.php
@@ -26,7 +26,7 @@ return new class extends Migration
         Schema::create('conversation_participants', function (Blueprint $table) {
             $table->id();
             $table->foreignId('conversation_id')->constrained()->cascadeOnDelete();
-            $table->foreignId('user_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('user_id')->constrained()->cascadeOnDelete(); // participant row is meaningless without its user; the DM thread itself survives via the remaining participant
             $table->timestamp('last_read_at')->nullable();
             $table->timestamps();
             $table->unique(['conversation_id', 'user_id']);
@@ -36,7 +36,7 @@ return new class extends Migration
         Schema::create('messages', function (Blueprint $table) {
             $table->id();
             $table->foreignId('conversation_id')->constrained()->cascadeOnDelete();
-            $table->foreignId('user_id')->constrained();
+            $table->foreignId('user_id')->nullable()->constrained()->nullOnDelete();
             $table->text('body')->nullable(); // nullable: image-only messages
             $table->timestamp('edited_at')->nullable();
             $table->softDeletes();

--- a/database/migrations/2026_07_12_000002_add_moderate_chat_permission.php
+++ b/database/migrations/2026_07_12_000002_add_moderate_chat_permission.php
@@ -1,0 +1,20 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Spatie\Permission\Models\Permission;
+use Spatie\Permission\PermissionRegistrar;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        app()[PermissionRegistrar::class]->forgetCachedPermissions();
+        Permission::firstOrCreate(['name' => 'moderate:chat', 'guard_name' => 'web']);
+    }
+
+    public function down(): void
+    {
+        Permission::where('name', 'moderate:chat')->where('guard_name', 'web')->delete();
+        app()[PermissionRegistrar::class]->forgetCachedPermissions();
+    }
+};

--- a/routes/api.php
+++ b/routes/api.php
@@ -120,6 +120,8 @@ Route::prefix('mobile')->group(function () {
         Route::get('/conversations', [App\Http\Controllers\Api\Mobile\ConversationsController::class, 'index'])->name('mobile.conversations.index');
         Route::post('/conversations/dm', [App\Http\Controllers\Api\Mobile\ConversationsController::class, 'storeDm'])->name('mobile.conversations.dm');
         Route::get('/chat/contacts', [App\Http\Controllers\Api\Mobile\ConversationsController::class, 'contacts'])->name('mobile.chat.contacts');
+        Route::get('/events/{event}/conversation', [App\Http\Controllers\Api\Mobile\ConversationsController::class, 'forEvent'])->name('mobile.events.conversation');
+        Route::get('/rehearsals/{rehearsal}/conversation', [App\Http\Controllers\Api\Mobile\ConversationsController::class, 'forRehearsal'])->name('mobile.rehearsals.conversation');
 
         // Events
         Route::get('/events/{event}', [App\Http\Controllers\Api\Mobile\EventsController::class, 'show'])->name('mobile.events.show');
@@ -227,6 +229,7 @@ Route::prefix('mobile')->group(function () {
             Route::get('/bands/{band}/bookings/{booking}/contract/download', [App\Http\Controllers\Api\Mobile\BookingsController::class, 'downloadContract'])->name('mobile.bookings.contract.download');
             Route::get('/bands/{band}/bookings/{booking}/history', [App\Http\Controllers\Api\Mobile\BookingsController::class, 'showHistory'])->name('mobile.bookings.history');
             Route::get('/bands/{band}/bookings/{booking}/payout', [App\Http\Controllers\Api\Mobile\BookingsController::class, 'payout'])->name('mobile.bookings.payout.show');
+            Route::get('/bands/{band}/bookings/{booking}/conversation', [App\Http\Controllers\Api\Mobile\ConversationsController::class, 'forBooking'])->name('mobile.bookings.conversation');
         });
 
         // ── Bookings (write) ───────────────────────────────────────────

--- a/routes/api.php
+++ b/routes/api.php
@@ -116,6 +116,11 @@ Route::prefix('mobile')->group(function () {
         Route::post('/devices', [App\Http\Controllers\Api\Mobile\DevicesController::class, 'store'])->name('mobile.devices.store');
         Route::delete('/devices', [App\Http\Controllers\Api\Mobile\DevicesController::class, 'destroy'])->name('mobile.devices.destroy');
 
+        // ── Chat / comments (band-agnostic; ConversationPolicy is the gate) ──
+        Route::get('/conversations', [App\Http\Controllers\Api\Mobile\ConversationsController::class, 'index'])->name('mobile.conversations.index');
+        Route::post('/conversations/dm', [App\Http\Controllers\Api\Mobile\ConversationsController::class, 'storeDm'])->name('mobile.conversations.dm');
+        Route::get('/chat/contacts', [App\Http\Controllers\Api\Mobile\ConversationsController::class, 'contacts'])->name('mobile.chat.contacts');
+
         // Events
         Route::get('/events/{event}', [App\Http\Controllers\Api\Mobile\EventsController::class, 'show'])->name('mobile.events.show');
         Route::patch('/events/{event}', [App\Http\Controllers\Api\Mobile\EventsController::class, 'update'])->name('mobile.events.update');

--- a/routes/api.php
+++ b/routes/api.php
@@ -125,7 +125,7 @@ Route::prefix('mobile')->group(function () {
         Route::get('/conversations/{conversation}/messages', [App\Http\Controllers\Api\Mobile\ConversationsController::class, 'messages'])->name('mobile.conversations.messages.index');
         Route::post('/conversations/{conversation}/messages', [App\Http\Controllers\Api\Mobile\ConversationsController::class, 'storeMessage'])->name('mobile.conversations.messages.store');
         Route::post('/conversations/{conversation}/read', [App\Http\Controllers\Api\Mobile\ConversationsController::class, 'read'])->name('mobile.conversations.read');
-        Route::post('/conversations/{conversation}/typing', [App\Http\Controllers\Api\Mobile\ConversationsController::class, 'typing'])->name('mobile.conversations.typing');
+        Route::post('/conversations/{conversation}/typing', [App\Http\Controllers\Api\Mobile\ConversationsController::class, 'typing'])->middleware('throttle:chat-typing')->name('mobile.conversations.typing');
         Route::patch('/messages/{message}', [App\Http\Controllers\Api\Mobile\MessagesController::class, 'update'])->name('mobile.messages.update');
         Route::delete('/messages/{message}', [App\Http\Controllers\Api\Mobile\MessagesController::class, 'destroy'])->name('mobile.messages.destroy');
         Route::get('/messages/{message}/attachments/{attachment}', [App\Http\Controllers\Api\Mobile\MessagesController::class, 'attachment'])->name('mobile.messages.attachments.show');

--- a/routes/api.php
+++ b/routes/api.php
@@ -122,6 +122,12 @@ Route::prefix('mobile')->group(function () {
         Route::get('/chat/contacts', [App\Http\Controllers\Api\Mobile\ConversationsController::class, 'contacts'])->name('mobile.chat.contacts');
         Route::get('/events/{event}/conversation', [App\Http\Controllers\Api\Mobile\ConversationsController::class, 'forEvent'])->name('mobile.events.conversation');
         Route::get('/rehearsals/{rehearsal}/conversation', [App\Http\Controllers\Api\Mobile\ConversationsController::class, 'forRehearsal'])->name('mobile.rehearsals.conversation');
+        Route::get('/conversations/{conversation}/messages', [App\Http\Controllers\Api\Mobile\ConversationsController::class, 'messages'])->name('mobile.conversations.messages.index');
+        Route::post('/conversations/{conversation}/messages', [App\Http\Controllers\Api\Mobile\ConversationsController::class, 'storeMessage'])->name('mobile.conversations.messages.store');
+        Route::post('/conversations/{conversation}/read', [App\Http\Controllers\Api\Mobile\ConversationsController::class, 'read'])->name('mobile.conversations.read');
+        Route::patch('/messages/{message}', [App\Http\Controllers\Api\Mobile\MessagesController::class, 'update'])->name('mobile.messages.update');
+        Route::delete('/messages/{message}', [App\Http\Controllers\Api\Mobile\MessagesController::class, 'destroy'])->name('mobile.messages.destroy');
+        Route::get('/messages/{message}/attachments/{attachment}', [App\Http\Controllers\Api\Mobile\MessagesController::class, 'attachment'])->name('mobile.messages.attachments.show');
 
         // Events
         Route::get('/events/{event}', [App\Http\Controllers\Api\Mobile\EventsController::class, 'show'])->name('mobile.events.show');

--- a/routes/api.php
+++ b/routes/api.php
@@ -125,6 +125,7 @@ Route::prefix('mobile')->group(function () {
         Route::get('/conversations/{conversation}/messages', [App\Http\Controllers\Api\Mobile\ConversationsController::class, 'messages'])->name('mobile.conversations.messages.index');
         Route::post('/conversations/{conversation}/messages', [App\Http\Controllers\Api\Mobile\ConversationsController::class, 'storeMessage'])->name('mobile.conversations.messages.store');
         Route::post('/conversations/{conversation}/read', [App\Http\Controllers\Api\Mobile\ConversationsController::class, 'read'])->name('mobile.conversations.read');
+        Route::post('/conversations/{conversation}/typing', [App\Http\Controllers\Api\Mobile\ConversationsController::class, 'typing'])->name('mobile.conversations.typing');
         Route::patch('/messages/{message}', [App\Http\Controllers\Api\Mobile\MessagesController::class, 'update'])->name('mobile.messages.update');
         Route::delete('/messages/{message}', [App\Http\Controllers\Api\Mobile\MessagesController::class, 'destroy'])->name('mobile.messages.destroy');
         Route::get('/messages/{message}/attachments/{attachment}', [App\Http\Controllers\Api\Mobile\MessagesController::class, 'attachment'])->name('mobile.messages.attachments.show');

--- a/routes/channels.php
+++ b/routes/channels.php
@@ -45,3 +45,12 @@ Broadcast::channel('rehearsal-planner.{sessionId}', function ($user, $sessionId)
 Broadcast::channel('band.{bandId}', function ($user, $bandId) {
     return $user->canRead('events', (int) $bandId);
 });
+
+// Open-thread channel: full message payloads (append/edit/delete), read
+// receipts, and typing for whoever has the conversation on screen. Unlike
+// band.{id}, payloads carry data, so auth is the full ConversationPolicy.
+Broadcast::channel('conversation.{conversationId}', function ($user, $conversationId) {
+    $conversation = \App\Models\Conversation::find($conversationId);
+
+    return $conversation !== null && $user->can('view', $conversation);
+});

--- a/tests/Feature/Api/Mobile/AccountDeletionTest.php
+++ b/tests/Feature/Api/Mobile/AccountDeletionTest.php
@@ -8,6 +8,8 @@ use App\Models\BandOwners;
 use App\Models\Bands;
 use App\Models\DeviceToken;
 use App\Models\User;
+use App\Services\AccountDeletionService;
+use App\Services\Chat\ConversationService;
 use App\Services\GoogleCalendarService;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Mail;
@@ -133,5 +135,38 @@ class AccountDeletionTest extends TestCase
         // used to probe whether an account id exists (always 403, never 404).
         $this->post('/account/confirm-deletion/999999?signature=deadbeef&expires=9999999999')
             ->assertForbidden();
+    }
+
+    public function test_deleting_a_user_with_chat_messages_succeeds_and_leaves_a_tombstoned_message(): void
+    {
+        $mockCalendar = Mockery::mock(GoogleCalendarService::class);
+        $this->app->instance(GoogleCalendarService::class, $mockCalendar);
+
+        $author = User::factory()->create();
+        $band   = Bands::factory()->create();
+        BandOwners::factory()->create(['user_id' => $author->id, 'band_id' => $band->id]);
+        $other = User::factory()->create();
+        BandMembers::factory()->create(['user_id' => $other->id, 'band_id' => $band->id]);
+
+        $dm = app(ConversationService::class)->dmBetween($author, $other);
+        $message = $dm->messages()->create(['user_id' => $author->id, 'body' => 'hey before I go']);
+
+        // Hard-deletes the User row directly — messages.user_id must survive
+        // via nullOnDelete rather than 500ing the whole deletion.
+        app(AccountDeletionService::class)->deleteAccount($author);
+
+        $this->assertDatabaseMissing('users', ['id' => $author->id]);
+        $this->assertDatabaseHas('messages', ['id' => $message->id, 'user_id' => null]);
+
+        // Thread page renders the tombstoned author as "Deleted user" with a
+        // non-null, contract-safe user_id.
+        $response = $this->actingAs($other)
+            ->getJson("/api/mobile/conversations/{$dm->id}/messages")
+            ->assertOk();
+
+        $row = collect($response->json('messages'))->firstWhere('id', $message->id);
+        $this->assertSame('hey before I go', $row['body']);
+        $this->assertSame('Deleted user', $row['user_name']);
+        $this->assertSame(0, $row['user_id']);
     }
 }

--- a/tests/Feature/Api/Mobile/Chat/ChatBroadcastingTest.php
+++ b/tests/Feature/Api/Mobile/Chat/ChatBroadcastingTest.php
@@ -119,6 +119,32 @@ class ChatBroadcastingTest extends TestCase
         );
     }
 
+    public function test_typing_has_its_own_rate_limit_separate_from_the_shared_api_budget(): void
+    {
+        Event::fake([ConversationStreamEvent::class]);
+        [$owner, $band] = $this->makeOwnerWithBand();
+        $channel = app(ConversationService::class)->bandChannelFor($band);
+
+        // 30/min budget: the 30th ping is fine, the 31st is throttled — and
+        // this alone (well under 60 calls) proves typing isn't sharing the
+        // general 'api' 60/min limiter, since it exhausts at half that.
+        for ($i = 1; $i <= 30; $i++) {
+            $this->actingAs($owner)
+                ->postJson("/api/mobile/conversations/{$channel->id}/typing")
+                ->assertStatus(204);
+        }
+
+        $this->actingAs($owner)
+            ->postJson("/api/mobile/conversations/{$channel->id}/typing")
+            ->assertStatus(429);
+
+        // Sending a message right after hitting the typing limit must not be
+        // starved — it lives on a separate budget.
+        $this->actingAs($owner)
+            ->postJson("/api/mobile/conversations/{$channel->id}/messages", ['body' => 'still works'])
+            ->assertStatus(201);
+    }
+
     public function test_duplicate_read_posts_broadcast_conversation_read_only_once(): void
     {
         Event::fake([ConversationStreamEvent::class]);

--- a/tests/Feature/Api/Mobile/Chat/ChatBroadcastingTest.php
+++ b/tests/Feature/Api/Mobile/Chat/ChatBroadcastingTest.php
@@ -119,6 +119,27 @@ class ChatBroadcastingTest extends TestCase
         );
     }
 
+    public function test_duplicate_read_posts_broadcast_conversation_read_only_once(): void
+    {
+        Event::fake([ConversationStreamEvent::class]);
+        [$owner, $band] = $this->makeOwnerWithBand();
+        $channel = app(ConversationService::class)->bandChannelFor($band);
+        $message = $channel->messages()->create(['user_id' => $owner->id, 'body' => 'mark me']);
+
+        foreach (range(1, 2) as $attempt) {
+            $this->actingAs($owner)
+                ->postJson("/api/mobile/conversations/{$channel->id}/read", ['last_read_message_id' => $message->id])
+                ->assertStatus(204);
+        }
+
+        // The marker only advances on the first POST — the duplicate must
+        // not re-broadcast conversation.read.
+        $this->assertCount(1, Event::dispatched(
+            ConversationStreamEvent::class,
+            fn (ConversationStreamEvent $e) => $e->type === 'conversation.read',
+        ));
+    }
+
     public function test_stream_event_broadcasts_as_its_type_with_no_envelope(): void
     {
         $event = new ConversationStreamEvent(7, 'message.deleted', ['message_id' => 42]);

--- a/tests/Feature/Api/Mobile/Chat/ChatBroadcastingTest.php
+++ b/tests/Feature/Api/Mobile/Chat/ChatBroadcastingTest.php
@@ -1,0 +1,129 @@
+<?php
+
+namespace Tests\Feature\Api\Mobile\Chat;
+
+use App\Events\BandDataChanged;
+use App\Events\ConversationChanged;
+use App\Events\ConversationStreamEvent;
+use App\Services\Chat\ConversationService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Event;
+use Tests\TestCase;
+
+class ChatBroadcastingTest extends TestCase
+{
+    use RefreshDatabase, ChatTestHelpers;
+
+    public function test_band_thread_message_broadcasts_thin_band_signal_with_conversation_parent(): void
+    {
+        Event::fake([BandDataChanged::class]);
+        [$owner, $band] = $this->makeOwnerWithBand();
+        $channel = app(ConversationService::class)->bandChannelFor($band);
+
+        $message = $channel->messages()->create(['user_id' => $owner->id, 'body' => 'hi band']);
+
+        Event::assertDispatched(
+            BandDataChanged::class,
+            fn (BandDataChanged $e) => $e->bandId === $band->id
+                && $e->model === 'message'
+                && $e->id === $message->id
+                && $e->action === 'created'
+                && $e->parent === ['model' => 'conversation', 'id' => $channel->id],
+        );
+    }
+
+    public function test_dm_message_signals_each_participants_user_channel_not_a_band(): void
+    {
+        Event::fake([BandDataChanged::class, ConversationChanged::class]);
+        [$owner, $band] = $this->makeOwnerWithBand();
+        $member = $this->makeMember($band);
+        $dm = app(ConversationService::class)->dmBetween($owner, $member);
+
+        $message = $dm->messages()->create(['user_id' => $owner->id, 'body' => 'psst']);
+
+        Event::assertNotDispatched(BandDataChanged::class);
+        foreach ([$owner->id, $member->id] as $userId) {
+            Event::assertDispatched(
+                ConversationChanged::class,
+                fn (ConversationChanged $e) => $e->userId === $userId
+                    && $e->conversationId === $dm->id
+                    && $e->messageId === $message->id
+                    && $e->action === 'created',
+            );
+        }
+    }
+
+    public function test_store_message_endpoint_emits_stream_event_with_full_payload(): void
+    {
+        Event::fake([ConversationStreamEvent::class]);
+        [$owner, $band] = $this->makeOwnerWithBand();
+        $channel = app(ConversationService::class)->bandChannelFor($band);
+
+        $this->actingAs($owner)
+            ->postJson("/api/mobile/conversations/{$channel->id}/messages", ['body' => 'live'])
+            ->assertStatus(201);
+
+        Event::assertDispatched(
+            ConversationStreamEvent::class,
+            fn (ConversationStreamEvent $e) => $e->conversationId === $channel->id
+                && $e->type === 'message.created'
+                && $e->data['message']['body'] === 'live',
+        );
+    }
+
+    public function test_edit_and_delete_emit_stream_events(): void
+    {
+        Event::fake([ConversationStreamEvent::class]);
+        [$owner, $band] = $this->makeOwnerWithBand();
+        $channel = app(ConversationService::class)->bandChannelFor($band);
+        $message = $channel->messages()->create(['user_id' => $owner->id, 'body' => 'v1']);
+
+        $this->actingAs($owner)->patchJson("/api/mobile/messages/{$message->id}", ['body' => 'v2'])->assertOk();
+        Event::assertDispatched(
+            ConversationStreamEvent::class,
+            fn (ConversationStreamEvent $e) => $e->type === 'message.updated'
+                && $e->data['message']['body'] === 'v2',
+        );
+
+        $this->actingAs($owner)->deleteJson("/api/mobile/messages/{$message->id}")->assertStatus(204);
+        Event::assertDispatched(
+            ConversationStreamEvent::class,
+            fn (ConversationStreamEvent $e) => $e->type === 'message.deleted'
+                && $e->data['message_id'] === $message->id,
+        );
+    }
+
+    public function test_read_and_typing_emit_stream_events(): void
+    {
+        Event::fake([ConversationStreamEvent::class]);
+        [$owner, $band] = $this->makeOwnerWithBand();
+        $channel = app(ConversationService::class)->bandChannelFor($band);
+        $message = $channel->messages()->create(['user_id' => $owner->id, 'body' => 'mark me']);
+
+        $this->actingAs($owner)
+            ->postJson("/api/mobile/conversations/{$channel->id}/read", ['last_read_message_id' => $message->id])
+            ->assertStatus(204);
+        Event::assertDispatched(
+            ConversationStreamEvent::class,
+            fn (ConversationStreamEvent $e) => $e->type === 'conversation.read'
+                && $e->data['user_id'] === $owner->id
+                && is_string($e->data['last_read_at']),
+        );
+
+        $this->actingAs($owner)->postJson("/api/mobile/conversations/{$channel->id}/typing")->assertStatus(204);
+        Event::assertDispatched(
+            ConversationStreamEvent::class,
+            fn (ConversationStreamEvent $e) => $e->type === 'conversation.typing'
+                && $e->data['user_id'] === $owner->id
+                && $e->data['name'] === $owner->name,
+        );
+    }
+
+    public function test_stream_event_broadcasts_as_its_type_with_no_envelope(): void
+    {
+        $event = new ConversationStreamEvent(7, 'message.deleted', ['message_id' => 42]);
+
+        $this->assertSame('message.deleted', $event->broadcastAs());
+        $this->assertSame(['message_id' => 42], $event->broadcastWith());
+    }
+}

--- a/tests/Feature/Api/Mobile/Chat/ChatModelsTest.php
+++ b/tests/Feature/Api/Mobile/Chat/ChatModelsTest.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Tests\Feature\Api\Mobile\Chat;
+
+use App\Models\Conversation;
+use App\Models\Message;
+use App\Models\User;
+use Illuminate\Database\QueryException;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class ChatModelsTest extends TestCase
+{
+    use RefreshDatabase, ChatTestHelpers;
+
+    public function test_key_builders_are_deterministic(): void
+    {
+        $this->assertSame('dm:3:9', Conversation::dmKeyFor(9, 3));
+        $this->assertSame('dm:3:9', Conversation::dmKeyFor(3, 9));
+        $this->assertSame('band:5', Conversation::bandKeyFor(5));
+
+        [, $band] = $this->makeOwnerWithBand();
+        $event = $this->makeBookingEvent($band);
+        $this->assertSame('topic:App\\Models\\Events:' . $event->id, Conversation::topicKeyFor($event));
+    }
+
+    public function test_unique_key_is_enforced_at_the_database(): void
+    {
+        [, $band] = $this->makeOwnerWithBand();
+        Conversation::create([
+            'type' => Conversation::TYPE_BAND, 'band_id' => $band->id,
+            'unique_key' => Conversation::bandKeyFor($band->id),
+        ]);
+
+        $this->expectException(QueryException::class);
+        Conversation::create([
+            'type' => Conversation::TYPE_BAND, 'band_id' => $band->id,
+            'unique_key' => Conversation::bandKeyFor($band->id),
+        ]);
+    }
+
+    public function test_message_soft_deletes_and_relations_work(): void
+    {
+        [$owner, $band] = $this->makeOwnerWithBand();
+        $conversation = Conversation::create([
+            'type' => Conversation::TYPE_BAND, 'band_id' => $band->id,
+            'unique_key' => Conversation::bandKeyFor($band->id),
+        ]);
+        $conversation->participants()->create(['user_id' => $owner->id, 'last_read_at' => now()]);
+        $message = $conversation->messages()->create(['user_id' => $owner->id, 'body' => 'hello']);
+
+        $this->assertSame($conversation->id, $message->conversation->id);
+        $this->assertSame($owner->id, $message->user->id);
+        $this->assertCount(1, $conversation->participants);
+
+        $message->delete();
+        $this->assertSoftDeleted('messages', ['id' => $message->id]);
+        $this->assertCount(1, $conversation->messages()->withTrashed()->get());
+    }
+
+    public function test_moderate_chat_permission_exists(): void
+    {
+        $this->assertDatabaseHas('permissions', ['name' => 'moderate:chat', 'guard_name' => 'web']);
+    }
+}

--- a/tests/Feature/Api/Mobile/Chat/ChatPushTest.php
+++ b/tests/Feature/Api/Mobile/Chat/ChatPushTest.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Tests\Feature\Api\Mobile\Chat;
+
+use App\Jobs\SendUserPush;
+use App\Services\Chat\ConversationService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Queue;
+use Tests\TestCase;
+
+class ChatPushTest extends TestCase
+{
+    use RefreshDatabase, ChatTestHelpers;
+
+    public function test_dm_message_pushes_only_to_the_other_participant(): void
+    {
+        Queue::fake([SendUserPush::class]);
+        [$owner, $band] = $this->makeOwnerWithBand();
+        $member = $this->makeMember($band);
+        $dm = app(ConversationService::class)->dmBetween($owner, $member);
+
+        $this->actingAs($owner)
+            ->postJson("/api/mobile/conversations/{$dm->id}/messages", ['body' => 'ping'])
+            ->assertStatus(201);
+
+        Queue::assertPushed(SendUserPush::class, 1);
+        Queue::assertPushed(SendUserPush::class, fn (SendUserPush $job) =>
+            $job->userId === $member->id
+            && $job->data['type'] === 'chat_message'
+            && $job->data['conversationId'] === (string) $dm->id
+            && $job->data['title'] === $owner->name
+            && $job->data['body'] === 'ping'
+            && str_starts_with($job->dedupeKey, 'chat_message:'));
+    }
+
+    public function test_band_channel_message_pushes_to_owner_and_members_except_author(): void
+    {
+        Queue::fake([SendUserPush::class]);
+        [$owner, $band] = $this->makeOwnerWithBand();
+        $memberA = $this->makeMember($band);
+        $memberB = $this->makeMember($band);
+        $channel = app(ConversationService::class)->bandChannelFor($band);
+
+        $this->actingAs($memberA)
+            ->postJson("/api/mobile/conversations/{$channel->id}/messages", ['body' => 'sound check 6pm'])
+            ->assertStatus(201);
+
+        Queue::assertPushed(SendUserPush::class, 2);
+        foreach ([$owner->id, $memberB->id] as $expected) {
+            Queue::assertPushed(SendUserPush::class, fn (SendUserPush $job) => $job->userId === $expected);
+        }
+        Queue::assertNotPushed(SendUserPush::class, fn (SendUserPush $job) => $job->userId === $memberA->id);
+    }
+
+    public function test_event_topic_message_pushes_to_readers_and_entitled_subs(): void
+    {
+        Queue::fake([SendUserPush::class]);
+        [$owner, $band] = $this->makeOwnerWithBand();
+        $member     = $this->makeMember($band, ['read:events']);
+        $noRead     = $this->makeMember($band, []);
+        $event      = $this->makeBookingEvent($band);
+        $otherEvent = $this->makeBookingEvent($band);
+        $entitled   = $this->makeSubAssignedTo($band, $event);
+        $unentitled = $this->makeSubAssignedTo($band, $otherEvent);
+        $topic = app(ConversationService::class)->topicFor($event);
+
+        $this->actingAs($owner)
+            ->postJson("/api/mobile/conversations/{$topic->id}/messages", ['body' => 'comment'])
+            ->assertStatus(201);
+
+        Queue::assertPushed(SendUserPush::class, 2); // member + entitled sub
+        Queue::assertPushed(SendUserPush::class, fn (SendUserPush $job) => $job->userId === $member->id);
+        Queue::assertPushed(SendUserPush::class, fn (SendUserPush $job) => $job->userId === $entitled->id);
+        Queue::assertNotPushed(SendUserPush::class, fn (SendUserPush $job) => in_array($job->userId, [$noRead->id, $unentitled->id, $owner->id]));
+    }
+
+    public function test_image_only_message_pushes_a_photo_placeholder_body(): void
+    {
+        Queue::fake([SendUserPush::class]);
+        \Illuminate\Support\Facades\Storage::fake(config('filesystems.default'));
+        [$owner, $band] = $this->makeOwnerWithBand();
+        $member = $this->makeMember($band);
+        $dm = app(ConversationService::class)->dmBetween($owner, $member);
+
+        $this->actingAs($owner)->post(
+            "/api/mobile/conversations/{$dm->id}/messages",
+            ['images' => [\Illuminate\Http\UploadedFile::fake()->image('pic.jpg')]],
+            ['Accept' => 'application/json'],
+        )->assertStatus(201);
+
+        Queue::assertPushed(SendUserPush::class, fn (SendUserPush $job) => $job->data['body'] === '📷 Photo');
+    }
+}

--- a/tests/Feature/Api/Mobile/Chat/ChatTestHelpers.php
+++ b/tests/Feature/Api/Mobile/Chat/ChatTestHelpers.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace Tests\Feature\Api\Mobile\Chat;
+
+use App\Models\Bands;
+use App\Models\BandSubs;
+use App\Models\Bookings;
+use App\Models\EventMember;
+use App\Models\Events;
+use App\Models\EventTypes;
+use App\Models\Rehearsal;
+use App\Models\User;
+
+trait ChatTestHelpers
+{
+    /** @return array{0: User, 1: Bands} */
+    protected function makeOwnerWithBand(): array
+    {
+        $owner = User::factory()->create();
+        $band  = Bands::factory()->create();
+        $band->owners()->create(['user_id' => $owner->id]);
+
+        return [$owner, $band];
+    }
+
+    protected function makeMember(Bands $band, array $permissions = ['read:events']): User
+    {
+        $member = User::factory()->create();
+        $band->members()->create(['user_id' => $member->id]);
+
+        setPermissionsTeamId($band->id);
+        foreach ($permissions as $permission) {
+            $member->givePermissionTo($permission);
+        }
+        setPermissionsTeamId(0);
+
+        return $member;
+    }
+
+    protected function makeBookingEvent(Bands $band): Events
+    {
+        $booking = Bookings::factory()->create(['band_id' => $band->id]);
+
+        return Events::factory()->create([
+            'eventable_id'   => $booking->id,
+            'eventable_type' => 'App\\Models\\Bookings',
+            'event_type_id'  => EventTypes::factory()->create()->id,
+            'date'           => now()->addDays(7)->format('Y-m-d'),
+            'title'          => 'Test Gig',
+        ]);
+    }
+
+    /** @return array{0: Rehearsal, 1: Events} */
+    protected function makeRehearsalEvent(Bands $band): array
+    {
+        $rehearsal = Rehearsal::factory()->create(['band_id' => $band->id]);
+        $event     = Events::factory()->create([
+            'eventable_id'   => $rehearsal->id,
+            'eventable_type' => 'App\\Models\\Rehearsal',
+            'event_type_id'  => EventTypes::factory()->create()->id,
+            'date'           => now()->addDays(7)->format('Y-m-d'),
+            'title'          => 'Rehearsal',
+        ]);
+
+        return [$rehearsal, $event];
+    }
+
+    /** A sub-only user assigned to $event (event_members path, like MobileSubEventsParityTest). */
+    protected function makeSubAssignedTo(Bands $band, Events $event): User
+    {
+        $sub = User::factory()->create();
+        BandSubs::firstOrCreate(['user_id' => $sub->id, 'band_id' => $band->id]);
+        EventMember::create([
+            'event_id'         => $event->id,
+            'band_id'          => $band->id,
+            'user_id'          => $sub->id,
+            'roster_member_id' => null,
+            'name'             => $sub->name,
+        ]);
+
+        return $sub;
+    }
+
+    /** A sub of the band NOT assigned to any event. */
+    protected function makeUnassignedSub(Bands $band): User
+    {
+        $sub = User::factory()->create();
+        BandSubs::firstOrCreate(['user_id' => $sub->id, 'band_id' => $band->id]);
+
+        return $sub;
+    }
+}

--- a/tests/Feature/Api/Mobile/Chat/ChatTokenAbilityTest.php
+++ b/tests/Feature/Api/Mobile/Chat/ChatTokenAbilityTest.php
@@ -2,13 +2,31 @@
 
 namespace Tests\Feature\Api\Mobile\Chat;
 
+use App\Services\GoogleCalendarService;
+use App\Services\GoogleDriveOAuthService;
 use App\Services\Mobile\TokenService;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Mockery;
 use Tests\TestCase;
 
 class ChatTokenAbilityTest extends TestCase
 {
     use RefreshDatabase, ChatTestHelpers;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // BandSettingsController injects BandMemberRemovalService, which depends on
+        // GoogleCalendarService and GoogleDriveOAuthService. Mock both so CI doesn't
+        // need real credentials or make network calls during removal.
+        $mock = Mockery::mock(GoogleCalendarService::class);
+        $this->app->instance(GoogleCalendarService::class, $mock);
+
+        $driveMock = Mockery::mock(GoogleDriveOAuthService::class);
+        $driveMock->shouldReceive('revokeToken')->andReturnTrue();
+        $this->app->instance(GoogleDriveOAuthService::class, $driveMock);
+    }
 
     public function test_every_token_carries_the_chat_ability(): void
     {

--- a/tests/Feature/Api/Mobile/Chat/ChatTokenAbilityTest.php
+++ b/tests/Feature/Api/Mobile/Chat/ChatTokenAbilityTest.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Tests\Feature\Api\Mobile\Chat;
+
+use App\Services\Mobile\TokenService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class ChatTokenAbilityTest extends TestCase
+{
+    use RefreshDatabase, ChatTestHelpers;
+
+    public function test_every_token_carries_the_chat_ability(): void
+    {
+        [$owner, $band] = $this->makeOwnerWithBand();
+        $event = $this->makeBookingEvent($band);
+        $sub   = $this->makeSubAssignedTo($band, $event);
+
+        $service = app(TokenService::class);
+        $this->assertContains('chat', $service->buildAbilities($owner));
+        $this->assertContains('chat', $service->buildAbilities($sub));
+    }
+
+    public function test_members_endpoint_exposes_moderate_chat_for_granting(): void
+    {
+        [$owner, $band] = $this->makeOwnerWithBand();
+        $member = $this->makeMember($band);
+
+        $response = $this->actingAs($owner)
+            ->withHeaders(['X-Band-ID' => $band->id])
+            ->getJson("/api/mobile/bands/{$band->id}/members")
+            ->assertOk();
+
+        $memberRow = collect($response->json('members'))->firstWhere('id', $member->id);
+        $this->assertArrayHasKey('moderate:chat', $memberRow['permissions']);
+        $this->assertFalse($memberRow['permissions']['moderate:chat']);
+
+        $this->actingAs($owner)
+            ->withHeaders(['X-Band-ID' => $band->id])
+            ->patchJson("/api/mobile/bands/{$band->id}/members/{$member->id}/permissions", [
+                'permission' => 'moderate:chat', 'granted' => true,
+            ])->assertOk();
+
+        $this->assertTrue($member->fresh()->canModerateChat($band->id));
+    }
+}

--- a/tests/Feature/Api/Mobile/Chat/ConversationChannelAuthTest.php
+++ b/tests/Feature/Api/Mobile/Chat/ConversationChannelAuthTest.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace Tests\Feature\Api\Mobile\Chat;
+
+use App\Models\User;
+use App\Services\Chat\ConversationService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Broadcast;
+use Illuminate\Testing\TestResponse;
+use Tests\TestCase;
+
+class ConversationChannelAuthTest extends TestCase
+{
+    use RefreshDatabase, ChatTestHelpers;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // The pusher driver signs auth responses locally (no network) — give
+        // it deterministic creds regardless of the surrounding .env.
+        config([
+            'broadcasting.default'                    => 'pusher',
+            'broadcasting.connections.pusher.key'     => 'test-key',
+            'broadcasting.connections.pusher.secret'  => 'test-secret',
+            'broadcasting.connections.pusher.app_id'  => 'test-app',
+        ]);
+
+        // routes/channels.php registers Broadcast::channel(...) callbacks
+        // against whichever driver is default at app-boot time (phpunit.xml
+        // pins BROADCAST_DRIVER=null). BroadcastManager::driver() caches one
+        // instance per driver name, so switching the default above resolves
+        // to a *new*, channel-less "pusher" broadcaster unless we purge the
+        // cache and replay the channel registrations against it.
+        Broadcast::purge();
+        require base_path('routes/channels.php');
+    }
+
+    private function authChannel(User $user, int $conversationId): TestResponse
+    {
+        return $this->actingAs($user)->post('/broadcasting/auth', [
+            'channel_name' => 'private-conversation.' . $conversationId,
+            'socket_id'    => '123.456',
+        ]);
+    }
+
+    public function test_participant_passes_and_outsider_fails_conversation_channel_auth(): void
+    {
+        [$owner, $band] = $this->makeOwnerWithBand();
+        $member   = $this->makeMember($band);
+        $outsider = User::factory()->create();
+        $dm = app(ConversationService::class)->dmBetween($owner, $member);
+
+        $this->authChannel($owner, $dm->id)->assertOk();
+        $this->authChannel($outsider, $dm->id)->assertStatus(403);
+    }
+
+    public function test_entitled_sub_passes_topic_channel_auth(): void
+    {
+        [, $band] = $this->makeOwnerWithBand();
+        $event      = $this->makeBookingEvent($band);
+        $otherEvent = $this->makeBookingEvent($band);
+        $entitled   = $this->makeSubAssignedTo($band, $event);
+        $unentitled = $this->makeSubAssignedTo($band, $otherEvent);
+        $topic = app(ConversationService::class)->topicFor($event);
+
+        $this->authChannel($entitled, $topic->id)->assertOk();
+        $this->authChannel($unentitled, $topic->id)->assertStatus(403);
+    }
+
+    public function test_unknown_conversation_fails_auth(): void
+    {
+        [$owner] = $this->makeOwnerWithBand();
+        $this->authChannel($owner, 999999)->assertStatus(403);
+    }
+}

--- a/tests/Feature/Api/Mobile/Chat/ConversationPolicyTest.php
+++ b/tests/Feature/Api/Mobile/Chat/ConversationPolicyTest.php
@@ -1,0 +1,127 @@
+<?php
+
+namespace Tests\Feature\Api\Mobile\Chat;
+
+use App\Models\User;
+use App\Services\Chat\ConversationService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class ConversationPolicyTest extends TestCase
+{
+    use RefreshDatabase, ChatTestHelpers;
+
+    private ConversationService $service;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->service = app(ConversationService::class);
+    }
+
+    // ── DM ───────────────────────────────────────────────────────────
+
+    public function test_dm_is_visible_only_to_its_participants(): void
+    {
+        [$owner, $band] = $this->makeOwnerWithBand();
+        $member   = $this->makeMember($band);
+        $outsider = User::factory()->create();
+
+        $dm = $this->service->dmBetween($owner, $member);
+
+        $this->assertTrue($owner->can('view', $dm));
+        $this->assertTrue($member->can('post', $dm));
+        $this->assertFalse($outsider->can('view', $dm));
+        $this->assertFalse($owner->can('moderate', $dm), 'DMs are never moderatable');
+    }
+
+    // ── Band channel ─────────────────────────────────────────────────
+
+    public function test_band_channel_admits_owner_and_member_but_never_subs(): void
+    {
+        [$owner, $band] = $this->makeOwnerWithBand();
+        $member = $this->makeMember($band);
+        $event  = $this->makeBookingEvent($band);
+        $sub    = $this->makeSubAssignedTo($band, $event);
+
+        $channel = $this->service->bandChannelFor($band);
+
+        $this->assertTrue($owner->can('view', $channel));
+        $this->assertTrue($member->can('view', $channel));
+        $this->assertTrue($member->can('post', $channel));
+        $this->assertFalse($sub->can('view', $channel), 'subs never see the band channel');
+    }
+
+    // ── Topic: event ─────────────────────────────────────────────────
+
+    public function test_event_topic_admits_members_with_read_events_and_entitled_subs_only(): void
+    {
+        [$owner, $band] = $this->makeOwnerWithBand();
+        $memberWithRead    = $this->makeMember($band, ['read:events']);
+        $memberWithoutRead = $this->makeMember($band, []);
+        $event         = $this->makeBookingEvent($band);
+        $otherEvent    = $this->makeBookingEvent($band);
+        $entitledSub   = $this->makeSubAssignedTo($band, $event);
+        $unentitledSub = $this->makeSubAssignedTo($band, $otherEvent);
+
+        $topic = $this->service->topicFor($event);
+
+        $this->assertTrue($owner->can('view', $topic));
+        $this->assertTrue($memberWithRead->can('post', $topic));
+        $this->assertFalse($memberWithoutRead->can('view', $topic));
+        $this->assertTrue($entitledSub->can('view', $topic), 'sub invited to THIS event may comment');
+        $this->assertTrue($entitledSub->can('post', $topic));
+        $this->assertFalse($unentitledSub->can('view', $topic), 'sub on a DIFFERENT event may not');
+    }
+
+    // ── Topic: rehearsal (canonicalized) ─────────────────────────────
+
+    public function test_rehearsal_topic_uses_rehearsal_read_for_members_and_event_entitlement_for_subs(): void
+    {
+        [$owner, $band] = $this->makeOwnerWithBand();
+        $member = $this->makeMember($band, ['read:rehearsals']);
+        $memberEventsOnly = $this->makeMember($band, ['read:events']);
+        [, $rehearsalEvent] = $this->makeRehearsalEvent($band);
+        $entitledSub = $this->makeSubAssignedTo($band, $rehearsalEvent);
+
+        $topic = $this->service->topicFor($rehearsalEvent); // canonicalizes to Rehearsal
+
+        $this->assertTrue($owner->can('view', $topic));
+        $this->assertTrue($member->can('view', $topic));
+        $this->assertFalse($memberEventsOnly->can('view', $topic), 'rehearsal topics need read:rehearsals');
+        $this->assertTrue($entitledSub->can('view', $topic), 'sub on the wrapping event reaches the rehearsal thread');
+    }
+
+    // ── Topic: booking ───────────────────────────────────────────────
+
+    public function test_booking_topic_requires_read_bookings_and_always_excludes_subs(): void
+    {
+        [$owner, $band] = $this->makeOwnerWithBand();
+        $memberWithBookings = $this->makeMember($band, ['read:bookings']);
+        $memberEventsOnly   = $this->makeMember($band, ['read:events']);
+        $event = $this->makeBookingEvent($band);
+        $sub   = $this->makeSubAssignedTo($band, $event);
+
+        $topic = $this->service->topicFor($event->eventable);
+
+        $this->assertTrue($owner->can('view', $topic));
+        $this->assertTrue($memberWithBookings->can('view', $topic));
+        $this->assertFalse($memberEventsOnly->can('view', $topic));
+        $this->assertFalse($sub->can('view', $topic), 'subs can never read booking threads');
+    }
+
+    // ── Moderation ───────────────────────────────────────────────────
+
+    public function test_moderate_requires_ownership_or_the_moderate_chat_permission(): void
+    {
+        [$owner, $band] = $this->makeOwnerWithBand();
+        $plainMember = $this->makeMember($band);
+        $moderator   = $this->makeMember($band, ['read:events', 'moderate:chat']);
+
+        $channel = $this->service->bandChannelFor($band);
+
+        $this->assertTrue($owner->can('moderate', $channel));
+        $this->assertTrue($moderator->can('moderate', $channel));
+        $this->assertFalse($plainMember->can('moderate', $channel));
+    }
+}

--- a/tests/Feature/Api/Mobile/Chat/ConversationServiceTest.php
+++ b/tests/Feature/Api/Mobile/Chat/ConversationServiceTest.php
@@ -1,0 +1,124 @@
+<?php
+
+namespace Tests\Feature\Api\Mobile\Chat;
+
+use App\Models\Conversation;
+use App\Services\Chat\ConversationService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class ConversationServiceTest extends TestCase
+{
+    use RefreshDatabase, ChatTestHelpers;
+
+    private ConversationService $service;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->service = app(ConversationService::class);
+    }
+
+    public function test_event_wrapping_a_rehearsal_canonicalizes_to_the_rehearsal(): void
+    {
+        [, $band] = $this->makeOwnerWithBand();
+        [$rehearsal, $event] = $this->makeRehearsalEvent($band);
+
+        $viaEvent     = $this->service->topicFor($event);
+        $viaRehearsal = $this->service->topicFor($rehearsal);
+
+        $this->assertSame($viaEvent->id, $viaRehearsal->id, 'both entry points must reach ONE thread');
+        $this->assertSame('App\\Models\\Rehearsal', $viaEvent->conversable_type);
+        $this->assertSame($rehearsal->id, (int) $viaEvent->conversable_id);
+        $this->assertSame($band->id, (int) $viaEvent->band_id);
+    }
+
+    public function test_booking_event_topic_attaches_to_the_event_not_the_booking(): void
+    {
+        [, $band] = $this->makeOwnerWithBand();
+        $event = $this->makeBookingEvent($band);
+
+        $topic = $this->service->topicFor($event);
+
+        $this->assertSame('App\\Models\\Events', $topic->conversable_type);
+        $this->assertSame($event->id, (int) $topic->conversable_id);
+        $this->assertSame($band->id, (int) $topic->band_id);
+    }
+
+    public function test_booking_topic_is_separate_from_its_events_topic(): void
+    {
+        [, $band] = $this->makeOwnerWithBand();
+        $event   = $this->makeBookingEvent($band);
+        $booking = $event->eventable;
+
+        $this->assertNotSame(
+            $this->service->topicFor($booking)->id,
+            $this->service->topicFor($event)->id,
+        );
+    }
+
+    public function test_topic_for_is_idempotent(): void
+    {
+        [, $band] = $this->makeOwnerWithBand();
+        $event = $this->makeBookingEvent($band);
+
+        $this->assertSame($this->service->topicFor($event)->id, $this->service->topicFor($event)->id);
+        $this->assertSame(1, Conversation::count());
+    }
+
+    public function test_band_channel_is_one_per_band(): void
+    {
+        [, $band] = $this->makeOwnerWithBand();
+
+        $a = $this->service->bandChannelFor($band);
+        $b = $this->service->bandChannelFor($band);
+
+        $this->assertSame($a->id, $b->id);
+        $this->assertSame(Conversation::TYPE_BAND, $a->type);
+        $this->assertSame($band->id, (int) $a->band_id);
+    }
+
+    public function test_dm_is_one_global_thread_per_user_pair_with_both_participants(): void
+    {
+        [$owner, $band] = $this->makeOwnerWithBand();
+        $member = $this->makeMember($band);
+
+        $a = $this->service->dmBetween($owner, $member);
+        $b = $this->service->dmBetween($member, $owner); // reversed order
+
+        $this->assertSame($a->id, $b->id);
+        $this->assertNull($a->band_id);
+        $this->assertSame(Conversation::TYPE_DM, $a->type);
+        $this->assertEqualsCanonicalizing(
+            [$owner->id, $member->id],
+            $a->participants()->pluck('user_id')->all(),
+        );
+    }
+
+    public function test_can_dm_requires_a_shared_band(): void
+    {
+        [$owner, $band] = $this->makeOwnerWithBand();
+        $member   = $this->makeMember($band);
+        $event    = $this->makeBookingEvent($band);
+        $sub      = $this->makeSubAssignedTo($band, $event);
+        $stranger = \App\Models\User::factory()->create();
+
+        $this->assertTrue($this->service->canDm($owner, $member));
+        $this->assertTrue($this->service->canDm($member, $sub), 'member can DM a sub of their band');
+        $this->assertTrue($this->service->canDm($sub, $member), 'sub can DM a member of a band they sub for');
+        $this->assertFalse($this->service->canDm($owner, $stranger));
+        $this->assertFalse($this->service->canDm($owner, $owner), 'no self-DM');
+    }
+
+    public function test_touch_participant_upserts_and_bumps_last_read(): void
+    {
+        [$owner, $band] = $this->makeOwnerWithBand();
+        $channel = $this->service->bandChannelFor($band);
+
+        $first = $this->service->touchParticipant($channel, $owner);
+        $this->assertNotNull($first->last_read_at);
+
+        $again = $this->service->touchParticipant($channel, $owner);
+        $this->assertSame($first->id, $again->id, 'no duplicate participant row');
+    }
+}

--- a/tests/Feature/Api/Mobile/Chat/ConversationsIndexTest.php
+++ b/tests/Feature/Api/Mobile/Chat/ConversationsIndexTest.php
@@ -1,0 +1,128 @@
+<?php
+
+namespace Tests\Feature\Api\Mobile\Chat;
+
+use App\Models\User;
+use App\Services\Chat\ConversationService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class ConversationsIndexTest extends TestCase
+{
+    use RefreshDatabase, ChatTestHelpers;
+
+    public function test_index_lists_band_channels_and_dms_with_unread_counts(): void
+    {
+        [$owner, $band] = $this->makeOwnerWithBand();
+        $member  = $this->makeMember($band);
+        $service = app(ConversationService::class);
+
+        $dm = $service->dmBetween($owner, $member);
+        $dm->messages()->create(['user_id' => $member->id, 'body' => 'hey there']);
+
+        $response = $this->actingAs($owner)->getJson('/api/mobile/conversations')->assertOk();
+
+        $conversations = collect($response->json('conversations'));
+        $this->assertCount(2, $conversations); // band channel (lazily created) + dm
+
+        $bandRow = $conversations->firstWhere('type', 'band');
+        $this->assertSame($band->name, $bandRow['title']);
+
+        $dmRow = $conversations->firstWhere('type', 'dm');
+        $this->assertSame($member->name, $dmRow['title']);
+        $this->assertSame('hey there', $dmRow['last_message_preview']);
+        $this->assertNotNull($dmRow['last_message_at']);
+        $this->assertSame(1, $dmRow['unread_count']);
+        $this->assertTrue($bandRow['can_moderate'], 'owner moderates the band channel');
+        $this->assertFalse($dmRow['can_moderate'], 'DMs are never moderatable');
+    }
+
+    public function test_own_messages_do_not_count_as_unread(): void
+    {
+        [$owner, $band] = $this->makeOwnerWithBand();
+        $member = $this->makeMember($band);
+        $dm = app(ConversationService::class)->dmBetween($owner, $member);
+        $dm->messages()->create(['user_id' => $owner->id, 'body' => 'my own']);
+
+        $response = $this->actingAs($owner)->getJson('/api/mobile/conversations')->assertOk();
+
+        $dmRow = collect($response->json('conversations'))->firstWhere('type', 'dm');
+        $this->assertSame(0, $dmRow['unread_count']);
+    }
+
+    public function test_sub_only_user_sees_no_band_channel(): void
+    {
+        [, $band] = $this->makeOwnerWithBand();
+        $event = $this->makeBookingEvent($band);
+        $sub   = $this->makeSubAssignedTo($band, $event);
+
+        $response = $this->actingAs($sub)->getJson('/api/mobile/conversations')->assertOk();
+
+        $this->assertSame([], $response->json('conversations'));
+    }
+
+    public function test_store_dm_creates_thread_with_a_bandmate(): void
+    {
+        [$owner, $band] = $this->makeOwnerWithBand();
+        $member = $this->makeMember($band);
+
+        $response = $this->actingAs($owner)
+            ->postJson('/api/mobile/conversations/dm', ['user_id' => $member->id])
+            ->assertOk();
+
+        $this->assertSame('dm', $response->json('conversation.type'));
+        $this->assertSame($member->name, $response->json('conversation.title'));
+
+        // Idempotent: same pair → same conversation id.
+        $again = $this->actingAs($member)
+            ->postJson('/api/mobile/conversations/dm', ['user_id' => $owner->id])
+            ->assertOk();
+        $this->assertSame($response->json('conversation.id'), $again->json('conversation.id'));
+    }
+
+    public function test_store_dm_rejects_users_with_no_shared_band(): void
+    {
+        [$owner] = $this->makeOwnerWithBand();
+        $stranger = User::factory()->create();
+
+        $this->actingAs($owner)
+            ->postJson('/api/mobile/conversations/dm', ['user_id' => $stranger->id])
+            ->assertStatus(403);
+    }
+
+    public function test_contacts_lists_bandmates_and_subs_with_context_but_not_strangers(): void
+    {
+        [$owner, $band] = $this->makeOwnerWithBand();
+        $member = $this->makeMember($band);
+        $event  = $this->makeBookingEvent($band);
+        $sub    = $this->makeSubAssignedTo($band, $event);
+        User::factory()->create(); // stranger
+
+        $response = $this->actingAs($owner)->getJson('/api/mobile/chat/contacts')->assertOk();
+
+        $contacts = collect($response->json('contacts'))->keyBy('id');
+        $this->assertEqualsCanonicalizing([$member->id, $sub->id], $contacts->keys()->all());
+
+        $this->assertSame($band->name, $contacts[$member->id]['context']);
+        $this->assertFalse($contacts[$member->id]['is_sub']);
+        $this->assertNull($contacts[$member->id]['avatar_url']);
+
+        $this->assertSame('Sub — ' . $band->name, $contacts[$sub->id]['context']);
+        $this->assertTrue($contacts[$sub->id]['is_sub']);
+    }
+
+    public function test_contacts_for_a_sub_lists_the_bands_owner_and_members(): void
+    {
+        [$owner, $band] = $this->makeOwnerWithBand();
+        $member = $this->makeMember($band);
+        $event  = $this->makeBookingEvent($band);
+        $sub    = $this->makeSubAssignedTo($band, $event);
+
+        $response = $this->actingAs($sub)->getJson('/api/mobile/chat/contacts')->assertOk();
+
+        $contacts = collect($response->json('contacts'))->keyBy('id');
+        $this->assertEqualsCanonicalizing([$owner->id, $member->id], $contacts->keys()->all());
+        $this->assertSame($band->name, $contacts[$owner->id]['context']);
+        $this->assertFalse($contacts[$owner->id]['is_sub']);
+    }
+}

--- a/tests/Feature/Api/Mobile/Chat/MessageAttachmentsTest.php
+++ b/tests/Feature/Api/Mobile/Chat/MessageAttachmentsTest.php
@@ -2,15 +2,24 @@
 
 namespace Tests\Feature\Api\Mobile\Chat;
 
+use App\Jobs\SendUserPush;
 use App\Services\Chat\ConversationService;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Queue;
 use Illuminate\Support\Facades\Storage;
 use Tests\TestCase;
 
 class MessageAttachmentsTest extends TestCase
 {
     use RefreshDatabase, ChatTestHelpers;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Queue::fake([SendUserPush::class]);
+    }
 
     public function test_message_with_images_stores_attachments_and_serves_them(): void
     {

--- a/tests/Feature/Api/Mobile/Chat/MessageAttachmentsTest.php
+++ b/tests/Feature/Api/Mobile/Chat/MessageAttachmentsTest.php
@@ -1,0 +1,101 @@
+<?php
+
+namespace Tests\Feature\Api\Mobile\Chat;
+
+use App\Services\Chat\ConversationService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Storage;
+use Tests\TestCase;
+
+class MessageAttachmentsTest extends TestCase
+{
+    use RefreshDatabase, ChatTestHelpers;
+
+    public function test_message_with_images_stores_attachments_and_serves_them(): void
+    {
+        Storage::fake(config('filesystems.default'));
+        [$owner, $band] = $this->makeOwnerWithBand();
+        $member = $this->makeMember($band);
+        $dm = app(ConversationService::class)->dmBetween($owner, $member);
+
+        $response = $this->actingAs($owner)->post(
+            "/api/mobile/conversations/{$dm->id}/messages",
+            ['body' => 'look', 'images' => [UploadedFile::fake()->image('pic.jpg', 640, 480)]],
+            ['Accept' => 'application/json'],
+        )->assertStatus(201);
+
+        $attachment = $response->json('message.attachments.0');
+        $this->assertSame(640, $attachment['width']);
+        $this->assertSame(480, $attachment['height']);
+        $this->assertDatabaseHas('message_attachments', ['id' => $attachment['id']]);
+
+        // Clients construct the binary URL from message id + attachment id.
+        $url = "/api/mobile/messages/{$response->json('message.id')}/attachments/{$attachment['id']}";
+
+        // Participant can fetch the binary.
+        $this->actingAs($member)->get($url)->assertOk();
+
+        // Non-participant cannot.
+        $outsider = \App\Models\User::factory()->create();
+        $this->actingAs($outsider)->get($url)->assertStatus(403);
+    }
+
+    public function test_image_only_message_needs_no_body(): void
+    {
+        Storage::fake(config('filesystems.default'));
+        [$owner, $band] = $this->makeOwnerWithBand();
+        $channel = app(ConversationService::class)->bandChannelFor($band);
+
+        $this->actingAs($owner)->post(
+            "/api/mobile/conversations/{$channel->id}/messages",
+            ['images' => [UploadedFile::fake()->image('solo.png')]],
+            ['Accept' => 'application/json'],
+        )->assertStatus(201)->assertJsonPath('message.body', null);
+    }
+
+    public function test_more_than_four_images_is_rejected(): void
+    {
+        [$owner, $band] = $this->makeOwnerWithBand();
+        $channel = app(ConversationService::class)->bandChannelFor($band);
+
+        $images = array_map(fn ($i) => UploadedFile::fake()->image("p{$i}.jpg"), range(1, 5));
+
+        $this->actingAs($owner)->post(
+            "/api/mobile/conversations/{$channel->id}/messages",
+            ['images' => $images],
+            ['Accept' => 'application/json'],
+        )->assertStatus(422);
+    }
+
+    public function test_non_image_files_are_rejected(): void
+    {
+        [$owner, $band] = $this->makeOwnerWithBand();
+        $channel = app(ConversationService::class)->bandChannelFor($band);
+
+        $this->actingAs($owner)->post(
+            "/api/mobile/conversations/{$channel->id}/messages",
+            ['images' => [UploadedFile::fake()->create('evil.pdf', 100, 'application/pdf')]],
+            ['Accept' => 'application/json'],
+        )->assertStatus(422);
+    }
+
+    public function test_deleted_messages_attachments_are_not_served(): void
+    {
+        Storage::fake(config('filesystems.default'));
+        [$owner, $band] = $this->makeOwnerWithBand();
+        $channel = app(ConversationService::class)->bandChannelFor($band);
+
+        $response = $this->actingAs($owner)->post(
+            "/api/mobile/conversations/{$channel->id}/messages",
+            ['images' => [UploadedFile::fake()->image('gone.jpg')]],
+            ['Accept' => 'application/json'],
+        )->assertStatus(201);
+        $messageId = $response->json('message.id');
+        $url = "/api/mobile/messages/{$messageId}/attachments/" . $response->json('message.attachments.0.id');
+
+        $this->actingAs($owner)->deleteJson("/api/mobile/messages/{$messageId}")->assertStatus(204);
+
+        $this->actingAs($owner)->get($url)->assertStatus(404);
+    }
+}

--- a/tests/Feature/Api/Mobile/Chat/MessageAttachmentsTest.php
+++ b/tests/Feature/Api/Mobile/Chat/MessageAttachmentsTest.php
@@ -98,4 +98,28 @@ class MessageAttachmentsTest extends TestCase
 
         $this->actingAs($owner)->get($url)->assertStatus(404);
     }
+
+    public function test_failed_attachment_insert_rolls_back_message_and_removes_stored_files(): void
+    {
+        $disk = config('filesystems.default');
+        Storage::fake($disk);
+        [$owner, $band] = $this->makeOwnerWithBand();
+        $channel = app(ConversationService::class)->bandChannelFor($band);
+
+        // Force the attachment row insert to blow up inside the transaction.
+        \App\Models\MessageAttachment::creating(function () {
+            throw new \RuntimeException('simulated insert failure');
+        });
+
+        $this->actingAs($owner)->post(
+            "/api/mobile/conversations/{$channel->id}/messages",
+            ['body' => 'doomed', 'images' => [UploadedFile::fake()->image('boom.jpg')]],
+            ['Accept' => 'application/json'],
+        )->assertStatus(500);
+
+        // Message row rolled back and no orphan blobs remain on disk.
+        $this->assertDatabaseCount('messages', 0);
+        $this->assertDatabaseCount('message_attachments', 0);
+        $this->assertSame([], Storage::disk($disk)->allFiles());
+    }
 }

--- a/tests/Feature/Api/Mobile/Chat/MessagesTest.php
+++ b/tests/Feature/Api/Mobile/Chat/MessagesTest.php
@@ -2,13 +2,22 @@
 
 namespace Tests\Feature\Api\Mobile\Chat;
 
+use App\Jobs\SendUserPush;
 use App\Services\Chat\ConversationService;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Queue;
 use Tests\TestCase;
 
 class MessagesTest extends TestCase
 {
     use RefreshDatabase, ChatTestHelpers;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Queue::fake([SendUserPush::class]);
+    }
 
     public function test_participant_can_send_and_list_messages(): void
     {

--- a/tests/Feature/Api/Mobile/Chat/MessagesTest.php
+++ b/tests/Feature/Api/Mobile/Chat/MessagesTest.php
@@ -1,0 +1,189 @@
+<?php
+
+namespace Tests\Feature\Api\Mobile\Chat;
+
+use App\Services\Chat\ConversationService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class MessagesTest extends TestCase
+{
+    use RefreshDatabase, ChatTestHelpers;
+
+    public function test_participant_can_send_and_list_messages(): void
+    {
+        [$owner, $band] = $this->makeOwnerWithBand();
+        $member = $this->makeMember($band);
+        $dm = app(ConversationService::class)->dmBetween($owner, $member);
+
+        $this->actingAs($owner)
+            ->postJson("/api/mobile/conversations/{$dm->id}/messages", ['body' => 'first!'])
+            ->assertStatus(201)
+            ->assertJsonPath('message.body', 'first!')
+            ->assertJsonPath('message.user_id', $owner->id);
+
+        $list = $this->actingAs($member)
+            ->getJson("/api/mobile/conversations/{$dm->id}/messages")->assertOk();
+        $this->assertCount(1, $list->json('messages'));
+        $this->assertFalse($list->json('has_more'));
+        $this->assertSame('first!', $list->json('messages.0.body'));
+        $this->assertSame($owner->name, $list->json('messages.0.user_name'));
+        $this->assertSame('dm', $list->json('conversation.type'));
+        $this->assertSame('private-conversation.' . $dm->id, $list->json('channel'));
+    }
+
+    public function test_non_participant_cannot_send_or_read(): void
+    {
+        [$owner, $band] = $this->makeOwnerWithBand();
+        $member   = $this->makeMember($band);
+        $outsider = \App\Models\User::factory()->create();
+        $dm = app(ConversationService::class)->dmBetween($owner, $member);
+
+        $this->actingAs($outsider)
+            ->postJson("/api/mobile/conversations/{$dm->id}/messages", ['body' => 'nope'])
+            ->assertStatus(403);
+        $this->actingAs($outsider)
+            ->getJson("/api/mobile/conversations/{$dm->id}/messages")->assertStatus(403);
+    }
+
+    public function test_cursor_pagination_walks_backwards(): void
+    {
+        [$owner, $band] = $this->makeOwnerWithBand();
+        $channel = app(ConversationService::class)->bandChannelFor($band);
+        for ($i = 1; $i <= 60; $i++) {
+            $channel->messages()->create(['user_id' => $owner->id, 'body' => "m{$i}"]);
+        }
+
+        $page1 = $this->actingAs($owner)
+            ->getJson("/api/mobile/conversations/{$channel->id}/messages")->assertOk();
+        $this->assertCount(50, $page1->json('messages'));
+        $this->assertTrue($page1->json('has_more'));
+        $this->assertSame('m60', collect($page1->json('messages'))->last()['body']);
+
+        $oldestId = $page1->json('messages')[0]['id'];
+        $page2 = $this->actingAs($owner)
+            ->getJson("/api/mobile/conversations/{$channel->id}/messages?before={$oldestId}")->assertOk();
+        $this->assertCount(10, $page2->json('messages'));
+        $this->assertFalse($page2->json('has_more'));
+    }
+
+    public function test_author_can_edit_own_message_and_gets_edited_marker(): void
+    {
+        [$owner, $band] = $this->makeOwnerWithBand();
+        $channel = app(ConversationService::class)->bandChannelFor($band);
+        $message = $channel->messages()->create(['user_id' => $owner->id, 'body' => 'typo']);
+
+        $response = $this->actingAs($owner)
+            ->patchJson("/api/mobile/messages/{$message->id}", ['body' => 'fixed'])
+            ->assertOk();
+
+        $this->assertSame('fixed', $response->json('message.body'));
+        $this->assertNotNull($response->json('message.edited_at'));
+    }
+
+    public function test_only_the_author_can_edit(): void
+    {
+        [$owner, $band] = $this->makeOwnerWithBand();
+        $member  = $this->makeMember($band);
+        $channel = app(ConversationService::class)->bandChannelFor($band);
+        $message = $channel->messages()->create(['user_id' => $member->id, 'body' => 'mine']);
+
+        // Even the owner (a moderator) cannot EDIT someone else's message.
+        $this->actingAs($owner)
+            ->patchJson("/api/mobile/messages/{$message->id}", ['body' => 'hijack'])
+            ->assertStatus(403);
+    }
+
+    public function test_author_deletes_own_message_leaving_a_tombstone(): void
+    {
+        [$owner, $band] = $this->makeOwnerWithBand();
+        $channel = app(ConversationService::class)->bandChannelFor($band);
+        $message = $channel->messages()->create(['user_id' => $owner->id, 'body' => 'oops']);
+
+        $this->actingAs($owner)->deleteJson("/api/mobile/messages/{$message->id}")->assertStatus(204);
+
+        $list = $this->actingAs($owner)
+            ->getJson("/api/mobile/conversations/{$channel->id}/messages")->assertOk();
+        $row = collect($list->json('messages'))->firstWhere('id', $message->id);
+        $this->assertTrue($row['is_deleted']);
+        $this->assertNull($row['body']);
+    }
+
+    public function test_moderator_can_delete_others_messages_in_band_thread_but_plain_member_cannot(): void
+    {
+        [$owner, $band] = $this->makeOwnerWithBand();
+        $author  = $this->makeMember($band);
+        $plain   = $this->makeMember($band);
+        $channel = app(ConversationService::class)->bandChannelFor($band);
+        $m1 = $channel->messages()->create(['user_id' => $author->id, 'body' => 'a']);
+        $m2 = $channel->messages()->create(['user_id' => $author->id, 'body' => 'b']);
+
+        $this->actingAs($plain)->deleteJson("/api/mobile/messages/{$m1->id}")->assertStatus(403);
+        $this->actingAs($owner)->deleteJson("/api/mobile/messages/{$m1->id}")->assertStatus(204);
+
+        setPermissionsTeamId($band->id);
+        $plain->givePermissionTo('moderate:chat');
+        setPermissionsTeamId(0);
+        $this->actingAs($plain)->deleteJson("/api/mobile/messages/{$m2->id}")->assertStatus(204);
+    }
+
+    public function test_dm_messages_cannot_be_deleted_by_the_other_participant(): void
+    {
+        [$owner, $band] = $this->makeOwnerWithBand();
+        $member  = $this->makeMember($band);
+        $dm      = app(ConversationService::class)->dmBetween($owner, $member);
+        $message = $dm->messages()->create(['user_id' => $member->id, 'body' => 'private']);
+
+        $this->actingAs($owner)->deleteJson("/api/mobile/messages/{$message->id}")->assertStatus(403);
+    }
+
+    public function test_read_endpoint_zeroes_the_unread_count(): void
+    {
+        [$owner, $band] = $this->makeOwnerWithBand();
+        $member = $this->makeMember($band);
+        $dm = app(ConversationService::class)->dmBetween($owner, $member);
+        $message = $dm->messages()->create(['user_id' => $member->id, 'body' => 'unread me']);
+
+        $this->actingAs($owner)
+            ->postJson("/api/mobile/conversations/{$dm->id}/read", ['last_read_message_id' => $message->id])
+            ->assertStatus(204);
+
+        $list = $this->actingAs($owner)->getJson('/api/mobile/conversations')->assertOk();
+        $dmRow = collect($list->json('conversations'))->firstWhere('type', 'dm');
+        $this->assertSame(0, $dmRow['unread_count']);
+    }
+
+    public function test_read_marker_never_moves_backwards(): void
+    {
+        [$owner, $band] = $this->makeOwnerWithBand();
+        $member = $this->makeMember($band);
+        $dm = app(ConversationService::class)->dmBetween($owner, $member);
+        $older = $dm->messages()->create(['user_id' => $member->id, 'body' => 'older']);
+        $newer = $dm->messages()->create(['user_id' => $member->id, 'body' => 'newer']);
+        $newer->forceFill(['created_at' => now()->addMinute()])->save();
+
+        $this->actingAs($owner)
+            ->postJson("/api/mobile/conversations/{$dm->id}/read", ['last_read_message_id' => $newer->id])
+            ->assertStatus(204);
+        $this->actingAs($owner)
+            ->postJson("/api/mobile/conversations/{$dm->id}/read", ['last_read_message_id' => $older->id])
+            ->assertStatus(204);
+
+        $list = $this->actingAs($owner)->getJson('/api/mobile/conversations')->assertOk();
+        $dmRow = collect($list->json('conversations'))->firstWhere('type', 'dm');
+        $this->assertSame(0, $dmRow['unread_count'], 'an out-of-order read call must not resurrect unreads');
+    }
+
+    public function test_body_is_required_without_images_and_capped(): void
+    {
+        [$owner, $band] = $this->makeOwnerWithBand();
+        $channel = app(ConversationService::class)->bandChannelFor($band);
+
+        $this->actingAs($owner)
+            ->postJson("/api/mobile/conversations/{$channel->id}/messages", [])
+            ->assertStatus(422);
+        $this->actingAs($owner)
+            ->postJson("/api/mobile/conversations/{$channel->id}/messages", ['body' => str_repeat('x', 4001)])
+            ->assertStatus(422);
+    }
+}

--- a/tests/Feature/Api/Mobile/Chat/MessagesTest.php
+++ b/tests/Feature/Api/Mobile/Chat/MessagesTest.php
@@ -76,6 +76,23 @@ class MessagesTest extends TestCase
         $this->assertFalse($page2->json('has_more'));
     }
 
+    public function test_non_integer_before_cursor_is_rejected(): void
+    {
+        [$owner, $band] = $this->makeOwnerWithBand();
+        $channel = app(ConversationService::class)->bandChannelFor($band);
+        $channel->messages()->create(['user_id' => $owner->id, 'body' => 'm1']);
+
+        // A garbage cursor used to cast to 0 and silently return page one
+        // instead of erroring — must 422 instead of masking client bugs.
+        $this->actingAs($owner)
+            ->getJson("/api/mobile/conversations/{$channel->id}/messages?before=not-a-number")
+            ->assertStatus(422);
+
+        $this->actingAs($owner)
+            ->getJson("/api/mobile/conversations/{$channel->id}/messages?before=0")
+            ->assertStatus(422);
+    }
+
     public function test_author_can_edit_own_message_and_gets_edited_marker(): void
     {
         [$owner, $band] = $this->makeOwnerWithBand();

--- a/tests/Feature/Api/Mobile/Chat/TopicConversationTest.php
+++ b/tests/Feature/Api/Mobile/Chat/TopicConversationTest.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace Tests\Feature\Api\Mobile\Chat;
+
+use App\Services\Chat\ConversationService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class TopicConversationTest extends TestCase
+{
+    use RefreshDatabase, ChatTestHelpers;
+
+    public function test_event_conversation_resolves_and_returns_messages(): void
+    {
+        [$owner, $band] = $this->makeOwnerWithBand();
+        $event = $this->makeBookingEvent($band);
+
+        $response = $this->actingAs($owner)
+            ->getJson("/api/mobile/events/{$event->id}/conversation")
+            ->assertOk();
+
+        $this->assertSame('topic', $response->json('conversation.type'));
+        $this->assertSame([], $response->json('messages'));
+        $this->assertFalse($response->json('has_more'));
+        $this->assertTrue($response->json('conversation.can_moderate'));
+        $this->assertSame(
+            'private-conversation.' . $response->json('conversation.id'),
+            $response->json('channel'),
+        );
+        // Opening the thread registered the viewer as a participant.
+        $this->assertContains($owner->id, collect($response->json('participants'))->pluck('user_id')->all());
+
+        // Same event → same conversation.
+        $again = $this->actingAs($owner)->getJson("/api/mobile/events/{$event->id}/conversation");
+        $this->assertSame($response->json('conversation.id'), $again->json('conversation.id'));
+    }
+
+    public function test_event_and_rehearsal_endpoints_reach_the_same_canonical_thread(): void
+    {
+        [$owner, $band] = $this->makeOwnerWithBand();
+        [$rehearsal, $event] = $this->makeRehearsalEvent($band);
+
+        $viaEvent = $this->actingAs($owner)
+            ->getJson("/api/mobile/events/{$event->id}/conversation")->assertOk();
+        $viaRehearsal = $this->actingAs($owner)
+            ->getJson("/api/mobile/rehearsals/{$rehearsal->id}/conversation")->assertOk();
+
+        $this->assertSame(
+            $viaEvent->json('conversation.id'),
+            $viaRehearsal->json('conversation.id'),
+        );
+    }
+
+    public function test_booking_conversation_is_reachable_and_distinct_from_event_thread(): void
+    {
+        [$owner, $band] = $this->makeOwnerWithBand();
+        $event   = $this->makeBookingEvent($band);
+        $booking = $event->eventable;
+
+        $bookingThread = $this->actingAs($owner)
+            ->withHeaders(['X-Band-ID' => $band->id])
+            ->getJson("/api/mobile/bands/{$band->id}/bookings/{$booking->id}/conversation")
+            ->assertOk();
+        $eventThread = $this->actingAs($owner)
+            ->getJson("/api/mobile/events/{$event->id}/conversation")->assertOk();
+
+        $this->assertNotSame(
+            $bookingThread->json('conversation.id'),
+            $eventThread->json('conversation.id'),
+        );
+    }
+
+    public function test_entitled_sub_reaches_event_thread_but_unentitled_sub_is_403(): void
+    {
+        [, $band] = $this->makeOwnerWithBand();
+        $event      = $this->makeBookingEvent($band);
+        $otherEvent = $this->makeBookingEvent($band);
+        $entitled   = $this->makeSubAssignedTo($band, $event);
+        $unentitled = $this->makeSubAssignedTo($band, $otherEvent);
+
+        $this->actingAs($entitled)
+            ->getJson("/api/mobile/events/{$event->id}/conversation")->assertOk();
+        $this->actingAs($unentitled)
+            ->getJson("/api/mobile/events/{$event->id}/conversation")->assertStatus(403);
+    }
+
+    public function test_sub_cannot_reach_a_booking_thread(): void
+    {
+        [, $band] = $this->makeOwnerWithBand();
+        $event = $this->makeBookingEvent($band);
+        $sub   = $this->makeSubAssignedTo($band, $event);
+
+        $this->actingAs($sub)
+            ->withHeaders(['X-Band-ID' => $band->id])
+            ->getJson("/api/mobile/bands/{$band->id}/bookings/{$event->eventable->id}/conversation")
+            ->assertStatus(403);
+    }
+}

--- a/tests/Feature/Api/Mobile/Chat/TopicConversationTest.php
+++ b/tests/Feature/Api/Mobile/Chat/TopicConversationTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Feature\Api\Mobile\Chat;
 
+use App\Models\Message;
 use App\Services\Chat\ConversationService;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
@@ -82,6 +83,30 @@ class TopicConversationTest extends TestCase
             ->getJson("/api/mobile/events/{$event->id}/conversation")->assertOk();
         $this->actingAs($unentitled)
             ->getJson("/api/mobile/events/{$event->id}/conversation")->assertStatus(403);
+    }
+
+    public function test_resolve_returns_real_last_message_preview_and_timestamp(): void
+    {
+        [$owner, $band] = $this->makeOwnerWithBand();
+        $event = $this->makeBookingEvent($band);
+
+        $conversation = app(ConversationService::class)->topicFor($event);
+        $message      = Message::factory()->create([
+            'conversation_id' => $conversation->id,
+            'user_id'         => $owner->id,
+            'body'            => 'Load in at 5pm',
+        ]);
+
+        $response = $this->actingAs($owner)
+            ->getJson("/api/mobile/events/{$event->id}/conversation")
+            ->assertOk();
+
+        $this->assertSame('Load in at 5pm', $response->json('conversation.last_message_preview'));
+        $this->assertSame(
+            $message->created_at->toIso8601String(),
+            $response->json('conversation.last_message_at'),
+        );
+        $this->assertSame('Thread', $response->json('conversation.title'));
     }
 
     public function test_sub_cannot_reach_a_booking_thread(): void


### PR DESCRIPTION
## Summary

Backend for the unified comments & chat system (spec + plans live in the mobile repo: `docs/superpowers/specs/2026-07-12-comments-chat-design.md`). One conversation model serves three shapes:

- **Topic threads** — comments on events, rehearsals, and bookings (polymorphic `conversable`, lazily created; an event wrapping a rehearsal canonicalizes to the rehearsal's single thread; bookings are never canonicalized)
- **Band channel** — one built-in group thread per band (owners + members; subs excluded)
- **DMs** — global per user pair (`unique_key` dm:lo:hi), creatable when the two users share ≥1 band in any role; subs can DM members

### Access & permissions
- `ConversationPolicy` is the single authority (controllers, `routes/channels.php`, and push audience all route through it). Subs reach only event/rehearsal threads they're entitled to (existing `event_subs`/`event_members` join); booking threads and band channels exclude subs. The known band-agnostic-token cross-band concern does **not** extend to chat (band-scoped policy checks; tested).
- New team-scoped **`moderate:chat`** permission (delete others' messages in band/topic threads; DMs are author-only, always; edit is author-only, always). Owners bypass via ownership. Exposed in the member-permissions screen; grantable via the existing setPermission endpoint. Every mobile token now carries a bare `chat` ability; the policy is the real gate.

### API (all under /api/mobile)
Conversations list (batched aggregate unread counts), DM find-or-create, DM-able contacts, topic resolve ×3, messages send (multipart, ≤4 images, atomic write with blob cleanup on rollback)/cursor-paginate/edit/delete(soft tombstone)/read(never-backwards marker), typing (204, own 30/min rate limiter), authenticated attachment serving.

### Realtime
- Band/topic messages: thin `band.data-changed` signals via the existing `BroadcastsBandChanges` trait (parent = conversation)
- DMs: `user.data-changed` on each participant's `App.Models.User.{id}` channel (queued, after-commit, error-contained)
- Open threads: new `private-conversation.{id}` channel — `message.created` / `message.updated` / `message.deleted` / `conversation.read` / `conversation.typing` (policy-authorized in channels.php)

### Push
`ProcessChatMessagePush` fans out data-only `chat_message` FCM via the existing `SendUserPush` layer; audience = policy-visible participants minus author; deduped per (user, message).

### Account deletion
New `messages.user_id` is nullable + `nullOnDelete` so account deletion keeps working with chat history; deleted authors render as "Deleted user" (`user_id: 0`) — covered in `AccountDeletionTest`.

## Tests

- `tests/Feature/Api/Mobile/Chat/` — **66 passed (248 assertions)** across 11 files (policy matrix, canonicalization, DM uniqueness, pagination boundaries, tombstones, rollback cleanup, broadcast wire names/payloads, channel auth, push audiences, token abilities, rate limiting)
- `AccountDeletionTest` — 8 passed (incl. new chat-tombstone case)

## Follow-ups (non-blocking, from the review process)

- Participant-row `firstOrCreate` race uncaught (conversation-level race IS caught; mirror it)
- `isEntitledToEvent` `event_subs` branch untested (helpers only build `event_members` paths)
- Missing attachment blob returns 500 (should 404)
- Dead `trashed()` check in `ProcessChatMessagePush` (find() already scopes)
- Orphaned topic conversations if the target event/rehearsal/booking is deleted (policy denies access; cruft only)
- Typing route is inside BOTH its own 30/min limiter and the shared `throttle:api` 60/min bucket (tighter one binds; full isolation would need route-group exclusion)
- `setPermission` has no allowlist vs `allPermissionNames()` (pre-existing; `moderate:chat` rides the same path as the other nine permissions)
- Topic push audience = per-candidate policy checks (O(N) queries in the async job) — deliberate: audience can never drift from visibility; if batching is ever needed, extract a shared `audienceFor(Conversation)` used by both policy and job

## Deploy notes

Backend must deploy before the mobile app rollout (Flutter client PR follows in TTS-App). No env changes required (typing uses server-side broadcast; no Pusher client-events setting needed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)